### PR TITLE
fix: provider storage strategy

### DIFF
--- a/src/orb/config/schemas/storage_schema.py
+++ b/src/orb/config/schemas/storage_schema.py
@@ -122,6 +122,18 @@ class RetryConfig(BaseModel):
         return v
 
 
+def _get_valid_storage_strategies() -> set[str]:
+    """Accepted ``storage.strategy`` values: generic baseline + registered backends."""
+    valid = {"json", "sql"}
+    try:
+        from orb.infrastructure.storage.registry import get_storage_registry
+
+        valid.update(get_storage_registry().get_registered_storage_types())
+    except Exception:
+        pass  # registry not ready -> baseline only
+    return valid
+
+
 class StorageConfig(BaseModel):
     """Storage configuration."""
 
@@ -133,10 +145,10 @@ class StorageConfig(BaseModel):
     @field_validator("strategy")
     @classmethod
     def validate_strategy(cls, v: str) -> str:
-        """Validate storage strategy."""
-        valid_strategies = ["json", "sql"]
+        """Validate storage strategy against registered backends (provider-agnostic)."""
+        valid_strategies = _get_valid_storage_strategies()
         if v not in valid_strategies:
-            raise ValueError(f"Storage strategy must be one of {valid_strategies}")
+            raise ValueError(f"Storage strategy must be one of {sorted(valid_strategies)}")
         return v
 
     @model_validator(mode="after")

--- a/src/orb/infrastructure/storage/registration.py
+++ b/src/orb/infrastructure/storage/registration.py
@@ -42,33 +42,43 @@ def get_available_storage_types() -> list:
 
     # Check JSON storage availability
     try:
-        pass
+        from orb.infrastructure.storage.json.registration import (  # noqa: F401
+            register_json_storage,
+        )
 
         available_types.append("json")
     except ImportError:
-        pass
+        pass  # optional backend not installed
 
     # Check SQL storage availability
     try:
-        pass
+        from orb.infrastructure.storage.sql.registration import (  # noqa: F401
+            register_sql_storage,
+        )
 
         available_types.append("sql")
     except ImportError:
-        pass
+        pass  # optional backend not installed
 
     # Check DynamoDB storage availability
     try:
-        pass
+        from orb.providers.aws.storage.registration import (  # noqa: F401
+            register_dynamodb_storage,
+        )
 
         available_types.append("dynamodb")
     except ImportError:
-        pass
+        pass  # optional backend not installed (boto3 missing)
 
     # Check Aurora storage availability
     try:
+        from orb.providers.aws.storage.registration import (  # noqa: F401
+            register_aurora_storage,
+        )
+
         available_types.append("aurora")
     except ImportError:
-        pass
+        pass  # optional backend not installed
 
     return available_types
 

--- a/src/orb/infrastructure/storage/registration.py
+++ b/src/orb/infrastructure/storage/registration.py
@@ -22,9 +22,13 @@ def register_all_storage_types() -> None:
 
     register_sql_storage()
 
-    from orb.providers.aws.storage.registration import register_dynamodb_storage
+    from orb.providers.aws.storage.registration import (
+        register_aurora_storage,
+        register_dynamodb_storage,
+    )
 
     register_dynamodb_storage()
+    register_aurora_storage()
 
 
 def get_available_storage_types() -> list:
@@ -57,6 +61,14 @@ def get_available_storage_types() -> list:
         pass
 
         available_types.append("dynamodb")
+    except ImportError:
+        pass
+
+    # Check Aurora storage availability
+    try:
+        pass
+
+        available_types.append("aurora")
     except ImportError:
         pass
 

--- a/src/orb/infrastructure/storage/registration.py
+++ b/src/orb/infrastructure/storage/registration.py
@@ -66,8 +66,6 @@ def get_available_storage_types() -> list:
 
     # Check Aurora storage availability
     try:
-        pass
-
         available_types.append("aurora")
     except ImportError:
         pass

--- a/src/orb/infrastructure/storage/registration.py
+++ b/src/orb/infrastructure/storage/registration.py
@@ -38,47 +38,19 @@ def get_available_storage_types() -> list:
     Returns:
         List of storage type names that are available for registration
     """
+    from importlib.util import find_spec
+
     available_types = []
 
-    # Check JSON storage availability
-    try:
-        from orb.infrastructure.storage.json.registration import (  # noqa: F401
-            register_json_storage,
-        )
-
+    # Each backend is available when its registration module can be imported.
+    # find_spec probes importability without binding an unused name.
+    if find_spec("orb.infrastructure.storage.json.registration") is not None:
         available_types.append("json")
-    except ImportError:
-        pass  # optional backend not installed
-
-    # Check SQL storage availability
-    try:
-        from orb.infrastructure.storage.sql.registration import (  # noqa: F401
-            register_sql_storage,
-        )
-
+    if find_spec("orb.infrastructure.storage.sql.registration") is not None:
         available_types.append("sql")
-    except ImportError:
-        pass  # optional backend not installed
-
-    # Check DynamoDB storage availability
-    try:
-        from orb.providers.aws.storage.registration import (  # noqa: F401
-            register_dynamodb_storage,
-        )
-
+    if find_spec("orb.providers.aws.storage.registration") is not None:
         available_types.append("dynamodb")
-    except ImportError:
-        pass  # optional backend not installed (boto3 missing)
-
-    # Check Aurora storage availability
-    try:
-        from orb.providers.aws.storage.registration import (  # noqa: F401
-            register_aurora_storage,
-        )
-
         available_types.append("aurora")
-    except ImportError:
-        pass  # optional backend not installed
 
     return available_types
 

--- a/src/orb/providers/aws/infrastructure/aws_client.py
+++ b/src/orb/providers/aws/infrastructure/aws_client.py
@@ -110,6 +110,8 @@ class AWSClient:
             self._sts_client = None
             self._cost_explorer_client = None
             self._ssm_client = None
+            self._dynamodb_client = None
+            self._dynamodb_resource = None
             self._account_id = None
             self._credentials_validated = False
 
@@ -383,6 +385,22 @@ class AWSClient:
             self._logger.debug("Initializing ELBv2 client on first use")
             self._elbv2_client = self.session.client("elbv2", config=self.boto_config)
         return self._elbv2_client
+
+    @property
+    def dynamodb_client(self):
+        """Lazy initialization of DynamoDB client."""
+        if self._dynamodb_client is None:
+            self._logger.debug("Initializing DynamoDB client on first use")
+            self._dynamodb_client = self.session.client("dynamodb", config=self.boto_config)
+        return self._dynamodb_client
+
+    @property
+    def dynamodb_resource(self):
+        """Lazy initialization of DynamoDB resource."""
+        if self._dynamodb_resource is None:
+            self._logger.debug("Initializing DynamoDB resource on first use")
+            self._dynamodb_resource = self.session.resource("dynamodb", config=self.boto_config)
+        return self._dynamodb_resource
 
     def _should_enable_aws_metrics(self) -> bool:
         """Check if AWS metrics should be enabled based on configuration."""

--- a/src/orb/providers/aws/storage/components/dynamodb_client_manager.py
+++ b/src/orb/providers/aws/storage/components/dynamodb_client_manager.py
@@ -41,8 +41,8 @@ class DynamoDBClientManager(ResourceManager):
         # Use provided client or create new one
         if aws_client:
             self.aws_client: Any = aws_client
-            self.dynamodb: Any = aws_client.get_client("dynamodb")
-            self.dynamodb_resource: Any = aws_client.get_resource("dynamodb")
+            self.dynamodb: Any = aws_client.dynamodb_client
+            self.dynamodb_resource: Any = aws_client.dynamodb_resource
             self._initialized = True
         else:
             self.aws_client: Any = None

--- a/src/orb/providers/aws/storage/components/dynamodb_converter.py
+++ b/src/orb/providers/aws/storage/components/dynamodb_converter.py
@@ -193,14 +193,10 @@ class DynamoDBConverter(DataConverter):
             else:
                 return float(value)
 
-        # Handle datetime strings
+        # Return strings (incl. ISO timestamps) as-is; the domain/repository
+        # layer owns datetime parsing, matching the JSON backend. Parsing here
+        # would hand a datetime to consumers that call fromisoformat() on it.
         if isinstance(value, str):
-            # Try to parse as ISO datetime
-            from contextlib import suppress
-
-            with suppress(ValueError, TypeError):
-                if "T" in value and ("Z" in value or "+" in value or value.endswith("00")):
-                    return datetime.fromisoformat(value.replace("Z", "+00:00"))
             return value
 
         # Handle lists

--- a/src/orb/providers/aws/storage/components/dynamodb_converter.py
+++ b/src/orb/providers/aws/storage/components/dynamodb_converter.py
@@ -145,13 +145,13 @@ class DynamoDBConverter(DataConverter):
         if isinstance(value, datetime):
             return value.isoformat()
 
+        # Handle boolean (must precede int: bool is a subclass of int)
+        if isinstance(value, bool):
+            return value
+
         # Handle numeric types - convert to Decimal for DynamoDB
         if isinstance(value, (int, float)):
             return Decimal(str(value))
-
-        # Handle boolean
-        if isinstance(value, bool):
-            return value
 
         # Handle strings
         if isinstance(value, str):

--- a/src/orb/providers/aws/storage/registration.py
+++ b/src/orb/providers/aws/storage/registration.py
@@ -74,12 +74,6 @@ def create_dynamodb_unit_of_work(config: Any) -> Any:
     Returns:
         DynamoDBUnitOfWork instance with correctly configured AWS client
     """
-    from botocore.config import Config
-
-    from orb.providers.aws.session_factory import AWSSessionFactory
-
-    boto_config = Config(connect_timeout=10, read_timeout=30, retries={"max_attempts": 3})
-
     from orb.config.manager import ConfigurationManager
     from orb.infrastructure.adapters.logging_adapter import LoggingAdapter
     from orb.providers.aws.storage.config import DynamodbStrategyConfig
@@ -90,15 +84,14 @@ def create_dynamodb_unit_of_work(config: Any) -> Any:
     # Handle different config types
     if isinstance(config, ConfigurationManager):
         from orb.providers.aws.configuration.config import AWSProviderConfig
+        from orb.providers.aws.infrastructure.aws_client import AWSClient
 
         aws_cfg = config.get_typed(AWSProviderConfig)
         dynamodb_config = aws_cfg.storage.dynamodb or DynamodbStrategyConfig()  # type: ignore[call-arg]
 
-        session = AWSSessionFactory.create_session(
-            profile=dynamodb_config.profile if dynamodb_config.profile else None,
-            region=dynamodb_config.region,
-        )
-        aws_client = session.client("dynamodb", config=boto_config)
+        # ORB AWS wrapper exposes dynamodb_client/dynamodb_resource (lazy boto3),
+        # which DynamoDBClientManager consumes directly.
+        aws_client = AWSClient(config=config, logger=_logger)
 
         collections = config.app_config.naming.collections
         machine_name = collections.get("machines", "machines")
@@ -115,18 +108,14 @@ def create_dynamodb_unit_of_work(config: Any) -> Any:
             template_table=f"{dynamodb_config.table_prefix}-{template_name}",
         )
     else:
-        # For testing or other scenarios - assume it's a dict with AWS config
+        # dict path (tests/direct) - no ConfigurationPort to build AWSClient,
+        # so let DynamoDBClientManager self-init its boto3 client/resource.
         region = config.get("region") or None
         profile = config.get("profile")
         table_prefix = config.get("table_prefix", "hostfactory")
 
-        session = AWSSessionFactory.create_session(
-            profile=profile if profile else None, region=region
-        )
-        aws_client = session.client("dynamodb", config=boto_config)
-
         return DynamoDBUnitOfWork(  # type: ignore[abstract]
-            aws_client=aws_client,
+            aws_client=None,
             logger=_logger,
             region=region,
             profile=profile,

--- a/src/orb/providers/aws/storage/registration.py
+++ b/src/orb/providers/aws/storage/registration.py
@@ -90,8 +90,9 @@ def create_dynamodb_unit_of_work(config: Any) -> Any:
         dynamodb_config = aws_cfg.storage.dynamodb or DynamodbStrategyConfig()  # type: ignore[call-arg]
 
         # ORB AWS wrapper exposes dynamodb_client/dynamodb_resource (lazy boto3),
-        # which DynamoDBClientManager consumes directly.
-        aws_client = AWSClient(config=config, logger=_logger)
+        # which DynamoDBClientManager consumes directly. ConfigurationManager
+        # provides the configuration access AWSClient needs at runtime.
+        aws_client = AWSClient(config=config, logger=_logger)  # type: ignore[arg-type]
 
         collections = config.app_config.naming.collections
         machine_name = collections.get("machines", "machines")

--- a/tests/integration/storage/conftest.py
+++ b/tests/integration/storage/conftest.py
@@ -114,9 +114,8 @@ def dynamodb_uow():
     if not HAS_MOTO:
         pytest.skip("moto not installed")
 
-    from orb.providers.aws.storage.unit_of_work import DynamoDBUnitOfWork
-
     from orb.infrastructure.adapters.logging_adapter import LoggingAdapter
+    from orb.providers.aws.storage.unit_of_work import DynamoDBUnitOfWork
 
     with _mock_aws():
         uow = DynamoDBUnitOfWork(

--- a/tests/integration/storage/test_aurora_factory.py
+++ b/tests/integration/storage/test_aurora_factory.py
@@ -12,8 +12,8 @@ import pytest
 @pytest.mark.integration
 class TestAuroraFactory:
     def test_create_aurora_strategy_with_simple_config(self):
-        from orb.providers.aws.storage.registration import create_aurora_strategy
         from orb.infrastructure.storage.sql.strategy import SQLStorageStrategy
+        from orb.providers.aws.storage.registration import create_aurora_strategy
 
         class _Cfg:
             connection_string = "sqlite:///:memory:"
@@ -22,8 +22,8 @@ class TestAuroraFactory:
         assert isinstance(strategy, SQLStorageStrategy)
 
     def test_create_aurora_unit_of_work_with_dict_config(self):
-        from orb.providers.aws.storage.registration import create_aurora_unit_of_work
         from orb.infrastructure.storage.sql.unit_of_work import SQLUnitOfWork
+        from orb.providers.aws.storage.registration import create_aurora_unit_of_work
 
         uow = create_aurora_unit_of_work({"connection_string": "sqlite:///:memory:"})
         assert isinstance(uow, SQLUnitOfWork)

--- a/tests/integration/storage/test_request_roundtrip_dynamodb.py
+++ b/tests/integration/storage/test_request_roundtrip_dynamodb.py
@@ -1,0 +1,46 @@
+"""Request aggregate round-trip through the DynamoDB UnitOfWork (moto).
+
+Exercises the real consumer path for timestamp handling: a Request is
+saved via uow.requests.save(...) and read back via get_by_id(...), which
+runs RequestSerializer.from_dict and calls datetime.fromisoformat on
+created_at. If the storage converter pre-parses ISO strings to datetime,
+that read raises "fromisoformat: argument must be str". This test fails
+on that regression and passes when storage returns timestamps as strings.
+"""
+
+import pytest
+
+from orb.domain.request.aggregate import Request
+from orb.domain.request.request_identifiers import RequestId
+from orb.domain.request.request_types import RequestType
+
+
+@pytest.mark.integration
+class TestRequestRoundTripDynamoDB:
+    def _make_request(self) -> Request:
+        return Request(
+            request_id=RequestId.generate(RequestType.ACQUIRE),
+            request_type=RequestType.ACQUIRE,
+            template_id="RunInstances-OnDemand",
+            provider_type="aws",
+            requested_count=2,
+            provider_api="RunInstances",
+        )
+
+    def test_save_then_get_by_id_reads_back(self, dynamodb_uow):
+        request = self._make_request()
+
+        with dynamodb_uow as uow:
+            uow.requests.save(request)
+
+        with dynamodb_uow as uow:
+            # The read path runs from_dict -> datetime.fromisoformat(created_at);
+            # must not raise "fromisoformat: argument must be str".
+            loaded = uow.requests.get_by_id(request.request_id)
+
+        assert loaded is not None
+        assert str(loaded.request_id) == str(request.request_id)
+        assert loaded.requested_count == 2
+        assert loaded.provider_api == "RunInstances"
+        # created_at round-trips back to a real datetime on the aggregate.
+        assert loaded.created_at is not None

--- a/tests/integration/storage/test_storage_contract.py
+++ b/tests/integration/storage/test_storage_contract.py
@@ -4,6 +4,8 @@ Each backend (JSON, SQL/SQLite, DynamoDB/moto) must satisfy the same CRUD
 behaviour. Fixtures live in conftest.py.
 """
 
+from decimal import Decimal
+
 import pytest
 
 
@@ -55,3 +57,38 @@ class TestStorageStrategyBatch:
         storage_strategy.delete_batch(["p", "q"])
         assert storage_strategy.find_by_id("p") is None
         assert storage_strategy.find_by_id("q") is None
+
+
+@pytest.mark.integration
+class TestDynamoDBRichTypes:
+    """Round-trip non-string scalar types through the DynamoDB backend (moto).
+
+    Covers type handling that the {id, name} CRUD tests do not exercise:
+    a boolean must not come back as a number, and a timestamp must come
+    back as a string the domain layer can parse with fromisoformat.
+
+    Scoped to DynamoDB: the SQL backend uses a fixed {id, name} column
+    schema and drops arbitrary fields, so it cannot host these fields.
+    """
+
+    def test_bool_roundtrip(self, dynamodb_strategy):
+        dynamodb_strategy.save("rt-bool", {"id": "rt-bool", "dry_run": True})
+        loaded = dynamodb_strategy.find_by_id("rt-bool")
+        assert loaded is not None
+        # Must be a real bool, never a Decimal/int (regression: bool->Decimal).
+        assert loaded["dry_run"] is True
+
+    def test_number_roundtrip(self, dynamodb_strategy):
+        dynamodb_strategy.save("rt-num", {"id": "rt-num", "count": 2})
+        loaded = dynamodb_strategy.find_by_id("rt-num")
+        assert loaded is not None
+        assert loaded["count"] == Decimal("2")
+        assert not isinstance(loaded["count"], bool)
+
+    def test_timestamp_roundtrips_as_string(self, dynamodb_strategy):
+        ts = "2026-06-11T10:30:45+00:00"
+        dynamodb_strategy.save("rt-ts", {"id": "rt-ts", "created_at": ts})
+        loaded = dynamodb_strategy.find_by_id("rt-ts")
+        assert loaded is not None
+        # Storage must not pre-parse to datetime (regression: double-parse).
+        assert isinstance(loaded["created_at"], str)

--- a/tests/unit/providers/aws/storage/test_aws_storage_config.py
+++ b/tests/unit/providers/aws/storage/test_aws_storage_config.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from orb.config.schemas.storage_schema import StorageConfig
+from orb.config.schemas.storage_schema import StorageConfig, _get_valid_storage_strategies
 from orb.providers.aws.configuration.config import AWSProviderConfig
 from orb.providers.aws.storage.config import AWSStorageConfig
 
@@ -84,15 +84,17 @@ def test_storage_config_accepts_strategy_once_registered(monkeypatch):
     The generic schema names no provider backend; validity is derived from the
     registry, so 'dynamodb' is accepted only after it is registered.
     """
-    import orb.config.schemas.storage_schema as storage_schema
-
     # Not registered (registry reports baseline only) -> rejected.
-    monkeypatch.setattr(storage_schema, "_get_valid_storage_strategies", lambda: {"json", "sql"})
+    monkeypatch.setattr(
+        "tests.unit.providers.aws.storage.test_aws_storage_config._get_valid_storage_strategies",
+        lambda: {"json", "sql"},
+    )
     with pytest.raises(ValueError):
         StorageConfig(strategy="dynamodb")
 
     # Registered (registry now advertises it) -> accepted.
     monkeypatch.setattr(
-        storage_schema, "_get_valid_storage_strategies", lambda: {"json", "sql", "dynamodb"}
+        "tests.unit.providers.aws.storage.test_aws_storage_config._get_valid_storage_strategies",
+        lambda: {"json", "sql", "dynamodb"},
     )
     assert StorageConfig(strategy="dynamodb").strategy == "dynamodb"

--- a/tests/unit/providers/aws/storage/test_aws_storage_config.py
+++ b/tests/unit/providers/aws/storage/test_aws_storage_config.py
@@ -87,9 +87,7 @@ def test_storage_config_accepts_strategy_once_registered(monkeypatch):
     import orb.config.schemas.storage_schema as storage_schema
 
     # Not registered (registry reports baseline only) -> rejected.
-    monkeypatch.setattr(
-        storage_schema, "_get_valid_storage_strategies", lambda: {"json", "sql"}
-    )
+    monkeypatch.setattr(storage_schema, "_get_valid_storage_strategies", lambda: {"json", "sql"})
     with pytest.raises(ValueError):
         StorageConfig(strategy="dynamodb")
 

--- a/tests/unit/providers/aws/storage/test_aws_storage_config.py
+++ b/tests/unit/providers/aws/storage/test_aws_storage_config.py
@@ -66,7 +66,35 @@ def test_aws_storage_config_both_none():
     assert cfg.aurora is None
 
 
-def test_storage_config_valid_strategies_unchanged():
-    """Regression guard: core StorageConfig must NOT accept dynamodb as a strategy."""
+def test_storage_config_rejects_unregistered_strategy():
+    """An unknown/unregistered strategy is still rejected."""
+    with pytest.raises(ValueError):
+        StorageConfig(strategy="not-a-real-backend")
+
+
+def test_storage_config_baseline_strategies_always_valid():
+    """json/sql are accepted regardless of registry state."""
+    assert StorageConfig(strategy="json").strategy == "json"
+    assert StorageConfig(strategy="sql").strategy == "sql"
+
+
+def test_storage_config_accepts_strategy_once_registered(monkeypatch):
+    """A backend becomes valid exactly when the storage registry advertises it.
+
+    The generic schema names no provider backend; validity is derived from the
+    registry, so 'dynamodb' is accepted only after it is registered.
+    """
+    import orb.config.schemas.storage_schema as storage_schema
+
+    # Not registered (registry reports baseline only) -> rejected.
+    monkeypatch.setattr(
+        storage_schema, "_get_valid_storage_strategies", lambda: {"json", "sql"}
+    )
     with pytest.raises(ValueError):
         StorageConfig(strategy="dynamodb")
+
+    # Registered (registry now advertises it) -> accepted.
+    monkeypatch.setattr(
+        storage_schema, "_get_valid_storage_strategies", lambda: {"json", "sql", "dynamodb"}
+    )
+    assert StorageConfig(strategy="dynamodb").strategy == "dynamodb"

--- a/tests/unit/providers/aws/storage/test_aws_storage_config.py
+++ b/tests/unit/providers/aws/storage/test_aws_storage_config.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from orb.config.schemas.storage_schema import StorageConfig, _get_valid_storage_strategies
+from orb.config.schemas.storage_schema import StorageConfig
 from orb.providers.aws.configuration.config import AWSProviderConfig
 from orb.providers.aws.storage.config import AWSStorageConfig
 
@@ -84,17 +84,15 @@ def test_storage_config_accepts_strategy_once_registered(monkeypatch):
     The generic schema names no provider backend; validity is derived from the
     registry, so 'dynamodb' is accepted only after it is registered.
     """
+    # Patch where validate_strategy looks it up (its own module), not the
+    # test module's reference.
+    target = "orb.config.schemas.storage_schema._get_valid_storage_strategies"
+
     # Not registered (registry reports baseline only) -> rejected.
-    monkeypatch.setattr(
-        "tests.unit.providers.aws.storage.test_aws_storage_config._get_valid_storage_strategies",
-        lambda: {"json", "sql"},
-    )
+    monkeypatch.setattr(target, lambda: {"json", "sql"})
     with pytest.raises(ValueError):
         StorageConfig(strategy="dynamodb")
 
     # Registered (registry now advertises it) -> accepted.
-    monkeypatch.setattr(
-        "tests.unit.providers.aws.storage.test_aws_storage_config._get_valid_storage_strategies",
-        lambda: {"json", "sql", "dynamodb"},
-    )
+    monkeypatch.setattr(target, lambda: {"json", "sql", "dynamodb"})
     assert StorageConfig(strategy="dynamodb").strategy == "dynamodb"

--- a/tests/unit/providers/aws/storage/test_dynamodb_converter.py
+++ b/tests/unit/providers/aws/storage/test_dynamodb_converter.py
@@ -1,0 +1,114 @@
+"""Unit tests for DynamoDBConverter type conversion.
+
+Direct coverage for two type-handling edge cases on the create/read
+round-trip:
+
+* booleans must serialize as DynamoDB BOOL, not Decimal (bool is a
+  subclass of int, so the bool check must precede the numeric check)
+* ISO-8601 timestamps must be returned as strings on read, not parsed
+  to datetime (the domain/repository layer owns datetime parsing)
+
+These are unit tests against the converter only (no AWS / moto needed).
+"""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from orb.providers.aws.storage.components.dynamodb_converter import DynamoDBConverter
+
+
+@pytest.fixture
+def converter() -> DynamoDBConverter:
+    return DynamoDBConverter(partition_key="id")
+
+
+# --- booleans must not be coerced to Decimal --------------------------------
+
+
+def test_bool_true_serialized_as_bool(converter):
+    assert converter._convert_to_dynamodb_type(True) is True
+
+
+def test_bool_false_serialized_as_bool(converter):
+    assert converter._convert_to_dynamodb_type(False) is False
+
+
+def test_int_serialized_as_decimal(converter):
+    result = converter._convert_to_dynamodb_type(5)
+    assert result == Decimal("5")
+    assert isinstance(result, Decimal)
+
+
+def test_float_serialized_as_decimal(converter):
+    result = converter._convert_to_dynamodb_type(1.5)
+    assert result == Decimal("1.5")
+    assert isinstance(result, Decimal)
+
+
+# --- ISO strings returned as-is on read (no eager datetime) -----------------
+
+
+def test_iso_timestamp_returned_as_str_on_read(converter):
+    value = converter._convert_from_dynamodb_type("2026-06-11T10:30:45+00:00")
+    assert isinstance(value, str)
+    assert value == "2026-06-11T10:30:45+00:00"
+
+
+def test_zulu_timestamp_returned_as_str_on_read(converter):
+    value = converter._convert_from_dynamodb_type("2026-06-11T10:30:45Z")
+    assert isinstance(value, str)
+
+
+def test_plain_string_returned_as_str_on_read(converter):
+    assert converter._convert_from_dynamodb_type("RunInstances") == "RunInstances"
+
+
+# --- write path still serialises datetime objects to ISO strings ------------
+
+
+def test_datetime_object_serialized_to_iso_on_write(converter):
+    dt = datetime(2026, 6, 11, 10, 30, 45, tzinfo=timezone.utc)
+    assert converter._convert_to_dynamodb_type(dt) == dt.isoformat()
+
+
+# --- full request-shaped round-trip integrity -------------------------------
+
+
+def test_request_item_roundtrip_preserves_types(converter):
+    """A request-shaped item survives to_dynamodb_item -> from_dynamodb_item
+    with bool, numeric and timestamp types intact."""
+    item = converter.to_dynamodb_item(
+        "req-1",
+        {
+            "id": "req-1",
+            "dry_run": True,
+            "requested_count": 2,
+            "provider_api": "RunInstances",
+            "created_at": "2026-06-11T10:30:45+00:00",
+        },
+    )
+
+    # On-the-wire form: bool stays BOOL, number becomes Decimal.
+    assert item["dry_run"] is True
+    assert item["requested_count"] == Decimal("2")
+
+    back = converter.from_dynamodb_item(item)
+
+    assert back["dry_run"] is True
+    assert back["requested_count"] == Decimal("2")
+    assert back["provider_api"] == "RunInstances"
+    # Timestamp comes back as a string for the domain layer to parse.
+    assert isinstance(back["created_at"], str)
+    assert back["created_at"] == "2026-06-11T10:30:45+00:00"
+
+
+def test_nested_bool_in_dict_roundtrip(converter):
+    """Booleans nested inside a map field are also preserved."""
+    item = converter.to_dynamodb_item(
+        "req-2", {"id": "req-2", "metadata": {"dry_run": True, "retries": 3}}
+    )
+    back = converter.from_dynamodb_item(item)
+    assert back["metadata"]["dry_run"] is True
+    assert back["metadata"]["retries"] == Decimal("3")


### PR DESCRIPTION
## Description

The DynamoDB storage backend was non-functional out of the box. Standing up the create → read → write → read-back loop hit a separate defect at each consecutive stage, each masking the next. This PR fixes the four blockers, adds the round-trip test coverage that would have caught them, and registers the Aurora backend that was implemented but never wired in.

**What:**
- Validator derives valid `storage.strategy` values from the storage registry instead of a hardcoded `["json", "sql"]`, so a registered backend (e.g. `dynamodb`, `aurora`) is accepted while the generic schema stays provider-agnostic.
- `AWSClient` gains lazy `dynamodb_client`/`dynamodb_resource` accessors (mirroring `ec2_client`); the DynamoDB UoW factory stops handing a raw boto3 client to wrapper-expecting code.
- DynamoDB converter: serialise `bool` before `int` (bool is an int subclass → was crashing on `Decimal("True")`); stop pre-parsing ISO timestamps to `datetime` on read (the repository layer owns parsing, matching the JSON backend).
- Register the existing Aurora backend in `register_all_storage_types()`.

**Why:** Each defect gates one stage of the only meaningful DynamoDB workflow (init → create → status), so the backend cannot provision or read back a single instance without all four fixes. Existing tests only round-tripped `{id, name}`, so the bool/timestamp regressions were never exercised.

**How:** Minimal, in-idiom changes scoped to the storage layer, preserving the provider-agnostic separation of the generic config layer (a prior refactor moved AWS storage code under `providers/aws/`). Backend selection is registry-driven; the converter fixes match the JSON backend's proven behaviour.

**Testing:** New converter unit tests + moto-backed contract/round-trip tests; reverting either converter fix turns the new integration tests red. Exercised end-to-end against real AWS (`eu-west-1`).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issues
Fixes #

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

New tests: `test_dynamodb_converter.py` (converter unit), `TestDynamoDBRichTypes` in `test_storage_contract.py` (bool/number/timestamp round-trip via moto), `test_request_roundtrip_dynamodb.py` (Request save → get_by_id), registry-driven validator tests in `test_aws_storage_config.py`. 77 storage tests + 2300+ architecture/config tests pass locally; storage-leak detection green; ruff clean. Manually ran create → status → terminate via `RunInstances` against real AWS.

## Test Configuration
* Python version: 3.13
* OS: macOS (darwin)
* AWS region: eu-west-1
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes

Follow-ups intentionally **not** in this PR:
- `region`/`profile` on `DynamodbStrategyConfig` duplicate `AWSProviderConfig.region/.profile` and should be removed so storage config carries only `table_prefix`; parked pending a multi-provider resolution rule (which provider supplies the storage block when several are configured).
- Aurora is registered and contract-tested via sqlite; live Aurora MySQL connectivity is not yet covered.

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications

## Dependencies

None.

## Migration Guide

Not a breaking change. To use DynamoDB, set top-level `storage.strategy: "dynamodb"` and provide `provider.providers[N].config.storage.dynamodb` (`table_prefix`, plus provider `region`/`profile`).

## Deployment Notes

DynamoDB tables are auto-created on first use (partition key `id`, on-demand billing). Requires `dynamodb:CreateTable`/`DescribeTable` plus read/write permissions.

## Reviewers
@finos/open-resource-broker-maintainers
