### PR TITLE
fix: add semantic release dry-run preview and manual approval gate

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -18,11 +18,12 @@ on:
         required: false
         type: string
       force_level:
-        description: 'Force a specific bump level (leave empty for auto)'
+        description: 'Force a specific bump level (auto = commit analysis)'
         required: false
+        default: 'auto'
         type: choice
         options:
-          - ''
+          - auto
           - major
           - minor
           - patch
@@ -64,7 +65,7 @@ jobs:
       - name: Compute next version (dry run)
         id: next_version
         run: |
-          FORCE_FLAG=${{ inputs.force_level && format('--{0}', inputs.force_level) || '' }}
+          FORCE_FLAG=${{ inputs.force_level != 'auto' && format('--{0}', inputs.force_level) || '' }}
           NEXT=$(uv run semantic-release version --print $FORCE_FLAG 2>/dev/null || echo "no-release")
           echo "next_version=$NEXT" >> "$GITHUB_OUTPUT"
           {
@@ -104,7 +105,7 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           git_committer_name: "github-actions[bot]"
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
-          force: ${{ inputs.force_level }}
+          force: ${{ inputs.force_level != 'auto' && inputs.force_level || '' }}
           
       - name: Publish to GitHub Release Assets
         uses: python-semantic-release/publish-action@v10.5.3


### PR DESCRIPTION
## Description
Adds a dry-run preview job and manual approval gate to the semantic release workflow to prevent accidental version bumps (e.g. the 2.0.0 incident caused by a Copilot Autofix commit with no conventional prefix).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## Changes

**`pyproject.toml`**
- `default_bump_level` confirmed already `2` (patch) — no change needed

**`.github/workflows/semantic-release.yml`**
- Removed unused `mode` input from `workflow_dispatch`
- Added `preview` job: runs `semantic-release version --print` and posts the next version to the GitHub Actions job summary (no side effects)
- Added `needs: [preview]` and `environment: release-approval` to the `release` job — GitHub pauses and requires human approval before the release fires
- Removed redundant `if:` condition from `release` job (gated by `needs: [preview]`)

## One-time manual step required
After merging: GitHub → Settings → Environments → create `release-approval` → add required reviewers. Without this the environment gate is a no-op.

## How Has This Been Tested?
- [ ] Manual testing performed

## Test Configuration
* N/A — CI/CD only change

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Security Considerations
- [x] Security improved — human approval gate prevents unintended releases