### PR TITLE
fix(release): bootstrap throwaway config for OpenAPI spec export

### DIFF
--- a/dev-tools/release/export_openapi_spec.sh
+++ b/dev-tools/release/export_openapi_spec.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Export the OpenAPI spec from a running ORB server into sdk/go/openapi.json.
+# Uses an existing config/config.json if present; otherwise bootstraps a
+# throwaway config via `orb init --non-interactive` to a temp directory.
+set -euo pipefail
+
+# Re-exec under `uv run` so `orb` and `python3` resolve from the project venv,
+# regardless of whether the caller already activated it.
+if [[ -z "${ORB_EXPORT_SPEC_REEXEC:-}" ]] && command -v uv >/dev/null 2>&1; then
+    export ORB_EXPORT_SPEC_REEXEC=1
+    exec uv run -- bash "$0" "$@"
+fi
+
+SOCK=/tmp/orb-spec.sock
+SPEC_TMP=$(mktemp -d)
+
+cleanup() {
+    if [[ -n "${SERVER_PID:-}" ]]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$SPEC_TMP"
+    rm -f "$SOCK"
+}
+trap cleanup EXIT
+
+if [[ -f config/config.json ]]; then
+    CONFIG_FLAG=(--config config/config.json)
+else
+    orb init --non-interactive --config-dir "$SPEC_TMP/config" >/dev/null
+    CONFIG_FLAG=(--config "$SPEC_TMP/config/config.json")
+fi
+
+orb "${CONFIG_FLAG[@]}" system serve --socket-path "$SOCK" &
+SERVER_PID=$!
+
+for _ in $(seq 1 30); do
+    if curl -sf --unix-socket "$SOCK" http://localhost/health \
+        | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if d.get('status') in ('healthy','degraded') else 1)" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+curl --fail --unix-socket "$SOCK" http://localhost/openapi.json > sdk/go/openapi.json
+python3 -c "import json; d=json.load(open('sdk/go/openapi.json')); assert d.get('openapi'), 'Invalid OpenAPI spec'"

--- a/makefiles/ci.mk
+++ b/makefiles/ci.mk
@@ -232,14 +232,5 @@ sdk-go-update-version:  ## Update Go SDK version file and commit (usage: make sd
 	git push
 
 sdk-go-export-spec:  ## Export OpenAPI spec from running ORB server into sdk/go/openapi.json
-	orb system serve --socket-path /tmp/orb-spec.sock &
-	@for i in $$(seq 1 30); do \
-		if curl -sf --unix-socket /tmp/orb-spec.sock http://localhost/health | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if d.get('status') in ('healthy','degraded') else 1)" 2>/dev/null; then \
-			break; \
-		fi; \
-		sleep 1; \
-	done
-	curl --fail --unix-socket /tmp/orb-spec.sock http://localhost/openapi.json > sdk/go/openapi.json
-	python3 -c "import json,sys; d=json.load(open('sdk/go/openapi.json')); assert d.get('openapi'), 'Invalid OpenAPI spec'"
-	kill %1 || true
+	@./dev-tools/release/export_openapi_spec.sh
 


### PR DESCRIPTION
## Description

[Run #26576870930](https://github.com/awslabs/open-resource-broker/actions/runs/26576870930/job/78298576584) failed at `Export OpenAPI spec for Go SDK`:

```
orb system serve --socket-path /tmp/orb-spec.sock &
Configuration file not found

Configuration not found in:
  - /home/runner/work/open-resource-broker/open-resource-broker/config/default_config.json
  - /home/runner/work/open-resource-broker/open-resource-broker/config/config.json

To initialize:
  orb init
```

### Root cause

`StartupValidator._find_config_file()` (`src/orb/infrastructure/validation/startup_validator.py:104-121`) demands a user `config/config.json` exists. The package ships a complete `default_config.json` *as package data* (per `pyproject.toml`: `"orb.config" = ["default_config.json"]`) which `ConfigurationLoader` always loads as the lowest-precedence layer — but the validator doesn't know about it. CI runners have no `config/config.json` (it's gitignored), so the server refuses to start.

The validator's strictness is reasonable for production: a real REST API with no provider instances configured is useless. But for OpenAPI spec extraction, the server only needs to start enough to enumerate routes and emit `/openapi.json` — it never contacts a provider.

### Fix

`make sdk-go-export-spec` now delegates to `dev-tools/release/export_openapi_spec.sh`, which:

- If `config/config.json` exists, use it (developer's existing config is preferred).
- Otherwise, run `orb init --non-interactive --config-dir <tmpdir>` to bootstrap a barebones config in a temp directory. This is the same path a real user follows on first install.

The script also handles cleanup (server process + temp dir + socket) via a single trap, instead of relying on Make's per-line shell semantics where `kill %1` doesn't refer to the backgrounded process from a previous line.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues

Follow-up to #221, #223, #224. The release pipeline now lacks only this final piece for end-to-end success.

## How Has This Been Tested?
- [x] Manual testing performed

`shellcheck dev-tools/release/export_openapi_spec.sh` — clean.

End-to-end locally:

```
$ mv config/config.json /tmp/config.json.bak
$ uv run make sdk-go-export-spec
[server starts, fetches /openapi.json, exits cleanly]
exit=0
```

Spec produced: 32 KB, OpenAPI 3.1.0, 16 paths. Both the bootstrap path (no local config) and the existing-config path (developer config present) verified.

## Test Configuration
* Python: 3.12 (local), 3.14 in semantic-release container
* OS: macOS (local) / Ubuntu 24.04 (CI runners)

## Checklist
- [x] Style: shellcheck clean
- [x] Self-review performed
- [x] Comments record *why*, not what
- [ ] Documentation: N/A
- [x] No new warnings
- [ ] Tests: N/A (CI-only change)
- [x] Existing tests pass locally
- [x] Dependent changes merged

## Performance Impact
- [x] No significant performance impact (~1s overhead from `orb init` when no local config)

## Security Considerations
- [x] No security implications (throwaway config, never persisted)

## Dependencies
None.

## Migration Guide
N/A — local developers see no behaviour change.

## Deployment Notes
After merge, trigger `Semantic Release` workflow → `force_level: patch` to ship 1.6.2 (since 1.6.1 was just cut and is the new latest tag).

## Reviewers
@awslabs/orb-maintainers