### PR TITLE
fix: replace broken SBOM upload-sarif with SPDX dependency submission

### DIFF
--- a/.github/workflows/dev-pypi.yml
+++ b/.github/workflows/dev-pypi.yml
@@ -120,7 +120,7 @@ jobs:
     needs: [config, publish]
 
     permissions:
-      contents: read
+      contents: write
       actions: write
       security-events: write
 
@@ -147,9 +147,10 @@ jobs:
           python-sbom-spdx.json
         retention-days: 180
 
-    - name: Upload SBOM to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v4
+    - name: Upload SBOM to GitHub dependency graph
+      uses: advanced-security/spdx-dependency-submission-action@v0.1.1
       if: always()
       with:
-        sarif_file: python-sbom-cyclonedx.json
+        filePath: "."
+        filePattern: "python-sbom-spdx.json"
       continue-on-error: true


### PR DESCRIPTION
## Description

The SBOM generation job in `dev-pypi.yml` was failing because it tried to upload a CycloneDX JSON file using `github/codeql-action/upload-sarif`, which only accepts SARIF format. Replaced with `advanced-security/spdx-dependency-submission-action` using the SPDX SBOM file, which correctly submits to the GitHub dependency graph. Also updated `contents` permission from `read` to `write` as required by the dependency submission API.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD or build process changes

## Related Issues
Fixes SBOM upload failure in generate-sbom job.

## How Has This Been Tested?
- [x] Manual testing performed — reviewed CI logs confirming the previous failure was `instance requires property "runs"` (CycloneDX uploaded as SARIF)

## Test Configuration
* Python version: 3.12
* OS: ubuntu-latest (GitHub Actions)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Security Considerations
- [x] Security improved — SBOM now correctly surfaces in GitHub dependency graph, enabling vulnerability tracking

## Dependencies
No new runtime dependencies. Adds `advanced-security/spdx-dependency-submission-action@v0.1.1` as a CI action.

## Additional Notes
The CycloneDX file is still generated and uploaded as a workflow artifact. Only the Security tab upload step changed.