### PR TITLE
ci(dependabot): use single (deps) scope on auto-generated commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       - "dependencies"
       - "python"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 3
 
@@ -97,7 +97,7 @@ updates:
       - "dependencies"
       - "go"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 2
 
@@ -113,6 +113,6 @@ updates:
       - "dependencies"
       - "docker"
     commit-message:
-      prefix: "chore(docker)"
+      prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 1

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           if [[ -n $(git status --porcelain) ]]; then
             git add uv.lock
-            git commit -m "chore: update uv.lock after dependabot changes"
+            git commit -m "chore(deps): update uv.lock after dependabot changes"
             git push
           else
             echo "No changes to commit"
@@ -206,8 +206,8 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: monthly dependency maintenance"
-          title: "chore: monthly dependency maintenance"
+          commit-message: "chore(deps): monthly dependency maintenance"
+          title: "chore(deps): monthly dependency maintenance"
           body: |
             ## Monthly Dependency Maintenance
 


### PR DESCRIPTION
## Description

Fixes the doubled `(deps)` scope on Dependabot-authored commits that breaks release-note grouping.

**Why this is needed.** Auditing the v1.7.0 release notes, every PR Dependabot opened for the `pip`, `gomod`, or `docker` ecosystems committed a header of the form `chore(deps)(deps): bump <pkg>`.  Ten such commits landed in v1.7.0 alone (security-updates group, aws-dependencies group, testing-tools group, individual bumps).  The doubled scope is not what `python-semantic-release` matches against, so all of them got grouped under the generic `Chores` heading in the release notes instead of `Dependencies`.

The root cause is in `.github/dependabot.yml`: the pip, gomod, and docker ecosystem entries set `prefix: "chore(deps)"` while also enabling `include: "scope"`.  Dependabot appends `(deps)` to the prefix when `include: scope` is set, which produces the doubled form.

**What changes.**

`.github/dependabot.yml` -- drop the embedded `(deps)` from the prefix on all three ecosystems so `include: scope` produces the canonical `chore(deps): <subject>` header:
- `pip` ecosystem: `prefix: "chore(deps)"` -> `prefix: "chore"`
- `gomod` ecosystem: `prefix: "chore(deps)"` -> `prefix: "chore"`
- `docker` ecosystem: `prefix: "chore(docker)"` -> `prefix: "chore"`

The `github-actions` ecosystem already uses `prefix: "ci"` and is unchanged.

`.github/workflows/dependabot.yml` -- align the two commits this workflow itself opens so they share the `chore(deps):` bucket alongside the Dependabot-authored bumps:
- `update-uv-lock` follow-up commit: `chore: update uv.lock after dependabot changes` -> `chore(deps): update uv.lock after dependabot changes`
- `monthly-maintenance` PR commit + title: `chore: monthly dependency maintenance` -> `chore(deps): monthly dependency maintenance`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
N/A

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

`actionlint` clean on the changed workflow.  The dependabot config syntax is validated by GitHub on push.  End-to-end verification will land naturally on the next weekly Dependabot run (Sunday 06:00 ET): the next opened PRs should carry `chore(deps): ...` headers without the doubled scope, and the next semantic-release run should bucket them under `Dependencies` in the changelog.

## Test Configuration
* Python version: N/A
* OS: GitHub Actions Ubuntu runners
* AWS region: N/A
* Dependencies changed: no

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file (semantic-release manages this)
- [ ] I have updated the version number (semantic-release manages this)

## Additional Notes

This only fixes the auto-generated commits.  Manual `chore:` / `ci:` commits that landed in v1.7.0 without a scope (e.g. `chore: ruff format`, `ci: exclude k8s/ from shellcheck`) are out of scope here -- those are author-convention drift and would be better addressed by adding a `commitlint` step to the PR checks, which can be a follow-up if we want to enforce conventional-commit scope at PR time.

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications

No new permissions, no new secrets, no new external actions.

## Dependencies

No dependency changes.

## Migration Guide

N/A.

## Deployment Notes

The change is in effect immediately after merge.  Dependabot picks up `.github/dependabot.yml` on its next scheduled run; the workflow file change applies to the next monthly-maintenance and any future post-bump `uv.lock` commits.

## Reviewers
@finos/open-resource-broker-maintainers
