### PR TITLE
fix(release): drop --no-isolation from semantic-release-build recipe

### DIFF
--- a/makefiles/deploy.mk
+++ b/makefiles/deploy.mk
@@ -83,7 +83,11 @@ build-with-version: clean dev-install  ## Build package with explicit version (s
 semantic-release-build:  ## Build package for semantic-release (runs inside the action's container; bypasses run_tool.sh)
 	rm -rf dist/ build/ ./*.egg-info/
 	python3 -m pip install --quiet build
-	python3 -m build --no-isolation
+	# Let `build` create its own isolated env satisfying pyproject's
+	# [build-system].requires (setuptools, wheel). The python:3.14-slim
+	# container does not ship setuptools, so --no-isolation would fail
+	# with "Backend 'setuptools.build_meta' is not available".
+	python3 -m build
 	@echo "SUCCESS: Package built. Files:"
 	@ls -1 dist/
 


### PR DESCRIPTION
## Description
Run [#26568552918](https://github.com/awslabs/open-resource-broker/actions/runs/26568552918/job/78269504844) failed at the `Build distribution` step inside the `python-semantic-release` Docker action with:

```
ERROR Backend 'setuptools.build_meta' is not available.
pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'
make: *** [makefiles/deploy.mk:86: semantic-release-build] Error 1
```

### Root cause
After the previous PR (#221), `makefiles/deploy.mk:semantic-release-build` runs `python3 -m build --no-isolation` inside the `python:3.14-slim-trixie` container. That image does not ship `setuptools`. With `--no-isolation`, `build` looks in the current Python for the backend declared in `pyproject.toml`:

```toml
[build-system]
requires = ["setuptools>=80.9.0", "wheel"]
build-backend = "setuptools.build_meta"
```

…finds nothing, and fails. `--no-isolation` was a leftover from when the recipe ran on the host with a pre-warmed `.venv`. Now that the recipe runs in a clean container, isolation is the correct default — `build` will pip-install `setuptools` + `wheel` into a temp env per `[build-system].requires`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Follow-up to #221. The two fixes together (the original PR's run_tool.sh defensiveness + this PR's isolation correction) are what unbreaks the release pipeline end-to-end.

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

`make semantic-release-build` run locally — produces both `dist/orb_py-1.6.0.tar.gz` and `dist/orb_py-1.6.0-py3-none-any.whl` cleanly.

End-to-end verification still requires `workflow_dispatch` on `main` after merge.

## Test Configuration
* Python version: 3.12 (local), 3.14 in semantic-release container
* OS: macOS (local), Ubuntu 24.04 runner (CI)
* AWS region: N/A
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
One-line code change. The added comment in the Makefile records *why* `--no-isolation` should not be re-introduced, since the surface is small and the failure mode is non-obvious.

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications

## Dependencies
None.

## Migration Guide
Not applicable.

## Deployment Notes
After merge, the next push to `main` containing `release:` should trigger the `Semantic Release` workflow successfully.

## Reviewers
@awslabs/orb-maintainers