### PR TITLE
fix(ci): restore build dependency fallback and add --group ci to uv sync

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -102,7 +102,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install ORB
-        run: uv sync --all-extras
+        run: uv sync --all-extras --group ci
 
       - name: Python Semantic Release
         id: release

--- a/dev-tools/package/build.sh
+++ b/dev-tools/package/build.sh
@@ -34,8 +34,14 @@ if [ "$QUIET" = false ]; then
     echo "INFO: Checking build dependencies..."
 fi
 if ! $RUN_TOOL python -c "import build" 2>/dev/null; then
-    echo "ERROR: 'build' package not found. Ensure 'uv sync --all-extras' has been run." >&2
-    exit 1
+    if [ "$QUIET" = false ]; then
+        echo "INFO: Installing build dependencies..."
+    fi
+    if command -v uv >/dev/null 2>&1; then
+        uv pip install build --quiet
+    else
+        $RUN_TOOL pip install build
+    fi
 fi
 
 # Build package


### PR DESCRIPTION
## Description

Fixes the semantic release build that has been broken since PR #197.

**Root cause:** `build` package lives in `[dependency-groups].ci`, not in `[project.optional-dependencies]`. `uv sync --all-extras` only installs extras, not dependency groups. PR #197 added `uv sync --all-extras` (needed for sdk-go-export-spec) but this never installed `build`. PR #198 then removed the self-healing fallback from `build.sh` assuming `--all-extras` covered `build` — it does not.

**Fix:**
1. Add `--group ci` to `uv sync` in `semantic-release.yml` so `build` is installed before PSR runs
2. Restore the self-healing fallback in `build.sh` as a safety net (uses `uv pip install` when uv is available, falls back to `$RUN_TOOL pip install`)
3. Keep `--no-isolation` on `python -m build` (correct fix for broken `.venv/bin/pip` stub in uv-managed venvs)

## Type of Change
- [x] Bug fix
- [x] CI/CD or build process changes

## Checklist
- [x] My code follows the project's style guidelines
- [x] My changes generate no new warnings

## Reviewers
@awslabs/orb-maintainers