### PR TITLE
ci: stop persisting GITHUB_TOKEN extraheader when App token authenticates the push

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -103,6 +103,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.head_ref }}
+          # See semantic-release.yml for the rationale - the App-token URL
+          # set by the composite below must be the only credential source
+          # so the auto-format push lands as the ORB CICD App rather than
+          # falling back to github-actions[bot] via the persisted extraheader.
+          persist-credentials: false
 
       - name: ORB CICD App token
         id: cicd

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -89,6 +89,15 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          # The composite below mints the App token and resets the remote
+          # URL to authenticate as the ORB CICD App.  If actions/checkout
+          # also persists the default GITHUB_TOKEN as an extraheader git
+          # config entry, that header beats the URL-embedded token at push
+          # time and the request lands as github-actions[bot] - which is
+          # not in the main branch protection bypass list and is rejected
+          # with GH006.  Skip the persistence so the composite's remote
+          # URL is the sole credential source.
+          persist-credentials: false
 
       - name: ORB CICD App token
         id: cicd


### PR DESCRIPTION
## Description

The Semantic Release run on `main` following PR #264 failed with:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

The orb-cicd-app is the only entry in `main`'s `bypass_pull_request_allowances.apps` list, so any push from another identity is rejected. PR #264 reordered the release workflow so `actions/checkout` runs first (with the default `GITHUB_TOKEN`) and then the `orb-cicd-app-token` composite sets the git remote URL with the App's installation token. The intent was for the App token to authenticate subsequent pushes.

`actions/checkout` also calls `git config --local http.https://github.com/.extraheader AUTHORIZATION: basic <GITHUB_TOKEN>` as part of its credential setup. That extraheader is attached to every request to github.com regardless of the remote URL. When `python-semantic-release` issues the push, the request carries both the URL-embedded App token and the extraheader-attached `GITHUB_TOKEN`; the extraheader wins, GitHub treats the push as coming from `github-actions[bot]`, and the bypass list lookup fails.

Setting `persist-credentials: false` on the checkout step skips the extraheader setup so the composite's URL token is the sole credential source. The same fix applies to the `auto-format` job in `ci-quality.yml`, which uses the same composite-after-checkout pattern.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
N/A. Regression introduced by #264.

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

`actionlint` clean on both modified workflows. End-to-end verification requires the workflow to run on a real `main` push or the auto-format job to fire on a same-repo PR, neither of which can be exercised by this PR's own CI run (the semantic-release `release` job has an `if:` guard that skips on PR builds, and the auto-format job needs a PR touching `src/**` or `tests/**`).

## Test Configuration
* Python version: N/A
* OS: GitHub Actions Ubuntu runners
* AWS region: N/A
* Dependencies changed: no

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file (semantic-release manages this)
- [ ] I have updated the version number (semantic-release manages this)

## Additional Notes

The composite action in `.github/actions/orb-cicd-app-token` already configures the remote URL with `https://x-access-token:${APP_TOKEN}@github.com/<repo>.git`, which is sufficient on its own to authenticate as the App. The composite is unchanged here; only the two checkout steps that precede it need the `persist-credentials: false` flag.

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] Security improved

This change ensures every automated commit lands under the orb-cicd-app identity rather than silently falling back to `github-actions[bot]`. The previous behaviour left a credential surface where two tokens with different permission scopes were being sent on the same request and GitHub chose between them implicitly.

## Dependencies

No new dependencies. Same pinned action versions as before.

## Migration Guide

N/A.

## Deployment Notes

The first post-merge semantic-release run will be the verification point. If it succeeds, the regression is fixed. If it fails again, the next step would be to log the headers and URL at push time to confirm which credential is reaching the server.

## Reviewers
@finos/open-resource-broker-maintainers
