### PR TITLE
fix(storage): repair SQL/DynamoDB strategies + add cross-backend contract tests

### DIFF
--- a/src/orb/domain/base/domain_interfaces.py
+++ b/src/orb/domain/base/domain_interfaces.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Generic, Optional, Protocol, TypeVar
 
-from .entity import AggregateRoot, Entity
+from .entity import AggregateRoot
 
 T = TypeVar("T")  # Generic type for domain entities/aggregates
 A = TypeVar("A", bound=AggregateRoot)
@@ -88,18 +88,6 @@ class UnitOfWork(Protocol):
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Exit the unit of work context."""
-        ...
-
-    def register_new(self, entity: Entity) -> None:
-        """Register a new entity."""
-        ...
-
-    def register_dirty(self, entity: Entity) -> None:
-        """Register a dirty entity."""
-        ...
-
-    def register_removed(self, entity: Entity) -> None:
-        """Register a removed entity."""
         ...
 
     @abstractmethod

--- a/src/orb/infrastructure/storage/components/sql_query_builder.py
+++ b/src/orb/infrastructure/storage/components/sql_query_builder.py
@@ -33,6 +33,7 @@ class SQLQueryBuilder(QueryManager):
             table_name: Name of the database table
             columns: Dictionary of column names and types
         """
+        super().__init__()
         self.table_name = table_name
         self.columns = columns
         self.logger = get_logger(__name__)
@@ -41,6 +42,66 @@ class SQLQueryBuilder(QueryManager):
         self._validate_identifier(table_name)
         for column in columns:
             self._validate_identifier(column)
+
+    def build_query(self, query_spec: dict[str, Any]) -> str:
+        """
+        Build a SQL query from specification (implements QueryManager interface).
+
+        Dispatches to existing build_* methods based on query_spec["type"].
+        """
+        query_type = query_spec.get("type", "").upper()
+        if query_type == "CREATE_TABLE":
+            return self.build_create_table()
+        if query_type == "SELECT_ALL":
+            return self.build_select_all()
+        if query_type == "SELECT_BY_ID":
+            id_column = query_spec.get("id_column", "id")
+            sql, _ = self.build_select_by_id(id_column)
+            return sql
+        if query_type == "INSERT":
+            sql, _ = self.build_insert(query_spec.get("data", {}))
+            return sql
+        if query_type == "UPDATE":
+            sql, _ = self.build_update(
+                query_spec.get("data", {}),
+                query_spec.get("id_column", "id"),
+                query_spec.get("entity_id", ""),
+            )
+            return sql
+        if query_type == "DELETE":
+            sql, _ = self.build_delete(query_spec.get("id_column", "id"))
+            return sql
+        raise ValueError(f"Unknown query type: {query_type}")
+
+    def execute_query(
+        self, query: str, parameters: Optional[dict[str, Any]] = None
+    ) -> Any:
+        """
+        Reject direct execution — execution belongs to SQLConnectionManager.
+
+        SQLQueryBuilder is build-only; this method exists to satisfy the
+        QueryManager interface but should not be used. Callers must execute
+        the built query via SQLConnectionManager.execute_query.
+        """
+        raise NotImplementedError(
+            "SQLQueryBuilder does not execute queries; use SQLConnectionManager.execute_query"
+        )
+
+    def validate_query(self, query: str) -> bool:
+        """
+        Validate a SQL query string (implements QueryManager interface).
+
+        Performs basic structural validation: non-empty, contains a known
+        SQL keyword, and no unbalanced quotes.
+        """
+        if not query or not query.strip():
+            return False
+        keywords = ("SELECT", "INSERT", "UPDATE", "DELETE", "CREATE")
+        if not any(kw in query.upper() for kw in keywords):
+            return False
+        if query.count("'") % 2 != 0:
+            return False
+        return True
 
     def _validate_identifier(self, identifier: str) -> None:
         """

--- a/src/orb/infrastructure/storage/components/sql_query_builder.py
+++ b/src/orb/infrastructure/storage/components/sql_query_builder.py
@@ -73,9 +73,7 @@ class SQLQueryBuilder(QueryManager):
             return sql
         raise ValueError(f"Unknown query type: {query_type}")
 
-    def execute_query(
-        self, query: str, parameters: Optional[dict[str, Any]] = None
-    ) -> Any:
+    def execute_query(self, query: str, parameters: Optional[dict[str, Any]] = None) -> Any:
         """
         Reject direct execution — execution belongs to SQLConnectionManager.
 

--- a/src/orb/infrastructure/storage/sql/registration.py
+++ b/src/orb/infrastructure/storage/sql/registration.py
@@ -118,12 +118,12 @@ def create_sql_unit_of_work(config: Any) -> Any:
             echo=getattr(sql_config, "echo", False),
         )
 
-        return SQLUnitOfWork(engine) 
+        return SQLUnitOfWork(engine)
     else:
         # For testing or other scenarios - assume it's a dict with connection info
         connection_string = config.get("connection_string", "sqlite:///data/test.db")
         engine = create_engine(connection_string)
-        return SQLUnitOfWork(engine) 
+        return SQLUnitOfWork(engine)
 
 
 def register_sql_storage() -> None:

--- a/src/orb/infrastructure/storage/sql/registration.py
+++ b/src/orb/infrastructure/storage/sql/registration.py
@@ -118,12 +118,12 @@ def create_sql_unit_of_work(config: Any) -> Any:
             echo=getattr(sql_config, "echo", False),
         )
 
-        return SQLUnitOfWork(engine)  # type: ignore[abstract]
+        return SQLUnitOfWork(engine) 
     else:
         # For testing or other scenarios - assume it's a dict with connection info
         connection_string = config.get("connection_string", "sqlite:///data/test.db")
         engine = create_engine(connection_string)
-        return SQLUnitOfWork(engine)  # type: ignore[abstract]
+        return SQLUnitOfWork(engine) 
 
 
 def register_sql_storage() -> None:

--- a/src/orb/infrastructure/storage/sql/strategy.py
+++ b/src/orb/infrastructure/storage/sql/strategy.py
@@ -43,7 +43,7 @@ class SQLStorageStrategy(BaseStorageStrategy):
 
         # Initialize components
         self.connection_manager = SQLConnectionManager(config)
-        self.query_builder = SQLQueryBuilder(table_name, columns)  # type: ignore[abstract]
+        self.query_builder = SQLQueryBuilder(table_name, columns)
         self.serializer = SQLSerializer(id_column=self._get_id_column())
         self.lock_manager = LockManager("simple")  # Simple lock for SQL
 
@@ -265,7 +265,7 @@ class SQLStorageStrategy(BaseStorageStrategy):
 
                 with self.connection_manager.get_session() as session:
                     for serialized_data in serialized_list:
-                        session.execute(query, serialized_data)
+                        session.execute(text(query), serialized_data)
                     session.commit()
 
                 self.logger.debug("Saved batch of %s entities", len(entities))

--- a/src/orb/providers/aws/storage/components/dynamodb_transaction_manager.py
+++ b/src/orb/providers/aws/storage/components/dynamodb_transaction_manager.py
@@ -3,6 +3,7 @@
 from contextlib import contextmanager
 from typing import Any, Callable, Optional
 
+from boto3.dynamodb.types import TypeSerializer
 from botocore.exceptions import ClientError
 
 from orb.infrastructure.storage.components.transaction_manager import (
@@ -30,6 +31,11 @@ class DynamoDBTransactionManager(TransactionManager):
         self.client_manager = client_manager
         self.transaction_items: list[dict[str, Any]] = []
         self.max_transaction_items = 25  # DynamoDB limit
+        # transact_write_items uses the low-level Client API, which requires
+        # AttributeValue-tagged dicts (e.g. {"id": {"S": "abc"}}). The
+        # higher-level Resource API (used elsewhere) accepts plain dicts;
+        # this serializer converts at the boundary.
+        self._serializer = TypeSerializer()
 
     def begin_transaction(self) -> None:
         """Begin a new DynamoDB transaction."""
@@ -60,7 +66,8 @@ class DynamoDBTransactionManager(TransactionManager):
         if len(self.transaction_items) >= self.max_transaction_items:
             raise RuntimeError(f"Transaction cannot exceed {self.max_transaction_items} items")
 
-        put_request = {"Put": {"TableName": table_name, "Item": item}}
+        serialized_item = {k: self._serializer.serialize(v) for k, v in item.items()}
+        put_request = {"Put": {"TableName": table_name, "Item": serialized_item}}
 
         if condition_expression:
             put_request["Put"]["ConditionExpression"] = condition_expression
@@ -92,12 +99,16 @@ class DynamoDBTransactionManager(TransactionManager):
         if len(self.transaction_items) >= self.max_transaction_items:
             raise RuntimeError(f"Transaction cannot exceed {self.max_transaction_items} items")
 
+        serialized_key = {k: self._serializer.serialize(v) for k, v in key.items()}
+        serialized_values = {
+            k: self._serializer.serialize(v) for k, v in expression_attribute_values.items()
+        }
         update_request = {
             "Update": {
                 "TableName": table_name,
-                "Key": key,
+                "Key": serialized_key,
                 "UpdateExpression": update_expression,
-                "ExpressionAttributeValues": expression_attribute_values,
+                "ExpressionAttributeValues": serialized_values,
             }
         }
 
@@ -127,7 +138,8 @@ class DynamoDBTransactionManager(TransactionManager):
         if len(self.transaction_items) >= self.max_transaction_items:
             raise RuntimeError(f"Transaction cannot exceed {self.max_transaction_items} items")
 
-        delete_request = {"Delete": {"TableName": table_name, "Key": key}}
+        serialized_key = {k: self._serializer.serialize(v) for k, v in key.items()}
+        delete_request = {"Delete": {"TableName": table_name, "Key": serialized_key}}
 
         if condition_expression:
             delete_request["Delete"]["ConditionExpression"] = condition_expression

--- a/tests/integration/storage/conftest.py
+++ b/tests/integration/storage/conftest.py
@@ -78,9 +78,7 @@ def dynamodb_strategy() -> Iterator:
 
 
 @pytest.fixture(params=["json", "sql", "dynamodb"])
-def storage_strategy(
-    request, json_strategy, sql_strategy, dynamodb_strategy
-):
+def storage_strategy(request, json_strategy, sql_strategy, dynamodb_strategy):
     """Parameterised strategy fixture used by contract tests."""
     return {
         "json": json_strategy,

--- a/tests/integration/storage/conftest.py
+++ b/tests/integration/storage/conftest.py
@@ -1,0 +1,139 @@
+"""Fixtures for storage strategy contract tests.
+
+Provides parameterised `storage_strategy` and `unit_of_work` fixtures so
+each backend (JSON, SQL/SQLite, DynamoDB/moto) runs the same contract tests.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+
+try:
+    from moto import mock_aws as _moto_mock_aws
+
+    HAS_MOTO = True
+except ImportError:
+    HAS_MOTO = False
+    _moto_mock_aws = None
+
+
+@contextmanager
+def _mock_aws():
+    if _moto_mock_aws is None:
+        yield
+        return
+    with _moto_mock_aws():
+        yield
+
+
+_ENTITY_TABLE = "entities"
+_ENTITY_COLUMNS = {"id": "TEXT PRIMARY KEY", "data": "TEXT", "name": "TEXT"}
+
+
+# ---------------------------------------------------------------------------
+# Strategy fixtures (low-level: SQLStorageStrategy / JSONStorageStrategy / DynamoDB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def json_strategy(tmp_path):
+    from orb.infrastructure.storage.json.strategy import JSONStorageStrategy
+
+    file_path = tmp_path / "entities.json"
+    return JSONStorageStrategy(file_path=str(file_path), entity_type="entities")
+
+
+@pytest.fixture
+def sql_strategy():
+    from orb.infrastructure.storage.sql.strategy import SQLStorageStrategy
+
+    return SQLStorageStrategy(
+        config={"type": "sqlite", "name": ":memory:"},
+        table_name=_ENTITY_TABLE,
+        columns=_ENTITY_COLUMNS,
+    )
+
+
+@pytest.fixture
+def dynamodb_strategy() -> Iterator:
+    if not HAS_MOTO:
+        pytest.skip("moto not installed")
+
+    from orb.providers.aws.storage.strategy import DynamoDBStorageStrategy
+
+    with _mock_aws():
+        # aws_client=None forces internal boto3 session, which moto intercepts.
+        from orb.infrastructure.adapters.logging_adapter import LoggingAdapter
+
+        strategy = DynamoDBStorageStrategy(
+            logger=LoggingAdapter("test.dynamo"),
+            aws_client=None,
+            region="us-east-1",
+            table_name=_ENTITY_TABLE,
+        )
+        yield strategy
+
+
+@pytest.fixture(params=["json", "sql", "dynamodb"])
+def storage_strategy(
+    request, json_strategy, sql_strategy, dynamodb_strategy
+):
+    """Parameterised strategy fixture used by contract tests."""
+    return {
+        "json": json_strategy,
+        "sql": sql_strategy,
+        "dynamodb": dynamodb_strategy,
+    }[request.param]
+
+
+# ---------------------------------------------------------------------------
+# UnitOfWork fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def json_uow(tmp_path):
+    from orb.infrastructure.storage.json.unit_of_work import JSONUnitOfWork
+
+    return JSONUnitOfWork(data_dir=str(tmp_path))
+
+
+@pytest.fixture
+def sql_uow():
+    from sqlalchemy import create_engine
+
+    from orb.infrastructure.storage.sql.unit_of_work import SQLUnitOfWork
+
+    engine = create_engine("sqlite:///:memory:")
+    return SQLUnitOfWork(engine)
+
+
+@pytest.fixture
+def dynamodb_uow():
+    if not HAS_MOTO:
+        pytest.skip("moto not installed")
+
+    from orb.providers.aws.storage.unit_of_work import DynamoDBUnitOfWork
+
+    from orb.infrastructure.adapters.logging_adapter import LoggingAdapter
+
+    with _mock_aws():
+        uow = DynamoDBUnitOfWork(
+            aws_client=None,
+            logger=LoggingAdapter("test.dynamo.uow"),
+            region="us-east-1",
+        )
+        yield uow
+
+
+@pytest.fixture(params=["json", "sql", "dynamodb"])
+def unit_of_work(request, json_uow, sql_uow, dynamodb_uow):
+    """Parameterised UoW fixture used by UoW contract tests."""
+    return {
+        "json": json_uow,
+        "sql": sql_uow,
+        "dynamodb": dynamodb_uow,
+    }[request.param]

--- a/tests/integration/storage/test_aurora_factory.py
+++ b/tests/integration/storage/test_aurora_factory.py
@@ -1,0 +1,32 @@
+"""Aurora SQL storage factory tests.
+
+Aurora's storage strategy is SQLAlchemy-based; the strategy and UoW
+themselves are exercised by SQL contract tests against sqlite. These
+tests verify the Aurora factory wires its connection string and engine
+into a working SQLUnitOfWork without contacting AWS.
+"""
+
+import pytest
+
+
+@pytest.mark.integration
+class TestAuroraFactory:
+    def test_create_aurora_strategy_with_simple_config(self):
+        from orb.providers.aws.storage.registration import create_aurora_strategy
+        from orb.infrastructure.storage.sql.strategy import SQLStorageStrategy
+
+        class _Cfg:
+            connection_string = "sqlite:///:memory:"
+
+        strategy = create_aurora_strategy(_Cfg())
+        assert isinstance(strategy, SQLStorageStrategy)
+
+    def test_create_aurora_unit_of_work_with_dict_config(self):
+        from orb.providers.aws.storage.registration import create_aurora_unit_of_work
+        from orb.infrastructure.storage.sql.unit_of_work import SQLUnitOfWork
+
+        uow = create_aurora_unit_of_work({"connection_string": "sqlite:///:memory:"})
+        assert isinstance(uow, SQLUnitOfWork)
+        assert uow.machines is not None
+        assert uow.requests is not None
+        assert uow.templates is not None

--- a/tests/integration/storage/test_storage_contract.py
+++ b/tests/integration/storage/test_storage_contract.py
@@ -1,0 +1,57 @@
+"""Contract tests applied to every storage backend.
+
+Each backend (JSON, SQL/SQLite, DynamoDB/moto) must satisfy the same CRUD
+behaviour. Fixtures live in conftest.py.
+"""
+
+import pytest
+
+
+@pytest.mark.integration
+class TestStorageStrategyCRUD:
+    def test_save_and_find(self, storage_strategy):
+        storage_strategy.save("e1", {"id": "e1", "name": "alpha"})
+        loaded = storage_strategy.find_by_id("e1")
+        assert loaded is not None
+        assert loaded.get("id") == "e1"
+
+    def test_find_missing_returns_none(self, storage_strategy):
+        assert storage_strategy.find_by_id("nope") is None
+
+    def test_find_all_returns_inserted(self, storage_strategy):
+        storage_strategy.save("a", {"id": "a", "name": "alpha"})
+        storage_strategy.save("b", {"id": "b", "name": "beta"})
+        all_rows = storage_strategy.find_all()
+        assert "a" in all_rows
+        assert "b" in all_rows
+
+    def test_delete_removes_entity(self, storage_strategy):
+        storage_strategy.save("d1", {"id": "d1", "name": "doomed"})
+        storage_strategy.delete("d1")
+        assert storage_strategy.find_by_id("d1") is None
+
+    def test_save_overwrites_existing(self, storage_strategy):
+        storage_strategy.save("u1", {"id": "u1", "name": "before"})
+        storage_strategy.save("u1", {"id": "u1", "name": "after"})
+        loaded = storage_strategy.find_by_id("u1")
+        assert loaded is not None
+        assert loaded.get("name") == "after"
+
+
+@pytest.mark.integration
+class TestStorageStrategyBatch:
+    def test_save_batch(self, storage_strategy):
+        batch = {
+            "x": {"id": "x", "name": "x-name"},
+            "y": {"id": "y", "name": "y-name"},
+        }
+        storage_strategy.save_batch(batch)
+        assert storage_strategy.find_by_id("x") is not None
+        assert storage_strategy.find_by_id("y") is not None
+
+    def test_delete_batch(self, storage_strategy):
+        storage_strategy.save("p", {"id": "p", "name": "p"})
+        storage_strategy.save("q", {"id": "q", "name": "q"})
+        storage_strategy.delete_batch(["p", "q"])
+        assert storage_strategy.find_by_id("p") is None
+        assert storage_strategy.find_by_id("q") is None

--- a/tests/integration/storage/test_uow_contract.py
+++ b/tests/integration/storage/test_uow_contract.py
@@ -1,0 +1,41 @@
+"""UnitOfWork contract tests across all backends.
+
+Each UoW must:
+- Expose machines / requests / templates repositories.
+- begin/commit/rollback transactions without raising.
+"""
+
+import pytest
+
+
+@pytest.mark.integration
+class TestUnitOfWorkRepositories:
+    def test_repositories_exposed(self, unit_of_work):
+        assert unit_of_work.machines is not None
+        assert unit_of_work.requests is not None
+        assert unit_of_work.templates is not None
+
+
+@pytest.mark.integration
+class TestUnitOfWorkTransactions:
+    def test_begin_then_commit(self, unit_of_work):
+        unit_of_work.begin()
+        assert unit_of_work.in_transaction is True
+        unit_of_work.commit()
+        assert unit_of_work.in_transaction is False
+
+    def test_begin_then_rollback(self, unit_of_work):
+        unit_of_work.begin()
+        unit_of_work.rollback()
+        assert unit_of_work.in_transaction is False
+
+    def test_context_manager_commits_on_success(self, unit_of_work):
+        with unit_of_work:
+            assert unit_of_work.in_transaction is True
+        assert unit_of_work.in_transaction is False
+
+    def test_context_manager_rolls_back_on_exception(self, unit_of_work):
+        with pytest.raises(RuntimeError):
+            with unit_of_work:
+                raise RuntimeError("boom")
+        assert unit_of_work.in_transaction is False

--- a/tests/unit/infrastructure/storage/test_sql_strategy.py
+++ b/tests/unit/infrastructure/storage/test_sql_strategy.py
@@ -1,0 +1,64 @@
+"""Tests for SQLStorageStrategy and SQLUnitOfWork construction + round-trip."""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestSQLQueryBuilderConcrete:
+    """SQLQueryBuilder must not be abstract."""
+
+    def test_can_instantiate_sql_query_builder(self):
+        from orb.infrastructure.storage.components.sql_query_builder import (
+            SQLQueryBuilder,
+        )
+
+        builder = SQLQueryBuilder("test_table", {"id": "TEXT PRIMARY KEY"})
+        assert builder is not None
+        assert builder.table_name == "test_table"
+
+
+@pytest.mark.unit
+class TestSQLStorageStrategyConstruction:
+    """SQLStorageStrategy must construct without abstract-method errors."""
+
+    def test_can_instantiate_with_sqlite_memory(self):
+        from orb.infrastructure.storage.sql.strategy import SQLStorageStrategy
+
+        strategy = SQLStorageStrategy(
+            config={"type": "sqlite", "name": ":memory:"},
+            table_name="entities",
+            columns={"id": "TEXT PRIMARY KEY", "data": "TEXT"},
+        )
+        assert strategy is not None
+        assert strategy.table_name == "entities"
+
+    def test_save_and_load_entity(self):
+        from orb.infrastructure.storage.sql.strategy import SQLStorageStrategy
+
+        strategy = SQLStorageStrategy(
+            config={"type": "sqlite", "name": ":memory:"},
+            table_name="entities",
+            columns={"id": "TEXT PRIMARY KEY", "data": "TEXT"},
+        )
+
+        strategy.save("e1", {"id": "e1", "data": "hello"})
+        loaded = strategy.find_by_id("e1")
+        assert loaded is not None
+        assert loaded.get("id") == "e1"
+
+
+@pytest.mark.unit
+class TestSQLUnitOfWorkConstruction:
+    """SQLUnitOfWork must wire up all three repositories without errors."""
+
+    def test_construct_with_sqlite_engine(self):
+        from sqlalchemy import create_engine
+
+        from orb.infrastructure.storage.sql.unit_of_work import SQLUnitOfWork
+
+        engine = create_engine("sqlite:///:memory:")
+        uow = SQLUnitOfWork(engine)
+
+        assert uow.machines is not None
+        assert uow.requests is not None
+        assert uow.templates is not None


### PR DESCRIPTION
## Description

The SQL storage mode was non-functional. Investigation found three independent root causes that each prevented `SQLStorageStrategy` from being constructed or used. DynamoDB had a related batch-operation bug exposed once tests began exercising it. None of these were caught because no tests existed for the strategies themselves — only for low-level components.

This PR fixes all four issues, removes a dead Protocol API that was hiding the SQL bug, and adds a parametrised contract test suite that exercises every storage backend end-to-end.

### Bugs fixed

| # | Backend | Bug |
|---|---------|-----|
| 1 | SQL | `SQLQueryBuilder` extended abstract `QueryManager` but did not implement `build_query` / `execute_query` / `validate_query` → `TypeError: Can't instantiate abstract class` on construction. |
| 2 | SQL | `SQLStorageStrategy.save_batch` passed raw SQL strings to `session.execute(...)`, which SQLAlchemy 2.x rejects without `text(...)` wrapping. |
| 3 | UoW | `UnitOfWork` Protocol declared `register_new` / `register_dirty` / `register_removed` (Fowler-style identity-map UoW) that no concrete UoW implemented and no caller invoked. Pyright complained, and the noise was silenced via `# type: ignore[abstract]`. |
| 4 | DynamoDB | `DynamoDBTransactionManager` built `TransactItems` with plain Python dicts; `transact_write_items` requires AttributeValue-tagged dicts, so every batch put / delete / update was rejected. |

### What changed

- `SQLQueryBuilder` — added `build_query`, `execute_query`, `validate_query` implementations satisfying `QueryManager`
- `SQLStorageStrategy.save_batch` — wrapped query in `text(...)` for SQLAlchemy 2.x
- `UnitOfWork` Protocol — removed unused `register_new` / `register_dirty` / `register_removed`. The codebase uses direct repository writes (`uow.machines.save(...)`), not the identity-map pattern. Re-add the methods only if and when that pattern is actually adopted.
- `DynamoDBTransactionManager` — added `boto3.dynamodb.types.TypeSerializer` at the Put / Delete / Update boundary
- Removed three `# type: ignore[abstract]` suppressions that hid the SQL abstract issue

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [ ] CI/CD or build process changes

## Related Issues
N/A

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

A new parametrised contract suite exercises every backend through the same tests, so future strategy bugs surface immediately:

- `tests/unit/infrastructure/storage/test_sql_strategy.py` — strategy + UoW construction + round-trip (4 cases)
- `tests/integration/storage/test_storage_contract.py` — CRUD + batch contract for JSON, SQL (sqlite), DynamoDB (moto) (21 cases)
- `tests/integration/storage/test_uow_contract.py` — UoW transaction semantics for the same three backends (15 cases)
- `tests/integration/storage/test_aurora_factory.py` — Aurora factory wires a working `SQLUnitOfWork` end-to-end via sqlite (2 cases)

DynamoDB tests use `moto` (already a dev dependency), so no AWS credentials are required.

```
pytest tests/integration/storage/ tests/unit/infrastructure/storage/ --no-cov
============================== 58 passed in 9.74s ==============================

pyright src/orb/infrastructure/storage/ src/orb/providers/aws/storage/ tests/integration/storage/ tests/unit/infrastructure/storage/
0 errors, 0 warnings
```

## Test Configuration
* Python version: 3.12 (also runs in CI matrix 3.10–3.14)
* OS: macOS / Linux
* AWS region: N/A (moto)
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes

The contract test framework is the load-bearing part: each backend now runs the same CRUD and UoW assertions. Future regressions in any one backend surface immediately rather than silently breaking that storage mode.

The Protocol cleanup also removes architectural aspiration that wasn't followed through. The Fowler identity-map UoW pattern (`register_new`/`register_dirty`/`register_removed`) was part of an early DDD scaffolding commit but the codebase consistently uses direct repository writes instead. Implementing the pattern properly is a multi-day refactor (identity map, flush logic per backend, ~18 handler call-site migrations, read-after-write consistency, DynamoDB 25-item transact batching) — out of scope for this fix. Drop the dead API now; revisit only when intentionally adopting the pattern.

## Screenshots (if appropriate)
N/A

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

## Security Considerations
- [x] No security implications
- [ ] Security improved
- [ ] Potential security concerns (explain and justify)

## Dependencies
None.

## Migration Guide
None — runtime behaviour for currently-working backends is unchanged. The removed Protocol methods (`register_new`/`register_dirty`/`register_removed`) had no implementations and no callers.

## Deployment Notes
None.

## Reviewers
@finos/open-resource-broker-maintainers