### PR TITLE
ci(release): attribute automated commits to the orb-cicd-app

### DIFF
--- a/.github/actions/orb-cicd-app-token/action.yml
+++ b/.github/actions/orb-cicd-app-token/action.yml
@@ -1,0 +1,57 @@
+name: 'ORB CICD App Token'
+description: 'Mint an installation token for the ORB CICD GitHub App and resolve its bot identity for git commit attribution.'
+
+inputs:
+  app-id:
+    description: 'GitHub App ID (from secrets.GH_APP_ID)'
+    required: true
+  private-key:
+    description: 'GitHub App private key (from secrets.GH_APP_PRIVATE_KEY)'
+    required: true
+
+outputs:
+  token:
+    description: 'Short-lived installation access token for the App'
+    value: ${{ steps.app-token.outputs.token }}
+  app-slug:
+    description: "App slug (e.g. open-resource-broker-cicd)"
+    value: ${{ steps.app-token.outputs.app-slug }}
+  user-id:
+    description: "Numeric user id of the App's bot account"
+    value: ${{ steps.app-user.outputs.user-id }}
+  committer-name:
+    description: 'Git committer name for App-authored commits'
+    value: ${{ steps.app-user.outputs.committer-name }}
+  committer-email:
+    description: 'Git committer email for App-authored commits'
+    value: ${{ steps.app-user.outputs.committer-email }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Mint App installation token
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+
+    - name: Resolve App bot identity
+      id: app-user
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+      run: |
+        USER_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+        echo "user-id=${USER_ID}" >> "$GITHUB_OUTPUT"
+        echo "committer-name=${APP_SLUG}[bot]" >> "$GITHUB_OUTPUT"
+        echo "committer-email=${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
+    - name: Configure git remote with App token
+      shell: bash
+      env:
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        REPO: ${{ github.repository }}
+      run: |
+        git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git"

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -91,7 +91,7 @@ jobs:
 
   auto-format:
     name: Auto-Format Code
-    # Same-repo PRs only: GITHUB_TOKEN can push directly to the branch.
+    # Same-repo PRs only: push commits as the ORB CICD App.
     # Fork PRs are handled by the auto-format-suggest job below.
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
@@ -102,8 +102,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
+
+      - name: ORB CICD App token
+        id: cicd
+        uses: ./.github/actions/orb-cicd-app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Setup UV with cache
         uses: ./.github/actions/setup-uv-cached
@@ -116,10 +122,10 @@ jobs:
 
       - name: Commit formatting changes
         env:
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_AUTHOR_NAME: ${{ steps.cicd.outputs.committer-name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.cicd.outputs.committer-email }}
+          GIT_COMMITTER_NAME: ${{ steps.cicd.outputs.committer-name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.cicd.outputs.committer-email }}
         run: |
           git add .
           if ! git diff --staged --quiet; then

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -85,18 +85,17 @@ jobs:
       id-token: write
 
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
+
+      - name: ORB CICD App token
+        id: cicd
+        uses: ./.github/actions/orb-cicd-app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Setup UV
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
@@ -108,16 +107,16 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0  # v10.5.3
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          git_committer_name: "github-actions[bot]"
-          git_committer_email: "github-actions[bot]@users.noreply.github.com"
+          github_token: ${{ steps.cicd.outputs.token }}
+          git_committer_name: ${{ steps.cicd.outputs.committer-name }}
+          git_committer_email: ${{ steps.cicd.outputs.committer-email }}
           force: ${{ inputs.force_level != 'auto' && inputs.force_level || '' }}
 
       - name: Publish to GitHub Release Assets
         uses: python-semantic-release/publish-action@310a9983a0ae878b29f3aac778d7c77c1db27378  # v10.5.3
         if: steps.release.outputs.released == 'true'
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ steps.cicd.outputs.token }}
           tag: ${{ steps.release.outputs.tag }}
 
       - name: Install ORB
@@ -131,8 +130,8 @@ jobs:
       - name: Update Go SDK version
         if: steps.release.outputs.released == 'true'
         env:
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_AUTHOR_NAME: ${{ steps.cicd.outputs.committer-name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.cicd.outputs.committer-email }}
+          GIT_COMMITTER_NAME: ${{ steps.cicd.outputs.committer-name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.cicd.outputs.committer-email }}
         run: uv run make sdk-go-update-version VERSION=${{ steps.release.outputs.version }}


### PR DESCRIPTION
## Description

Adds a composite action `.github/actions/orb-cicd-app-token` that mints a GitHub App installation token for the ORB CICD App and resolves its bot identity (slug + numeric user id) for git commit attribution. Both `semantic-release.yml` (version commit, tag, GitHub Release publish, Go SDK version bump) and the same-repo `auto-format` job in `ci-quality.yml` now consume the composite, so every automated commit lands attributed to the App's bot identity rather than `github-actions[bot]`.

Authorisation already routed through the App for semantic-release (the App is the sole entry in `main` branch protection's bypass list, which is why the August release failure surfaced with `GH006` before the App was wired in). This PR addresses the attribution mismatch: commits were authorised by the App but `git log` showed `github-actions[bot]`. Same-repo auto-format now also routes through the App for consistency.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
N/A

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

`actionlint` clean on both modified workflows. The composite action manifest is structurally valid against GitHub's composite-action schema (actionlint itself doesn't lint `action.yml` files since it expects workflow shape). Confirmation in practice requires the next release run and a same-repo PR triggering the auto-format job.

## Test Configuration
* Python version: N/A (workflow changes only)
* OS: GitHub Actions Ubuntu runners
* AWS region: N/A
* Dependencies changed: no

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file (semantic-release manages this)
- [ ] I have updated the version number (semantic-release manages this)

## Additional Notes

**Scope intentionally excluded:**
- Dependabot workflows (`update-uv-lock`, `auto-merge`, `monthly-maintenance`) - these target dependabot branches which aren't under main's bypass requirement; the existing `github-actions[bot]` auth path works.
- Fork-PR `auto-format-suggest` - posts inline review suggestions via reviewdog, doesn't commit anywhere.
- `prod-release.yml`, `dev-pypi.yml`, `docs.yml` - none of these create git commits; they use `GITHUB_TOKEN` or OIDC publishing only.

**Composite action design:**
`actions/create-github-app-token@v3` exposes the App slug as an output. The composite combines that with a `gh api /users/<slug>[bot]` lookup to produce a `user-id` and the canonical noreply-email format (`<user-id>+<slug>[bot]@users.noreply.github.com`) GitHub uses for App commits. Composite outputs: `token`, `app-slug`, `user-id`, `committer-name`, `committer-email`. Future workflows that need to commit as the App add a 6-line step.

## Performance Impact
- [x] No significant performance impact

Adds one `gh api` call per workflow run that mints a token. Single HTTP roundtrip, negligible.

## Security Considerations
- [x] Security improved

Single bot identity for every automated repo write makes audit and revocation cleaner. Previously, semantic-release and auto-format presented as the same `github-actions[bot]` identity despite using different tokens with different permission scopes. Post-merge, both surfaces present as the ORB CICD App, matching the actual authorisation principal.

## Dependencies

No new runtime dependencies. The composite uses pinned versions of already-vetted actions:
- `actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1` (v3)

## Migration Guide

N/A. Operators don't see a behavioural change. Maintainers will notice commits attributed to `orb-cicd-app[bot]` (or whatever the App slug resolves to) instead of `github-actions[bot]` in release commits and same-repo auto-format pushes.

## Deployment Notes

Requires `GH_APP_ID` and `GH_APP_PRIVATE_KEY` repository secrets to be configured (already in place per the audit; this PR does not introduce new secrets).

## Reviewers
@finos/open-resource-broker-maintainers
