### PR TITLE
fix: disable PyPI publishing in semantic-release until OIDC configured

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,6 @@ name = "origin"
 type = "github"
 
 [tool.semantic_release.publish]
-dist = true
+dist = false
 upload_to_vcs_release = true
 dist_glob_patterns = ["dist/*", "checksums.txt"]


### PR DESCRIPTION
## Description
Semantic-release is failing with 401 errors because it attempts to publish to PyPI without OIDC permissions configured. This change disables PyPI publishing temporarily while keeping GitHub release functionality intact.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes semantic-release 401 unauthorized errors during release process

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Manual testing shows semantic-release fails when attempting PyPI upload due to missing OIDC configuration.

## Test Configuration
* Python version: 3.11
* OS: GitHub Actions Ubuntu
* AWS region: N/A
* Dependencies changed: None

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes
This is a temporary fix to enable end-to-end GitHub release testing. After this change works consistently, PyPI OIDC permissions should be configured and publishing re-enabled.

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

## Security Considerations
- [x] No security implications
- [ ] Security improved
- [ ] Potential security concerns (explain and justify)

## Dependencies
No dependency changes

## Deployment Notes
After merge, semantic-release should successfully create GitHub releases with build artifacts attached. PyPI publishing will be skipped until OIDC is configured.