### PR TITLE
fix: use repository name for container cleanup package-name

### DIFF
--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -323,7 +323,7 @@ jobs:
     - name: Delete old untagged container images
       uses: actions/delete-package-versions@v5
       with:
-        package-name: ${{ needs.config.outputs.container-image }}
+        package-name: ${{ github.event.repository.name }}
         package-type: container
         min-versions-to-keep: 0
         delete-only-untagged-versions: true
@@ -331,7 +331,7 @@ jobs:
     - name: Delete old tagged versions (preserve releases and special tags)
       uses: actions/delete-package-versions@v5
       with:
-        package-name: ${{ needs.config.outputs.container-image }}
+        package-name: ${{ github.event.repository.name }}
         package-type: container
         min-versions-to-keep: 5
         ignore-versions: '^(latest|main|dev|develop|python.*|v?\d+\.\d+\.\d+.*)$'

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -224,7 +224,7 @@ jobs:
     - name: Delete untagged container images
       uses: actions/delete-package-versions@v5
       with:
-        package-name: ${{ needs.config.outputs.container-image }}
+        package-name: ${{ github.event.repository.name }}
         package-type: container
         min-versions-to-keep: 0
         delete-only-untagged-versions: true


### PR DESCRIPTION
## Description
Fix container cleanup jobs failing with "Package not found" error. The `delete-package-versions` action expects just the package name (e.g. `open-resource-broker`) but `container-image` config output includes the org prefix (`awslabs/open-resource-broker`). Replace with `github.event.repository.name`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes container cleanup failure on every main push since cleanup was added.

## How Has This Been Tested?
- [x] Manual testing performed
- Verified `github.event.repository.name` resolves to `open-resource-broker` (without org prefix)
- Confirmed `delete-package-versions@v5` docs require package name without org

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications