### PR TITLE
ci(containers): use buildx imagetools for multi-arch manifest check

### DIFF
--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -289,6 +289,9 @@ jobs:
           done
         fi
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
+
     - name: Test multi-architecture support
       env:
         REGISTRY: ${{ needs.config.outputs.container-registry }}
@@ -296,13 +299,17 @@ jobs:
         VERSION: ${{ needs.config.outputs.package-version }}
         DEFAULT_PYTHON: ${{ needs.config.outputs.default-python-version }}
       run: |
-        # Test that multi-arch manifests exist
-        echo "Testing multi-arch manifest for $VERSION-python$DEFAULT_PYTHON"
-        docker manifest inspect "$REGISTRY/$IMAGE:$VERSION-python$DEFAULT_PYTHON"
-        
-        # Verify both amd64 and arm64 are present
-        if docker manifest inspect "$REGISTRY/$IMAGE:$VERSION-python$DEFAULT_PYTHON" | grep -q "amd64" && \
-           docker manifest inspect "$REGISTRY/$IMAGE:$VERSION-python$DEFAULT_PYTHON" | grep -q "arm64"; then
+        # Use buildx imagetools rather than `docker manifest inspect`:
+        # imagetools authenticates via the existing docker login session and
+        # handles both OCI and Docker manifest media types consistently for
+        # GHCR-hosted images.
+        REF="$REGISTRY/$IMAGE:$VERSION-python$DEFAULT_PYTHON"
+        echo "Testing multi-arch manifest for $REF"
+        INSPECT=$(docker buildx imagetools inspect --raw "$REF")
+        echo "$INSPECT"
+
+        if echo "$INSPECT" | grep -q '"architecture": "amd64"' && \
+           echo "$INSPECT" | grep -q '"architecture": "arm64"'; then
           echo "Multi-arch manifest contains both amd64 and arm64"
         else
           echo "Multi-arch manifest missing architectures"


### PR DESCRIPTION
## Description

`Validate Container Tags` (in `Container Build`) consistently fails with `manifest unknown` on every main-branch push, even when the per-Python multi-arch images were pushed successfully by the matrix build job. The `docker manifest inspect` CLI subcommand uses its own auth path that does not pick up the `docker login` session performed in the same job for GHCR, so the inspection call fails the registry's authentication check and returns `manifest unknown`.

Swap to `docker buildx imagetools inspect --raw`, which shares the buildx credential store with the rest of the job and handles both OCI and Docker manifest media types consistently. The architecture check now parses the manifest list JSON for explicit `"architecture": "amd64"` / `"architecture": "arm64"` entries rather than substring-matching the raw manifest dump, which avoids false positives if a label or annotation happens to contain the architecture string.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
N/A

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

`actionlint` clean. End-to-end verification requires the workflow to run against a real main-branch push, which only happens once this PR merges. The CI run on this PR exercises the same workflow under `pull_request`; the validation job has an `if` guard skipping it on PRs, so the fix path won't be exercised by the PR check itself.

## Test Configuration
* Python version: N/A
* OS: GitHub Actions Ubuntu runners
* AWS region: N/A
* Dependencies changed: no

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file (semantic-release manages this)
- [ ] I have updated the version number (semantic-release manages this)

## Additional Notes

Adds a `docker/setup-buildx-action` step to the `container-validation` job since `imagetools` requires a buildx instance to be initialised. The `container-pipeline` job already does this in its own steps.

Considered (and not done): publishing dev containers for PR builds, mirroring `dev-pypi.yml` for TestPyPI. Current behaviour is consistent across both workflows (no PR publish, push-to-main only); changing this is a scope decision beyond this fix.

## Performance Impact
- [x] No significant performance impact

Adds one buildx init step on the validation job; existing build matrix jobs already initialise buildx so the action layer is cached.

## Security Considerations
- [x] No security implications

Same auth surface; the change is in how the existing docker login is consumed.

## Dependencies

No new runtime dependencies. Already-pinned action versions reused:
- `docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5` (v4)

## Migration Guide

N/A.

## Deployment Notes

None.

## Reviewers
@finos/open-resource-broker-maintainers
