### PR TITLE
fix: preserve unique machine IDs during provider sync in list query

### DIFF
--- a/src/orb/application/queries/machine_query_handlers.py
+++ b/src/orb/application/queries/machine_query_handlers.py
@@ -143,6 +143,7 @@ class ListMachinesHandler(BaseQueryHandler[ListMachinesQuery, list[MachineDTO]])
 
                 machine_dtos = []
                 for machine in machines:
+                    # Refresh running machines with live AWS state before building DTOs
                     if machine.status.value == "running" and machine.request_id:
                         try:
                             request = uow.requests.get_by_id(machine.request_id)
@@ -161,7 +162,10 @@ class ListMachinesHandler(BaseQueryHandler[ListMachinesQuery, list[MachineDTO]])
                                         request, [machine], provider_machines
                                     )
                                     if synced_machines:
-                                        machine = synced_machines[0]
+                                        for sm in synced_machines:
+                                            if sm.machine_id == machine.machine_id:
+                                                machine = sm
+                                                break
                         except Exception as e:
                             self.logger.debug(f"Sync failed for machine {machine.machine_id}: {e}")
 

--- a/tests/unit/application/queries/test_list_machines_sync_unique_ids.py
+++ b/tests/unit/application/queries/test_list_machines_sync_unique_ids.py
@@ -1,0 +1,77 @@
+"""Regression test: listing machines must preserve unique IDs after provider sync."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orb.application.dto.queries import ListMachinesQuery
+from orb.application.queries.machine_query_handlers import ListMachinesHandler
+from orb.domain.base.value_objects import InstanceType
+from orb.domain.machine.aggregate import Machine
+from orb.domain.machine.machine_identifiers import MachineId
+from orb.domain.machine.value_objects import MachineStatus
+
+
+def _make_machine(instance_id: str) -> Machine:
+    return Machine(
+        machine_id=MachineId(value=instance_id),
+        name=instance_id,
+        status=MachineStatus.RUNNING,
+        instance_type=InstanceType(value="t3.medium"),
+        request_id="req-001",
+        provider_name="aws_test",
+        provider_type="aws",
+        provider_api="RunInstances",
+        resource_id="r-001",
+        template_id="tmpl-001",
+        image_id="ami-123",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_list_machines_sync_preserves_unique_ids():
+    """Syncing during list should not replace all machines with the first synced machine."""
+    m1 = _make_machine("i-aaa")
+    m2 = _make_machine("i-bbb")
+    m3 = _make_machine("i-ccc")
+
+    mock_uow = MagicMock()
+    mock_uow.machines.find_active_machines.return_value = [m1, m2, m3]
+    mock_uow.requests.get_by_id.return_value = MagicMock(
+        request_id="req-001",
+        resource_ids=["r-001"],
+        provider_api="RunInstances",
+        provider_name="aws_test",
+        provider_type="aws",
+        template_id="tmpl-001",
+    )
+
+    mock_uow_factory = MagicMock()
+    mock_uow_factory.create_unit_of_work.return_value.__enter__ = MagicMock(return_value=mock_uow)
+    mock_uow_factory.create_unit_of_work.return_value.__exit__ = MagicMock(return_value=False)
+
+    # Sync service returns all 3 machines (simulating AWS returning full reservation)
+    mock_sync = AsyncMock()
+    mock_sync.fetch_provider_machines.return_value = ([m1, m2, m3], {})
+    mock_sync.sync_machines_with_provider.return_value = ([m1, m2, m3], {})
+
+    handler = ListMachinesHandler(
+        logger=MagicMock(),
+        error_handler=MagicMock(),
+        uow_factory=mock_uow_factory,
+        container=MagicMock(),
+        command_bus=MagicMock(),
+        timestamp_service=MagicMock(format_with_type=lambda v, f: str(v)),
+        generic_filter_service=MagicMock(),
+        machine_sync_service=mock_sync,
+    )
+
+    query = ListMachinesQuery(all_resources=True)
+    result = await handler.execute_query(query)
+
+    ids = [dto.machine_id for dto in result]
+    assert ids == ["i-aaa", "i-bbb", "i-ccc"], f"Expected 3 unique IDs, got {ids}"
+    assert len(set(ids)) == 3, "All machine IDs should be unique"


### PR DESCRIPTION
## Description
`ListMachinesHandler.execute_query()` used `synced_machines[0]` after syncing with AWS, always picking the first instance in the reservation regardless of which machine was being iterated. This caused `orb machines return --all` to send the same instance ID repeated N times instead of N unique IDs — only 1 instance was actually terminated. Affected all code paths using `ListMachinesQuery`: return, list, stop, start (CLI, SDK, API, MCP).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [ ] CI/CD or build process changes

## Related Issues
<!-- No tracked issue yet -->

## How Has This Been Tested?
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- Regression test: `tests/unit/application/queries/test_list_machines_sync_unique_ids.py`
- Verified via logs that `orb machines return --all --force` was sending duplicate IDs

## Test Configuration
* Python version: 3.13
* OS: macOS Darwin 25.3.0
* AWS region: eu-west-1
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes
Root cause: `fetch_provider_machines()` returns all instances in a reservation (not just the one being iterated). The code then blindly took `synced_machines[0]`, overwriting every machine in the loop with the same instance. Fix: match the synced machine back to the current machine by ID.

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

## Security Considerations
- [x] No security implications
- [ ] Security improved
- [ ] Potential security concerns (explain and justify)

## Dependencies
None.

## Reviewers
@awslabs/orb-maintainers