### PR TITLE
ci(dependabot): pin uv-lock checkout to PR head branch

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -50,6 +50,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          # On a Dependabot pull_request the default checkout target is the
+          # synthesised merge ref, which lands as a detached HEAD.  The
+          # subsequent commit succeeds but the push errors with
+          # `fatal: You are not currently on a branch`.  Pin to the PR head
+          # branch by name so push has an upstream to write to.
+          ref: ${{ github.head_ref }}
 
       - name: Setup Python and UV
         uses: ./.github/actions/setup-uv-cached


### PR DESCRIPTION
## Description

Fixes the `Update UV Lock File` job in `.github/workflows/dependabot.yml` which has been failing on every Dependabot PR.

**Why this is needed.** On a Dependabot `pull_request` event, `actions/checkout` without an explicit `ref` defaults to checking out the synthesised PR merge ref (`Merge <head> into <base>`).  That lands the working tree at a detached HEAD with no associated branch name.  The job's commit step works, but the subsequent `git push` fails with:

```
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use
    git push origin HEAD:<name-of-remote-branch>
```

Example run that hit this on PR #271: https://github.com/finos/open-resource-broker/actions/runs/28026204667/job/82954606892?pr=271

The `permissions:` block on the job already grants `contents: write` and the runner log confirms the token's `Contents: write` permission is in effect, so this isn't a permissions issue -- only the missing branch reference.

**What changes.**

Add `ref: ${{ github.head_ref }}` to the `actions/checkout` step in the `update-uv-lock` job so the working tree is on the PR head branch by name.  `git push` then has a concrete upstream to write to.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
N/A

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

`actionlint` clean on the changed workflow.  End-to-end verification happens on the next Dependabot PR; if the lock file diff is non-empty the job should now commit and push back to the PR branch without the detached-HEAD error.

## Test Configuration
* Python version: N/A
* OS: GitHub Actions Ubuntu runners
* AWS region: N/A
* Dependencies changed: no

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file (semantic-release manages this)
- [ ] I have updated the version number (semantic-release manages this)

## Additional Notes

The companion failure on the same PR -- the `Auto-Format Code` job in `ci-quality.yml` failing with `Input 'client-id' must be set to a non-empty string` -- has a different root cause and a different fix path.  That job's `${{ secrets.GH_APP_ID }}` resolves to an empty string on Dependabot PRs because GitHub injects the `dependabot/secrets` scope (currently empty) into Dependabot-triggered workflow runs, not the repo `actions/secrets` scope where `GH_APP_ID` and `GH_APP_PRIVATE_KEY` actually live.  Mirroring those two values into the Dependabot secret scope (`gh secret set GH_APP_ID --app dependabot ...`) is the simplest fix and does not require a workflow change.  Out of scope for this PR.

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications

Same `GITHUB_TOKEN`, same permissions, same branch.  Pinning the ref does not widen the credential or write scope.

## Dependencies

No dependency changes.

## Migration Guide

N/A.

## Deployment Notes

Takes effect on the next Dependabot PR after merge.  No backfill needed -- the failing job re-runs automatically when Dependabot opens or updates a PR.

## Reviewers
@finos/open-resource-broker-maintainers
