### PR TITLE
refactor: fix domain layer aggregate mutation and template factory DIP

### DIFF
--- a/src/orb/application/queries/template_query_handlers.py
+++ b/src/orb/application/queries/template_query_handlers.py
@@ -17,7 +17,7 @@ from orb.application.ports.template_dto_port import TemplateDTOPort
 from orb.domain.base.exceptions import EntityNotFoundError
 from orb.domain.base.ports import ContainerPort, ErrorHandlingPort, LoggingPort
 from orb.domain.services.generic_filter_service import GenericFilterService
-from orb.domain.template.factory import TemplateFactory
+from orb.domain.template.factory import TemplateFactoryPort
 from orb.domain.template.template_aggregate import Template
 from orb.infrastructure.template.dtos import TemplateDTO
 
@@ -31,7 +31,7 @@ class GetTemplateHandler(BaseQueryHandler[GetTemplateQuery, TemplateDTOPort]):
         logger: LoggingPort,
         error_handler: ErrorHandlingPort,
         container: ContainerPort,
-        template_factory: TemplateFactory,
+        template_factory: TemplateFactoryPort,
     ) -> None:
         super().__init__(logger, error_handler)
         self._container = container

--- a/src/orb/application/services/provisioning_orchestration_service.py
+++ b/src/orb/application/services/provisioning_orchestration_service.py
@@ -99,7 +99,7 @@ class ProvisioningOrchestrationService:
             )
 
             # Stamp attempt number so provider-level idempotency tokens are unique per attempt
-            request.metadata["provisioning_attempt"] = attempt_number
+            request = request.update_metadata({"provisioning_attempt": attempt_number})
 
             try:
                 last_result = await self._dispatch_single_attempt(
@@ -134,9 +134,9 @@ class ProvisioningOrchestrationService:
                 "started_at": attempt_started.isoformat(),
                 "completed_at": attempt_completed.isoformat(),
             }
-            if "fulfillment_attempts" not in request.metadata:
-                request.metadata["fulfillment_attempts"] = []
-            request.metadata["fulfillment_attempts"].append(attempt_record)
+            existing_attempts = list(request.metadata.get("fulfillment_attempts", []))
+            existing_attempts.append(attempt_record)
+            request = request.update_metadata({"fulfillment_attempts": existing_attempts})
 
             if not last_result.success:
                 self._logger.warning(

--- a/src/orb/infrastructure/di/infrastructure_services.py
+++ b/src/orb/infrastructure/di/infrastructure_services.py
@@ -84,9 +84,10 @@ def _register_template_services(container: DIContainer):
             )
         return factory
 
-    from orb.domain.template.factory import TemplateFactory
+    from orb.domain.template.factory import TemplateFactory, TemplateFactoryPort
 
     container.register_singleton(TemplateFactory, create_template_factory)
+    container.register_singleton(TemplateFactoryPort, lambda c: c.get(TemplateFactory))
 
     # Register template configuration manager with factory function
     def create_template_configuration_manager(

--- a/src/orb/providers/aws/infrastructure/adapters/aws_provisioning_adapter.py
+++ b/src/orb/providers/aws/infrastructure/adapters/aws_provisioning_adapter.py
@@ -8,6 +8,7 @@ It implements the ResourceProvisioningPort interface from the domain layer.
 from typing import Any, Optional
 
 from orb.domain.base.dependency_injection import injectable
+from orb.domain.base.exceptions import InfrastructureError
 from orb.domain.base.ports import LoggingPort
 from orb.domain.base.ports.configuration_port import ConfigurationPort
 from orb.domain.request.aggregate import Request
@@ -16,7 +17,6 @@ from orb.infrastructure.adapters.ports.resource_provisioning_port import (
     ResourceProvisioningPort,
 )
 from orb.infrastructure.template.configuration_manager import TemplateConfigurationManager
-from orb.domain.base.exceptions import InfrastructureError
 from orb.providers.aws.exceptions.aws_exceptions import (
     AWSEntityNotFoundError,
     AWSValidationError,

--- a/src/orb/providers/aws/infrastructure/aws_handler_factory.py
+++ b/src/orb/providers/aws/infrastructure/aws_handler_factory.py
@@ -123,8 +123,8 @@ class AWSHandlerFactory:
                 else:
                     # Attempt lazy resolution via container as last resort
                     try:
-                        from orb.infrastructure.di.container import get_container
                         from orb.application.services.native_spec_service import NativeSpecService
+                        from orb.infrastructure.di.container import get_container
 
                         container = get_container()
                         aws_native_spec_service = AWSNativeSpecService(

--- a/tests/unit/providers/aws/infrastructure/handlers/test_cleanup.py
+++ b/tests/unit/providers/aws/infrastructure/handlers/test_cleanup.py
@@ -1,9 +1,9 @@
 """Unit tests for ORB launch template cleanup after full machine return."""
 
-import pytest
 from typing import cast
 from unittest.mock import MagicMock, patch
 
+import pytest
 from botocore.exceptions import ClientError
 
 from orb.config.schemas.cleanup_schema import CleanupConfig, CleanupResourcesConfig


### PR DESCRIPTION
## Description
Fix architecture violations in the domain and application layers.

**Changes:**
- Replace direct `request.metadata` dict mutation with `request.update_metadata()` calls in `ProvisioningOrchestrationService` — routes all aggregate state changes through proper domain methods
- Swap `TemplateFactory` (concrete) for `TemplateFactoryPort` (protocol) in `GetTemplateHandler` constructor — Dependency Inversion Principle
- Register `TemplateFactoryPort` in DI container as alias for `TemplateFactory`

## Type of Change
- [x] Code cleanup or refactor

## Related Issues
N/A

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Architecture boundary tests pass

## Test Configuration
* Python version: 3.12
* OS: macOS / Linux

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications