### PR TITLE
fix: remove hardcoded src prefix from package imports

### DIFF
--- a/src/infrastructure/di/components/dependency_resolver.py
+++ b/src/infrastructure/di/components/dependency_resolver.py
@@ -353,9 +353,9 @@ class DependencyResolver:
                 # Last resort: try to import from common locations
                 for module_name in [
                     "typing",
-                    "src.domain",
-                    "src.application",
-                    "src.infrastructure",
+                    "domain",
+                    "application",
+                    "infrastructure",
                 ]:
                     try:
                         module_obj = __import__(module_name, fromlist=[annotation])

--- a/src/infrastructure/di/handler_discovery.py
+++ b/src/infrastructure/di/handler_discovery.py
@@ -93,7 +93,7 @@ class HandlerDiscoveryService:
         os.makedirs(cache_dir, exist_ok=True)
         return os.path.join(cache_dir, "handler_discovery.json")
 
-    def discover_and_register_handlers(self, base_package: str = "src.application") -> None:
+    def discover_and_register_handlers(self, base_package: str = "application") -> None:
         """
         Discover all handlers and register them with the DI container.
         Uses caching to improve performance on subsequent runs.
@@ -336,7 +336,7 @@ class HandlerDiscoveryService:
     def _fallback_to_full_discovery(self) -> None:
         """Fall back to full discovery if cache loading fails."""
         logger.info("Falling back to full handler discovery")
-        self._discover_handlers("src.application")
+        self._discover_handlers("application")
         self._register_handlers()
 
     def _get_source_file_mtimes(self, base_package: str) -> dict[str, float]:


### PR DESCRIPTION
## Description
Fixes hardcoded 'src.' prefix in package import paths that caused CLI failures when the package is installed via pip.

The handler discovery and dependency resolver were using hardcoded string literals like 'src.application', 'src.domain', 'src.infrastructure' which don't exist in the installed package structure. When installed via pip, modules are at top-level (application/, domain/, infrastructure/) not under src/.

This caused the CLI to fail with 'No matches found for pattern: src' when running commands like `orb templates list` from an installed package.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
Fixes the CLI import errors discovered during TestPyPI testing.

## How Has This Been Tested?
- [x] Manual testing performed
  - Built package with `make build-with-version`
  - Installed in clean virtualenv: `pip install dist/orb_py-*.whl`
  - Verified CLI works: `orb --help` and `orb templates list`
  - Confirmed handler discovery succeeds without 'src' pattern errors

## Test Configuration
* Python version: 3.12
* OS: macOS
* AWS region: N/A (local testing)
* Dependencies changed: None

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
This is a minimal, surgical fix that only changes 3 hardcoded string literals used for dynamic module discovery. All actual import statements in the codebase already use the correct pattern (without 'src.' prefix).

Analysis document included at `docs/research/package-structure-analysis.md` for future reference on package structure alignment with Python standards.

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications

## Dependencies
None

## Files Changed
- `src/infrastructure/di/handler_discovery.py`: Changed default base_package from 'src.application' to 'application' (2 locations)
- `src/infrastructure/di/components/dependency_resolver.py`: Removed 'src.' prefix from fallback import locations
- `docs/research/package-structure-analysis.md`: Added analysis document (new file)