### PR TITLE
fix: use absolute URLs for README logo so it renders on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/orb-logo-horizontal-dark.svg">
-    <source media="(prefers-color-scheme: light)" srcset="docs/assets/orb-logo-horizontal.svg">
-    <img alt="Open Resource Broker" src="docs/assets/orb-logo-horizontal.svg" width="520">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/awslabs/open-resource-broker/main/docs/assets/orb-logo-horizontal-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/awslabs/open-resource-broker/main/docs/assets/orb-logo-horizontal.svg">
+    <img alt="Open Resource Broker" src="https://raw.githubusercontent.com/awslabs/open-resource-broker/main/docs/assets/orb-logo-horizontal.svg" width="520">
   </picture>
 </p>
 


### PR DESCRIPTION
## Description
The README logo uses relative paths (`docs/assets/orb-logo-horizontal.svg`) which resolve on GitHub but not on PyPI. PyPI has no repo context, so relative paths point nowhere and the logo is broken.

Changed all three image references (dark mode source, light mode source, fallback img) to absolute `raw.githubusercontent.com` URLs.

Note: PyPI strips `<picture>`/`<source>` tags entirely, so only the `<img>` fallback matters there. The `<picture>` wrapper continues to work on GitHub for dark/light mode switching.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
Fixes broken logo rendering on https://pypi.org/project/orb-py/

## How Has This Been Tested?
- [x] Manual testing performed
  - Verified absolute URLs resolve to the correct SVG files
  - Confirmed logo still renders on GitHub with dark/light mode support

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications

## Deployment Notes
This fix will only take effect on PyPI after the next release is published (1.2.1).