### PR TITLE
chore(providers): onboarding prep — unblock Azure/GCP/OCI merges

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -319,7 +319,25 @@ jobs:
         ls -la .coverage* 2>/dev/null || echo "no .coverage data files found"
 
     - name: Combine coverage and enforce combined threshold
+      id: coverage-gate
       run: make ci-tests-coverage-check
+
+    # Single deterministic Codecov upload: the combined report from ALL legs is
+    # sent once here, instead of each leg uploading separately.  Codecov then
+    # shows one stable number (no mid-run partial-merge flapping) and this needs
+    # no hardcoded leg count — it auto-scales to any number of provider legs.
+    # if: always() so the report uploads even when the threshold gate fails
+    # above (the job still fails on the gate; Codecov still gets the data).
+    - name: Upload combined coverage to Codecov
+      if: always()
+      continue-on-error: true
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: coverage-combined.xml
+        name: combined
+        # Overwrite any prior partial report for this commit with the full merge.
+        override_commit: ${{ github.event.pull_request.head.sha || github.sha }}
 
   # Single stable required status check for branch protection.  Replaces listing
   # every individual job name (which drifts silently when jobs are renamed).

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -185,15 +185,12 @@ jobs:
             coverage-*.xml
             .coverage*
 
-      - name: Upload coverage to Codecov
-        if: inputs.upload-coverage && always()
-        continue-on-error: true
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage-${{ inputs.test-type }}${{ inputs.provider != '' && format('-{0}', inputs.provider) || '' }}.xml
-          flags: ${{ inputs.test-type }}${{ inputs.provider != '' && format('-{0}', inputs.provider) || '' }}
-          name: ${{ inputs.test-type }}${{ inputs.provider != '' && format('-{0}', inputs.provider) || '' }}-tests
+      # NOTE: per-leg coverage is NOT uploaded to Codecov here.  The .coverage
+      # data files are uploaded as artifacts (above) and the coverage-combine
+      # fan-in job in ci-tests.yml merges them and uploads ONE combined report
+      # to Codecov.  A single upload gives Codecov one deterministic number
+      # (no mid-run partial-merge flapping) and auto-scales to any number of
+      # provider legs without a hardcoded after_n_builds count.
 
       - name: Upload test results to Codecov
         # Gated on upload-coverage: legs without pytest (e.g. ui-smoke) produce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### BREAKING CHANGES
 
+- **`Template.instance_type` renamed to `Template.machine_type`.**
+  The `instance_type` field on the `Template` domain model has been renamed
+  to `machine_type` to reflect provider-neutral terminology.  The old name
+  is accepted as a write-only alias (via `AliasChoices`) for backward
+  compatibility with existing YAML / JSON configuration files, but it emits
+  a `DeprecationWarning` when used in Python code.  Update template
+  definitions to use `machine_type` at your earliest convenience.
+
+- **`Template.instance_profile` renamed to `Template.machine_role`.**
+  The `instance_profile` field has been renamed to `machine_role` for the
+  same provider-neutral reason.  The old name is accepted as a write-only
+  alias with a `DeprecationWarning`, just like `instance_type` above.
+  Update template definitions to use `machine_role`.
+
+- **`Template.provider_data` field removed.**
+  The `provider_data` catch-all dict has been deleted.  Provider-specific
+  data is now carried on typed subclasses (`AWSTemplate`, `K8sTemplate`,
+  etc.).  Code that reads or writes `template.provider_data` must be
+  migrated to the appropriate typed subclass field.
+
+### Deprecated aliases
+
+The following backward-compat aliases are available on the `Template` model
+and will be removed in the next major release:
+
+| Old name | New name | Notes |
+|---|---|---|
+| `instance_type` | `machine_type` | Accepted by `model_validate` and `__init__`; emits `DeprecationWarning` in Python |
+| `instance_profile` | `machine_role` | Accepted by `model_validate` and `__init__`; emits `DeprecationWarning` in Python |
+
 - **Daemon token file at `<work_dir>/server/orb-server.token`.**
   When `orb server start` is invoked (daemon or `--foreground` mode), a
   random bearer token is written to `<work_dir>/server/orb-server.token`

--- a/README.md
+++ b/README.md
@@ -13,24 +13,24 @@
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/orb-py/"><img src="https://img.shields.io/pypi/v/orb-py" alt="PyPI Version"></a>
-  <a href="https://pypi.org/project/orb-py/"><img src="https://img.shields.io/pypi/pyversions/orb-py" alt="Python Versions"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/finos/open-resource-broker" alt="License"></a>
+  <a href="https://pypi.org/project/orb-py/"><img src="https://img.shields.io/pypi/v/orb-py" alt="PyPI Version"></a>
   <a href="https://github.com/finos/open-resource-broker/releases"><img src="https://img.shields.io/github/v/release/finos/open-resource-broker" alt="Latest Release"></a>
+  <a href="https://pypi.org/project/orb-py/"><img src="https://img.shields.io/pypi/pyversions/orb-py" alt="Python Versions"></a>
   <a href="https://deepwiki.com/finos/open-resource-broker"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
-</p>
-
-<p align="center">
+  <br>
   <a href="https://github.com/finos/open-resource-broker/actions/workflows/ci-tests.yml"><img src="https://github.com/finos/open-resource-broker/actions/workflows/ci-tests.yml/badge.svg" alt="Unit Tests"></a>
   <a href="https://github.com/finos/open-resource-broker/actions/workflows/ci-quality.yml"><img src="https://github.com/finos/open-resource-broker/actions/workflows/ci-quality.yml/badge.svg" alt="Quality Checks"></a>
   <a href="https://github.com/finos/open-resource-broker/actions/workflows/security-code.yml"><img src="https://github.com/finos/open-resource-broker/actions/workflows/security-code.yml/badge.svg" alt="Security Scanning"></a>
-  <a href="https://codecov.io/gh/finos/open-resource-broker"><img src="https://codecov.io/gh/finos/open-resource-broker/graph/badge.svg" alt="Coverage"></a>
   <a href="https://github.com/finos/open-resource-broker/actions/workflows/docs.yml"><img src="https://github.com/finos/open-resource-broker/actions/workflows/docs.yml/badge.svg" alt="Documentation"></a>
+  <br>
+  <a href="https://codecov.io/gh/finos/open-resource-broker"><img src="https://codecov.io/gh/finos/open-resource-broker/graph/badge.svg" alt="Coverage"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/finos/open-resource-broker"><img src="https://api.securityscorecards.dev/projects/github.com/finos/open-resource-broker/badge" alt="OpenSSF Scorecard"></a>
 </p>
 
 ---
 
-ORB is a unified API for orchestrating and provisioning compute capacity programmatically. Define what you need in a template, request it, track it, return it — through a CLI, REST API, Python SDK, or MCP server.
+Open Resource Broker (ORB) is a unified API for orchestrating and provisioning compute capacity programmatically. Define what you need in a template, request it, track it, return it — through a CLI, REST API, Python SDK, or MCP server.
 
 Built for AWS today (EC2, Auto Scaling Groups, SpotFleet, EC2Fleet), with an extensible provider system for adding new cloud backends.
 
@@ -189,6 +189,31 @@ aws sts get-caller-identity
 | `AutoScalingGroup` | Managed scaling groups |
 
 See the [AWS Provider Guide](docs/root/user_guide/configuration.md) for required IAM permissions and SpotFleet service-linked role setup.
+
+</details>
+
+<details>
+<summary>Kubernetes Provider Setup</summary>
+
+ORB uses the standard Kubernetes client credential chain — any context that works with `kubectl` works with ORB. Running in-cluster, it auto-detects the mounted service account; running outside, it reads your `KUBECONFIG` and current context.
+
+```bash
+# Verify your context is active
+kubectl config current-context
+```
+
+**Supported credential methods:** `KUBECONFIG` contexts, the default `~/.kube/config`, and in-cluster service accounts (auto-detected). See [provider discovery](docs/root/providers/k8s/discovery.md) for the detection order.
+
+### Supported resource types
+
+| Type | Description |
+|---|---|
+| `Pod` | Single-pod provisioning |
+| `Deployment` | Replica-managed stateless workloads |
+| `StatefulSet` | Stable-identity stateful workloads |
+| `Job` | Run-to-completion batch workloads |
+
+Install with `pip install "orb-py[k8s]"`. Minimum RBAC is in [`docs/root/providers/k8s/rbac.yaml`](docs/root/providers/k8s/rbac.yaml); see the [Kubernetes Provider Guide](docs/root/providers/k8s/index.md) for full setup.
 
 </details>
 
@@ -377,7 +402,8 @@ curl http://localhost:8000/health
 
 </details>
 
-## Symphony HostFactory on Kubernetes (legacy)
+<details>
+<summary>Symphony HostFactory on Kubernetes (legacy)</summary>
 
 The `k8s-legacy` module is a Symphony HostFactory custom provider plugin for Kubernetes, predating the modern multi-cloud ORB architecture.  It is now bundled with `orb-py` as an optional install extra rather than as a separate PyPI package.
 
@@ -397,6 +423,8 @@ The plugin is in maintenance mode.  A modern Kubernetes provider with native ORB
 
 - **Upgrading from `open-resource-broker`?** See the [migration guide](docs/root/operational/from-open-resource-broker.md).
 - **Deploying the Symphony HF plugin?** See the [k8s-legacy deployment guide](k8s-legacy/README.md).
+
+</details>
 
 ## Project
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
+# Coverage is uploaded to Codecov exactly ONCE, from the ci-tests
+# coverage-combine job, which merges every leg's .coverage data first.  A single
+# upload gives Codecov one deterministic number (no mid-run partial-merge
+# flapping) and needs no hardcoded leg count — it auto-scales to any number of
+# provider legs.
 coverage:
   status:
     project:
@@ -22,7 +27,14 @@ flags:
       - src/orb/
     carryforward: true
 
+# Kept in sync with [tool.coverage.run] omit in pyproject.toml so Codecov's
+# view matches the combined report we upload.
 ignore:
   - "tests/"
   - "docs/"
   - "scripts/"
+  - "src/orb/k8s_legacy/**"  # own separate test suite; runs outside the main legs
+  - "**/tests/**"            # test files under src/ are not production source
+  - "src/orb/__main__.py"    # thin process entrypoints — not unit-tested
+  - "src/orb/run.py"
+  - "src/orb/interface/server_daemon.py"

--- a/config/default_config.json
+++ b/config/default_config.json
@@ -41,16 +41,6 @@
       "audit_logs": "audit_logs",
       "metrics_logs": "metrics_logs"
     },
-    "fleet_types": {
-      "instant": "instant",
-      "request": "request",
-      "maintain": "maintain"
-    },
-    "price_types": {
-      "ondemand": "ondemand",
-      "spot": "spot",
-      "heterogeneous": "heterogeneous"
-    },
     "statuses": {
       "request": {
         "pending": "pending",
@@ -80,22 +70,14 @@
       }
     },
     "patterns": {
-      "ec2_instance": "^i-[a-f0-9]+$",
-      "spot_fleet": "^sfr-[a-f0-9]+$",
-      "ec2_fleet": "^fleet-[a-f0-9]+$",
-      "asg": "^[a-zA-Z0-9_-]+$",
-      "instance_type": "^[a-z][0-9][a-z]?\\.[a-z0-9]+$",
-      "region": "^[a-z]{2}-[a-z]+-\\d$",
-      "request_id": "^(req|ret)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+      "request_id": "^(req|ret)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "tag_key": "^[\\w\\s+=.@-]+$",
+      "cidr_block": "^(\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2}$"
     },
     "prefixes": {
       "default": "",
       "request": "req-",
       "return_prefix": "ret-",
-      "launch_template": "",
-      "instance": "",
-      "fleet": "",
-      "asg": "",
       "tag": ""
     }
   },
@@ -214,7 +196,7 @@
   },
   "server": {
     "enabled": false,
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "port": 8000,
     "workers": 1,
     "reload": false,
@@ -222,6 +204,7 @@
     "docs_url": "/docs",
     "redoc_url": "/redoc",
     "openapi_url": "/openapi.json",
+    "trusted_hosts": ["localhost", "127.0.0.1", "::1", "testserver"],
     "auth": {
       "enabled": false,
       "strategy": "none",
@@ -234,7 +217,7 @@
     "cors": {
       "enabled": true,
       "origins": [
-        "*"
+        "http://localhost:8000"
       ],
       "methods": [
         "GET",
@@ -270,11 +253,6 @@
       "default": "",
       "request": "req-",
       "return_prefix": "ret-",
-      "launch_template": "",
-      "instance": "",
-      "fleet": "",
-      "spot_fleet": "",
-      "asg": "",
       "tag": ""
     }
   }

--- a/dev-tools/package/generate_pyproject.py
+++ b/dev-tools/package/generate_pyproject.py
@@ -230,19 +230,20 @@ def update_pyproject_selective(pyproject_path: Path) -> None:
             continue
 
         elif line.startswith("[tool.coverage.run]"):
-            # Replace coverage source with package_root from .project.yml
-            new_lines.extend(
-                [
-                    "[tool.coverage.run]",
-                    f'source = ["{package_root}"]',
-                    "branch = true",
-                    "",
-                ]
-            )
-            # Skip existing coverage.run section
+            # Re-template only source (from package_root) + branch; preserve every
+            # other hand-authored key in this section (e.g. omit) instead of
+            # dropping it — the generator manages source, not the whole policy.
             i += 1
+            preserved = []
             while i < len(lines) and not lines[i].strip().startswith("["):
+                existing = lines[i].strip()
+                if not existing.startswith("source ") and not existing.startswith("branch "):
+                    preserved.append(lines[i])
                 i += 1
+            new_lines.append("[tool.coverage.run]")
+            new_lines.append(f'source = ["{package_root}"]')
+            new_lines.append("branch = true")
+            new_lines.extend(preserved)
             continue
 
         else:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
       - Performance Optimization: developer_guide/performance-optimization.md
       - Development Setup: developer_guide/development.md
       - BaseSetting Providers: developer_guide/basesettings-providers.md
+      - Deprecating Fields & APIs: developer_guide/deprecation.md
       - Changelog Management: developer_guide/changelog_management.md
       - Releases: developer_guide/releases.md
       - Testing: developer_guide/testing.md

--- a/docs/root/cli/template-commands.md
+++ b/docs/root/cli/template-commands.md
@@ -75,7 +75,7 @@ Templates can be defined in JSON or YAML format:
   "name": "My AWS Template",
   "provider_api": "aws",
   "image_id": "ami-12345678",
-  "instance_type": "t3.medium",
+  "machine_type": "t3.medium",
   "key_name": "my-keypair",
   "security_group_ids": ["sg-12345678"],
   "subnet_ids": ["subnet-12345678"],
@@ -94,7 +94,7 @@ template_id: my-aws-template
 name: My AWS Template
 provider_api: aws
 image_id: ami-12345678
-instance_type: t3.medium
+machine_type: t3.medium
 key_name: my-keypair
 security_group_ids:
   - sg-12345678
@@ -179,7 +179,7 @@ $ orb templates list
       "name": "Basic AWS Template",
       "provider_api": "aws",
       "image_id": "ami-12345678",
-      "instance_type": "t3.medium"
+      "machine_type": "t3.medium"
     }
   ],
   "total_count": 1,
@@ -195,7 +195,7 @@ $ orb templates show aws-basic
     "name": "Basic AWS Template",
     "provider_api": "aws",
     "image_id": "ami-12345678",
-    "instance_type": "t3.medium",
+    "machine_type": "t3.medium",
     "key_name": "my-keypair",
     "security_group_ids": ["sg-12345678"],
     "subnet_ids": ["subnet-12345678"],
@@ -248,7 +248,7 @@ $ orb templates validate --file invalid-template.json
   "valid": false,
   "validation_errors": [
     "Missing required field: template_id",
-    "Invalid instance_type: must be valid EC2 instance type"
+    "Invalid machine_type: must be a valid instance type"
   ],
   "validation_warnings": [
     "No tags specified: recommended for resource management"
@@ -295,7 +295,7 @@ $ orb templates refresh
 ```bash
 $ orb templates list --format table
 +---------------+--------------------+------------+---------------+-------------+
-│ Template ID     │ Name                 │ Provider API │ Image ID        │ Instance Type │
+│ Template ID     │ Name                 │ Provider API │ Image ID        │ Machine Type  │
 +---------------+--------------------+------------+---------------+-------------+
 │ aws-basic       │ Basic AWS Template   │ aws          │ ami-12345678    │ t3.medium     │
 │ aws-spot        │ Spot Instance Temp   │ aws          │ ami-87654321    │ t3.large      │

--- a/docs/root/developer_guide/deprecation.md
+++ b/docs/root/developer_guide/deprecation.md
@@ -1,0 +1,150 @@
+# Deprecating Fields, Parameters, and APIs
+
+How to deprecate a field, config key, parameter, method, or endpoint so the
+deprecation signal actually reaches the people who need to see it.
+
+## The core principle: match the signal to the audience
+
+A deprecation is only useful if the person still using the old thing finds
+out. The right mechanism depends entirely on **who** consumes the surface:
+
+| Audience | Surface | Correct signal |
+|----------|---------|----------------|
+| **Operators** | Config YAML/JSON, REST request bodies (anything deserialized via Pydantic `model_validate`) | `logger.warning` (+ `Field(deprecated=)` for schema) |
+| **Operators** | Config keys detected in a loaded dict at startup | `logger.warning` |
+| **Developers** | Python/SDK API — constructors, `@property`, classmethods, functions called from Python | `warnings.warn(..., DeprecationWarning, stacklevel=2)` |
+
+### Why `warnings.warn` is wrong for operator-facing surfaces
+
+`DeprecationWarning` is designed for **library consumers** — it surfaces via
+test runners, linters, and `python -W all`. It does **not** reach operators:
+
+- Operators run the packaged server; they never pass `-W`.
+- `pyproject.toml` sets `filterwarnings = ["ignore::DeprecationWarning"]`, so
+  the warning is suppressed even in our own test suite.
+- A `DeprecationWarning` on a config-file load path is effectively silent in
+  production and in CI.
+
+Operators read **logs**. So an operator-facing deprecation must emit a
+`logger.warning`.
+
+## Pattern 1 — Operator-facing Pydantic field deprecation (the common case)
+
+When you rename a field on a Pydantic model that operators populate via config
+or REST (e.g. `instance_type` → `machine_type`):
+
+```python
+import logging
+
+from pydantic import AliasChoices, BaseModel, Field, model_validator
+
+logger = logging.getLogger(__name__)
+
+
+class Template(BaseModel):
+    # 1. AliasChoices keeps old data deserialising.
+    # 2. Field(deprecated=...) surfaces `deprecated: true` in the OpenAPI /
+    #    JSON schema so schema tooling and API docs flag it.
+    machine_type: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("machine_type", "instance_type"),
+    )
+
+    # 3. A model_validator(mode="before") runs on the RAW input dict on EVERY
+    #    entry path — __init__ kwargs AND model_validate()/YAML — so the
+    #    logger.warning fires no matter how the object was built. This is the
+    #    load-bearing part: it closes the gap AliasChoices alone leaves open.
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_deprecated_aliases(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            if "instance_type" in data and "machine_type" not in data:
+                logger.warning(
+                    "Template field 'instance_type' is deprecated; "
+                    "use 'machine_type' instead."
+                )
+        return data
+```
+
+`AliasChoices` alone is **not** enough — it accepts the old key *silently*.
+The `model_validator(mode="before")` is what makes the deprecation visible.
+
+## Pattern 2 — Operator-facing config-key deprecation
+
+When a top-level config key is renamed or relocated and you detect it in a
+loaded dict at startup:
+
+```python
+if "dynamodb_strategy" in storage_config:
+    logger.warning(
+        "Config key 'storage.dynamodb_strategy' is deprecated and will be "
+        "removed in ORB 3.0; move it under "
+        "provider.providers[N].config.storage.dynamodb."
+    )
+    # ... migrate the value ...
+```
+
+Emit the `logger.warning` at the point of detection. A `warnings.warn` here is
+invisible to operators.
+
+## Pattern 3 — Developer-facing Python/SDK deprecation
+
+For a Python API surface consumed by developers (SDK constructors, properties,
+classmethods), `warnings.warn` is the **correct** tool — it is what developers'
+test suites and `python -W all` surface:
+
+```python
+import warnings
+
+
+class SDKConfig:
+    @property
+    def region(self) -> Optional[str]:
+        warnings.warn(
+            "SDKConfig.region is deprecated and will be removed in the next "
+            "major release; read provider_config['region'] instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.provider_config.get("region")
+```
+
+Always pass `stacklevel=2` so the warning points at the *caller's* line, not
+the property body.
+
+## Pattern 4 — Deprecated functions/methods with active callers
+
+If a function is deprecated but still has callers, emit `warnings.warn` inside
+the body on every call:
+
+```python
+def register_all_provider_types() -> None:
+    warnings.warn(
+        "register_all_provider_types() is deprecated; "
+        "call register_all_providers() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return register_all_providers()
+```
+
+Only `raise NotImplementedError` when **zero** callers remain — a hard break is
+inappropriate while callers still exist.
+
+## Always include a removal horizon
+
+State when the deprecated surface will be removed (e.g. "removed in ORB 3.0" /
+"the next major release"). An open-ended deprecation gives no migration
+deadline and tends to live forever.
+
+## Checklist
+
+- [ ] Identified the audience: operator (config/REST) or developer (Python/SDK)?
+- [ ] Operator-facing → `logger.warning` on the deserialization / detection path
+- [ ] Operator-facing Pydantic field → `model_validator(mode="before")` +
+      `AliasChoices` + `Field(deprecated=)`
+- [ ] Developer-facing → `warnings.warn(DeprecationWarning, stacklevel=2)`
+- [ ] Named the replacement in the message
+- [ ] Stated the removal version
+- [ ] Added a test asserting the signal fires (use `caplog` for `logger.warning`,
+      `pytest.warns` for `DeprecationWarning`)

--- a/docs/root/user_guide/api_reference.md
+++ b/docs/root/user_guide/api_reference.md
@@ -41,7 +41,7 @@ Returns all available templates.
     {
       "template_id": "aws-basic",
       "provider_api": "RunInstances",
-      "instance_type": "t3.medium",
+      "machine_type": "t3.medium",
       "image_id": "ami-0abcdef1234567890",
       "subnet_ids": ["subnet-aaa111"],
       "security_group_ids": ["sg-11111111"],
@@ -81,7 +81,7 @@ Returns a single template by ID.
   "template": {
     "template_id": "aws-basic",
     "provider_api": "RunInstances",
-    "instance_type": "t3.medium",
+    "machine_type": "t3.medium",
     "image_id": "ami-0abcdef1234567890",
     "subnet_ids": ["subnet-aaa111"],
     "security_group_ids": ["sg-11111111"],
@@ -112,7 +112,7 @@ Creates a new template.
 {
   "template_id": "aws-spot",
   "provider_api": "SpotFleet",
-  "instance_type": "c5.xlarge",
+  "machine_type": "c5.xlarge",
   "image_id": "ami-0abcdef1234567890",
   "subnet_ids": ["subnet-aaa111"],
   "security_group_ids": ["sg-11111111"],
@@ -129,7 +129,7 @@ Creates a new template.
 | `template_id` | string | Yes | Unique template identifier |
 | `provider_api` | string | No | Provider API type (default: `aws`) |
 | `image_id` | string | No | AMI ID |
-| `instance_type` | string | No | EC2 instance type |
+| `machine_type` | string | No | Machine / instance type (e.g. `t3.medium`). The alias `instance_type` is also accepted for backward compatibility but is deprecated. |
 | `key_name` | string | No | EC2 key pair name |
 | `security_group_ids` | list[string] | No | Security group IDs |
 | `subnet_ids` | list[string] | No | Subnet IDs |
@@ -152,7 +152,7 @@ Creates a new template.
 ```bash
 curl -X POST http://localhost:8000/api/v1/templates/ \
   -H "Content-Type: application/json" \
-  -d '{"template_id": "aws-spot", "provider_api": "SpotFleet", "instance_type": "c5.xlarge"}'
+  -d '{"template_id": "aws-spot", "provider_api": "SpotFleet", "machine_type": "c5.xlarge"}'
 ```
 
 ---
@@ -171,7 +171,7 @@ Updates an existing template.
 **Request Body** (JSON, all fields optional, accepts `camelCase` or `snake_case`):
 ```json
 {
-  "instance_type": "m5.large",
+  "machine_type": "m5.large",
   "tags": {
     "Environment": "staging"
   }
@@ -194,7 +194,7 @@ Updates an existing template.
 ```bash
 curl -X PUT http://localhost:8000/api/v1/templates/aws-basic \
   -H "Content-Type: application/json" \
-  -d '{"instance_type": "m5.large"}'
+  -d '{"machine_type": "m5.large"}'
 ```
 
 ---

--- a/docs/root/user_guide/configuration.md
+++ b/docs/root/user_guide/configuration.md
@@ -201,7 +201,7 @@ orb server start --foreground --config /etc/orb/production.json
       "subnet_ids": ["subnet-12345678", "subnet-87654321"],
       "security_group_ids": ["sg-abcdef12"],
       "key_name": "production-key-pair",
-      "instance_type": "t3.medium"
+      "machine_type": "t3.medium"
     }
   },
   "scheduler": {

--- a/docs/root/workflows/end-to-end.md
+++ b/docs/root/workflows/end-to-end.md
@@ -198,7 +198,7 @@ async with orb() as sdk:
         provider_api="EC2Fleet",
         image_id="ami-0abcdef1234567890",
         name="My Template",
-        instance_type="t3.medium",
+        machine_type="t3.medium",
         subnet_ids=["subnet-abc"],
         security_group_ids=["sg-123"],
         tags={"env": "dev"},
@@ -214,7 +214,7 @@ async with orb() as sdk:
     result = await sdk.update_template(
         template_id="my-tmpl",
         name="Updated Name",
-        instance_type="t3.large",
+        machine_type="t3.large",
     )
     # -> {"updated": True}
     # -> {"updated": False, "validation_errors": ["..."]}  on failure
@@ -247,7 +247,7 @@ curl -s -X POST http://localhost:8000/api/v1/templates/ \
     "provider_api": "EC2Fleet",
     "image_id": "ami-0abcdef1234567890",
     "name": "My Template",
-    "instance_type": "t3.medium",
+    "machine_type": "t3.medium",
     "subnet_ids": ["subnet-abc"],
     "security_group_ids": ["sg-123"],
     "tags": {"env": "dev"}
@@ -256,7 +256,7 @@ curl -s -X POST http://localhost:8000/api/v1/templates/ \
 # Update a template (only supplied fields are changed)
 curl -s -X PUT http://localhost:8000/api/v1/templates/my-tmpl \
   -H "Content-Type: application/json" \
-  -d '{"name": "Updated Name", "instance_type": "t3.large"}'
+  -d '{"name": "Updated Name", "machine_type": "t3.large"}'
 
 # Delete a template
 curl -s -X DELETE http://localhost:8000/api/v1/templates/my-tmpl

--- a/makefiles/ci.mk
+++ b/makefiles/ci.mk
@@ -168,6 +168,9 @@ ci-tests-infrastructure:  ## Run infrastructure tests only (matches ci.yml infra
 ci-tests-coverage-check:  ## Combined-coverage gate: merge per-leg data + enforce threshold
 	@echo "Combining per-leg coverage data and checking combined threshold ($(COVERAGE_THRESHOLD)%)..."
 	$(call run-tool,coverage,combine)
+	# Emit the merged XML BEFORE the threshold check so it is always produced
+	# for the single Codecov upload, even when the gate below fails.
+	$(call run-tool,coverage,xml -o coverage-combined.xml)
 	# `coverage report` uses --fail-under (the pytest-cov spelling
 	# --cov-fail-under is not valid for the coverage CLI).
 	$(call run-tool,coverage,report --fail-under=$(COVERAGE_THRESHOLD))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -545,6 +545,20 @@ env = []
 [tool.coverage.run]
 source = ["src/orb"]
 branch = true
+omit = [
+    # k8s_legacy is the legacy HostFactory plugin: it has its own test suite
+    # under src/orb/k8s_legacy/tests (in pytest testpaths) that runs separately
+    # from the main legs, so it always shows 0% here and unfairly drags the
+    # combined number.  Exclude it from the main coverage report.
+    "src/orb/k8s_legacy/*",
+    # Test files that live under src/ are not production source.
+    "*/tests/*",
+    # Thin process entrypoints / daemon lifecycle: not meaningfully unit-tested
+    # (exercised via subprocess/integration, not the coverage-uploading legs).
+    "src/orb/__main__.py",
+    "src/orb/run.py",
+    "src/orb/interface/server_daemon.py",
+]
 
 [tool.coverage.report]
 precision = 2

--- a/src/orb/api/models/responses.py
+++ b/src/orb/api/models/responses.py
@@ -159,7 +159,7 @@ class TemplateItem(BaseModel):
     # --- Access and security ---
     key_name: Optional[str] = None
     user_data: Optional[str] = None
-    instance_profile: Optional[str] = None
+    machine_role: Optional[str] = None
     launch_template_id: Optional[str] = None
 
     # --- Advanced configuration ---
@@ -168,7 +168,6 @@ class TemplateItem(BaseModel):
     # --- Tags and metadata ---
     tags: Optional[dict[str, Any]] = None
     metadata: Optional[dict[str, Any]] = None
-    provider_data: Optional[dict[str, Any]] = None
 
     # --- Provider configuration ---
     provider_type: Optional[str] = None

--- a/src/orb/api/routers/templates.py
+++ b/src/orb/api/routers/templates.py
@@ -1,6 +1,9 @@
 """Template management API routes."""
 
+import logging
 from typing import Any, Optional
+
+_logger = logging.getLogger(__name__)
 
 try:
     from fastapi import APIRouter, Body, Depends, Query
@@ -60,6 +63,10 @@ class TemplateCreateRequest(APIRequest):
     """Request model for creating templates.
 
     Accepts both camelCase and snake_case field names.
+
+    ``machine_type`` is the canonical field name; ``instance_type`` is
+    accepted as a deprecated alias for backward compatibility with older
+    clients.  When both are supplied, ``machine_type`` takes precedence.
     """
 
     template_id: str
@@ -67,7 +74,8 @@ class TemplateCreateRequest(APIRequest):
     description: Optional[str] = None
     provider_api: Optional[str] = None
     image_id: Optional[str] = None
-    instance_type: Optional[str] = None
+    machine_type: Optional[str] = None
+    instance_type: Optional[str] = None  # deprecated: use machine_type
     key_name: Optional[str] = None
     security_group_ids: Optional[list[str]] = None
     subnet_ids: Optional[list[str]] = None
@@ -75,24 +83,37 @@ class TemplateCreateRequest(APIRequest):
     tags: Optional[dict[str, str]] = None
     version: Optional[str] = "1.0"
 
+    def resolved_machine_type(self) -> Optional[str]:
+        """Return the effective machine type, preferring machine_type over instance_type."""
+        return self.machine_type or self.instance_type
+
 
 class TemplateUpdateRequest(APIRequest):
     """Request model for updating templates.
 
     Accepts both camelCase and snake_case field names.
+
+    ``machine_type`` is the canonical field name; ``instance_type`` is
+    accepted as a deprecated alias for backward compatibility with older
+    clients.  When both are supplied, ``machine_type`` takes precedence.
     """
 
     name: Optional[str] = None
     description: Optional[str] = None
     provider_api: Optional[str] = None
     image_id: Optional[str] = None
-    instance_type: Optional[str] = None
+    machine_type: Optional[str] = None
+    instance_type: Optional[str] = None  # deprecated: use machine_type
     key_name: Optional[str] = None
     security_group_ids: Optional[list[str]] = None
     subnet_ids: Optional[list[str]] = None
     user_data: Optional[str] = None
     tags: Optional[dict[str, str]] = None
     version: Optional[str] = None
+
+    def resolved_machine_type(self) -> Optional[str]:
+        """Return the effective machine type, preferring machine_type over instance_type."""
+        return self.machine_type or self.instance_type
 
 
 @router.get(
@@ -302,13 +323,20 @@ async def create_template(
     - **template_data**: Template configuration data
     """
     template_dict = template_data.model_dump(exclude_unset=True)
+    # Prefer machine_type; fall back to the deprecated instance_type alias.
+    effective_machine_type = template_data.resolved_machine_type()
+    if template_dict.get("instance_type") and not template_dict.get("machine_type"):
+        _logger.warning(
+            "Template create request used deprecated 'instance_type' field; "
+            "use 'machine_type' instead."
+        )
     result = await orchestrator.execute(
         CreateTemplateInput(
             template_id=template_dict["template_id"],
             name=template_dict.get("name"),
             description=template_dict.get("description"),
             provider_api=template_dict.get("provider_api"),
-            instance_type=template_dict.get("instance_type"),
+            machine_type=effective_machine_type,
             image_id=template_dict.get("image_id") or "",
             tags=template_dict.get("tags") or {},
             configuration=template_dict,
@@ -348,12 +376,19 @@ async def update_template(
     - **template_data**: Updated template configuration data
     """
     template_dict = template_data.model_dump(exclude_unset=True)
+    # Prefer machine_type; fall back to the deprecated instance_type alias.
+    effective_machine_type = template_data.resolved_machine_type()
+    if template_dict.get("instance_type") and not template_dict.get("machine_type"):
+        _logger.warning(
+            "Template update request used deprecated 'instance_type' field; "
+            "use 'machine_type' instead."
+        )
     result = await orchestrator.execute(
         UpdateTemplateInput(
             template_id=template_id,
             name=template_dict.get("name"),
             description=template_dict.get("description"),
-            instance_type=template_dict.get("instance_type"),
+            machine_type=effective_machine_type,
             image_id=template_dict.get("image_id"),
             configuration=template_dict,
         )

--- a/src/orb/api/server.py
+++ b/src/orb/api/server.py
@@ -375,10 +375,31 @@ def create_fastapi_app(server_config: Any) -> Any:
         if auth_strategy:
             # Wrap the real strategy so loopback tokens are checked first.
             auth_port: Any = _LoopbackAdminAuthWrapper(auth_strategy)
+
+            # Build the excluded-paths list for auth middleware.
+            # /health is always public (liveness probe, no sensitive detail).
+            # /favicon.ico is static UI chrome, not sensitive.
+            # /docs, /redoc, /openapi.json are excluded ONLY when
+            # docs.require_auth=False — by default they are protected so that
+            # the full route map is not disclosed to unauthenticated callers.
+            _docs_require_auth: bool = getattr(
+                getattr(server_config, "docs", None), "require_auth", True
+            )
+            _excluded: list[str] = ["/health", "/favicon.ico"]
+            if not _docs_require_auth:
+                _excluded.extend(["/docs", "/redoc", "/openapi.json"])
+            else:
+                logger.info(
+                    "API documentation endpoints (/docs, /redoc, /openapi.json) "
+                    "are protected by authentication (docs.require_auth=true). "
+                    "Set docs.require_auth=false to make them public."
+                )
+
             app.add_middleware(
                 AuthMiddleware,
                 auth_port=auth_port,
                 require_auth=True,
+                excluded_paths=_excluded,
                 trusted_proxies=server_config.trusted_proxies,
             )
             logger.info(
@@ -521,12 +542,16 @@ def create_fastapi_app(server_config: Any) -> Any:
     # Add info endpoint
     @app.get("/info", tags=["System"])
     async def info() -> dict[str, Any]:
-        """Service information endpoint."""
+        """Service information endpoint.
+
+        Returns basic service metadata only.  Authentication configuration is
+        intentionally omitted so that unauthenticated callers cannot discover
+        which auth method is in use and tailor attacks accordingly.
+        """
         return {
             "service": "open-resource-broker",
             "version": __version__,
             "description": "REST API for Open Resource Broker",
-            "auth_enabled": server_config.auth.enabled,
         }
 
     # Serve favicon from project logo assets

--- a/src/orb/application/commands/provider_handlers.py
+++ b/src/orb/application/commands/provider_handlers.py
@@ -15,8 +15,8 @@ from orb.domain.base.events.provider_events import (
     ProviderOperationExecutedEvent,
     ProviderStrategyRegisteredEvent,
 )
+from orb.domain.base.exceptions import ConfigurationError
 from orb.domain.base.ports import ContainerPort, ErrorHandlingPort, EventPublisherPort, LoggingPort
-from orb.domain.constants import PROVIDER_TYPE_AWS
 
 
 @command_handler(ExecuteProviderOperationCommand)  # type: ignore[arg-type]
@@ -50,7 +50,12 @@ class ExecuteProviderOperationHandler(BaseCommandHandler[ExecuteProviderOperatio
         self.logger.info("Executing provider operation: %s", operation.operation_type)
         start_time = time.time()
         try:
-            provider_identifier = command.strategy_override or PROVIDER_TYPE_AWS
+            if not command.strategy_override:
+                raise ConfigurationError(
+                    "ExecuteProviderOperationCommand requires an explicit strategy_override. "
+                    "Set strategy_override to the name or type of the target provider."
+                )
+            provider_identifier = command.strategy_override
             result = await self._provider_registry_service.execute_operation(
                 provider_identifier, operation
             )

--- a/src/orb/application/commands/template_handlers.py
+++ b/src/orb/application/commands/template_handlers.py
@@ -1,6 +1,10 @@
 """Template command handlers for CQRS pattern."""
 
+import logging
+
 from orb.application.base.handlers import BaseCommandHandler
+
+_logger = logging.getLogger(__name__)
 from orb.application.decorators import command_handler
 from orb.application.dto.template import TemplateDTO
 from orb.application.template.commands import (
@@ -98,6 +102,9 @@ class CreateTemplateHandler(BaseCommandHandler[CreateTemplateCommand, None]):  #
         }
         # instance_type → machine_types (backward compat)
         if command.instance_type is not None and "machine_types" not in dto_fields:
+            _logger.warning(
+                "CreateTemplateCommand.instance_type is deprecated; use machine_type instead."
+            )
             dto_fields["machine_types"] = {command.instance_type: 1}
         # Remove None values so TemplateDTO defaults apply
         dto_fields = {k: v for k, v in dto_fields.items() if v is not None}
@@ -171,6 +178,9 @@ class UpdateTemplateHandler(BaseCommandHandler[UpdateTemplateCommand, None]):  #
 
         # instance_type → machine_types (backward compat)
         if command.instance_type is not None and "machine_types" not in update_fields:
+            _logger.warning(
+                "UpdateTemplateCommand.instance_type is deprecated; use machine_type instead."
+            )
             update_fields["machine_types"] = {command.instance_type: 1}
 
         if update_fields:

--- a/src/orb/application/commands/template_handlers.py
+++ b/src/orb/application/commands/template_handlers.py
@@ -49,8 +49,9 @@ class CreateTemplateHandler(BaseCommandHandler[CreateTemplateCommand, None]):  #
             raise ValueError("template_id is required")
         if not command.provider_api:
             raise ValueError("provider_api is required")
-        if not command.image_id:
-            raise ValueError("image_id is required")
+        # image_id presence is provider-specific: AWS requires it, other providers
+        # (e.g. GCP uses image_family/image_project, Azure uses image_reference).
+        # Enforcement is delegated to the provider's own validator.
 
     async def execute_command(self, command: CreateTemplateCommand) -> None:
         """Create new template via TemplateConfigurationManager."""

--- a/src/orb/application/services/orchestration/create_template.py
+++ b/src/orb/application/services/orchestration/create_template.py
@@ -29,6 +29,7 @@ class CreateTemplateOrchestrator(OrchestratorBase[CreateTemplateInput, CreateTem
             image_id=input.image_id,
             name=input.name,
             description=input.description,
+            machine_type=input.machine_type,
             instance_type=input.instance_type,
             tags=input.tags,
             configuration=input.configuration,

--- a/src/orb/application/services/orchestration/dtos.py
+++ b/src/orb/application/services/orchestration/dtos.py
@@ -279,7 +279,8 @@ class CreateTemplateInput:
     provider_api: Optional[str] = None
     name: Optional[str] = None
     description: Optional[str] = None
-    instance_type: Optional[str] = None
+    machine_type: Optional[str] = None
+    instance_type: Optional[str] = None  # deprecated: use machine_type
     tags: dict[str, str] = dataclasses.field(default_factory=dict)
     configuration: dict[str, Any] = dataclasses.field(default_factory=dict)
 
@@ -296,7 +297,8 @@ class UpdateTemplateInput:
     template_id: str
     name: Optional[str] = None
     description: Optional[str] = None
-    instance_type: Optional[str] = None
+    machine_type: Optional[str] = None
+    instance_type: Optional[str] = None  # deprecated: use machine_type
     image_id: Optional[str] = None
     configuration: dict[str, Any] = dataclasses.field(default_factory=dict)
 

--- a/src/orb/application/services/orchestration/update_template.py
+++ b/src/orb/application/services/orchestration/update_template.py
@@ -27,6 +27,7 @@ class UpdateTemplateOrchestrator(OrchestratorBase[UpdateTemplateInput, UpdateTem
             template_id=input.template_id,
             name=input.name,
             description=input.description,
+            machine_type=input.machine_type,
             instance_type=input.instance_type,
             image_id=input.image_id,
             configuration=input.configuration,

--- a/src/orb/application/services/template_generation_service.py
+++ b/src/orb/application/services/template_generation_service.py
@@ -18,7 +18,6 @@ from orb.domain.base.ports.template_example_generator_resolver_port import (
     TemplateExampleGeneratorResolverPort,
 )
 from orb.domain.base.utils import extract_provider_type
-from orb.domain.constants import PROVIDER_TYPE_AWS
 
 
 class TemplateGenerationService:
@@ -264,9 +263,10 @@ class TemplateGenerationService:
             providers = provider_config.get_active_providers()  # type: ignore[union-attr]
             return [{"name": p.name, "type": p.type} for p in providers]
         except Exception as e:
-            self._logger.warning("Failed to get providers from config: %s", str(e))
-            # Fallback to single default provider
-            return [{"name": "aws_default_us-east-1", "type": PROVIDER_TYPE_AWS}]
+            self._logger.warning(
+                "Failed to get providers from config; returning empty list: %s", str(e)
+            )
+            return []
 
     def _get_config_dict(self) -> Dict[str, Any]:
         """Get template configuration for filename generation."""

--- a/src/orb/application/template/commands.py
+++ b/src/orb/application/template/commands.py
@@ -17,8 +17,9 @@ class CreateTemplateCommand(BaseCommand):
     name: Optional[str] = None
     description: Optional[str] = None
     provider_api: Optional[str] = None
-    instance_type: Optional[str] = None
-    image_id: str
+    machine_type: Optional[str] = None
+    instance_type: Optional[str] = None  # deprecated: use machine_type
+    image_id: Optional[str] = None
     tags: dict[str, str] = Field(default_factory=dict)
     configuration: dict[str, Any] = Field(default_factory=dict)
 
@@ -36,7 +37,8 @@ class UpdateTemplateCommand(BaseCommand):
     template_id: str
     name: Optional[str] = None
     description: Optional[str] = None
-    instance_type: Optional[str] = None
+    machine_type: Optional[str] = None
+    instance_type: Optional[str] = None  # deprecated: use machine_type
     image_id: Optional[str] = None
     configuration: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/orb/bootstrap/domain_services.py
+++ b/src/orb/bootstrap/domain_services.py
@@ -8,9 +8,7 @@ from orb.domain.base.configuration_service import DomainConfigurationService
 from orb.domain.base.ports.configuration_port import ConfigurationPort
 from orb.domain.base.ports.container_port import ContainerPort
 from orb.domain.base.ports.logging_port import LoggingPort
-from orb.domain.base.ports.provider_registry_port import ProviderRegistryPort
 from orb.domain.base.ports.provider_selection_port import ProviderSelectionPort
-from orb.domain.constants import PROVIDER_TYPE_AWS
 from orb.domain.services.filter_service import FilterService
 from orb.domain.services.generic_filter_service import GenericFilterService
 from orb.domain.services.template_validation_domain_service import TemplateValidationDomainService
@@ -68,18 +66,15 @@ def register_domain_services(container: DIContainer) -> None:
 
     container.register_singleton(DeprovisioningOrchestrator, create_deprovisioning_orchestrator)
 
-    # Provider validation service (SRP refactoring)
+    # Provider validation service
+    # Per-request validation is delegated to ProviderSelectionPort.validate_template_requirements,
+    # which is already provider-agnostic.  A static validator is not wired at boot time so that
+    # any registered provider can supply its own validator when selected.
     def create_provider_validation_service(c):
-        validator = None
-        try:
-            validator = c.get(ProviderRegistryPort).create_validator(PROVIDER_TYPE_AWS)
-        except Exception as e:
-            c.get(LoggingPort).debug("Could not create AWS provider validator: %s", e)
         return ProviderValidationService(
             container=c.get(ContainerPort),
             logger=c.get(LoggingPort),
             provider_selection_port=c.get(ProviderSelectionPort),
-            validator=validator,
         )
 
     container.register_singleton(ProviderValidationService, create_provider_validation_service)

--- a/src/orb/cli/args.py
+++ b/src/orb/cli/args.py
@@ -12,6 +12,7 @@ import sys
 # Optional: Rich formatting for help text
 import sys as _sys
 
+from orb.cli.parsers.common_args import add_provider_type_arg
 from orb.domain.machine.machine_status import MachineStatus
 from orb.domain.request.value_objects import RequestStatus
 from orb.infrastructure.registry.cli_spec_registry import CLISpecRegistry
@@ -61,12 +62,7 @@ def add_global_arguments(parser):
         metavar="NAME",
         help="Restrict to a specific provider instance by exact name (e.g. aws-prod)",
     )
-    parser.add_argument(
-        "--provider-type",
-        dest="provider_type",
-        metavar="TYPE",
-        help="Restrict to all active instances of a provider type (e.g. aws, k8s)",
-    )
+    add_provider_type_arg(parser)
     parser.add_argument(
         "--scheduler", choices=["default", "hostfactory"], help="Override scheduler strategy"
     )
@@ -776,11 +772,10 @@ For more information, visit: {DOCS_URL}
     init_parser.add_argument(
         "--scheduler", choices=["default", "hostfactory"], help="Scheduler type"
     )
-    init_parser.add_argument(
-        "--provider-type",
-        dest="provider_type",
+    add_provider_type_arg(
+        init_parser,
         default="aws",
-        help="Provider type to initialise (e.g. aws, k8s)",
+        extra_help="Provider type to initialise.",
     )
     init_parser.add_argument("--config-dir", help="Custom configuration directory")
     init_parser.add_argument(

--- a/src/orb/cli/parsers/common_args.py
+++ b/src/orb/cli/parsers/common_args.py
@@ -1,0 +1,78 @@
+"""Shared argument-registration helpers for the ORB CLI.
+
+All cross-cutting arguments that appear on more than one subcommand must be
+registered through the helpers defined here.  Centralising them in one module
+prevents the argparse conflict error (``conflicting option string(s)``) that
+arises when the same flag is added twice to the same parser.
+
+Adding a new provider type
+--------------------------
+New provider types are picked up automatically because ``add_provider_type_arg``
+reads the :class:`~orb.infrastructure.registry.cli_spec_registry.CLISpecRegistry`
+at parse-construction time.  If the registry is empty (e.g. during a
+lightweight unit-test that never calls ``register_all_provider_cli_specs``),
+the function falls back to an open-ended ``metavar`` so the CLI still builds.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+
+def add_provider_type_arg(
+    parser: argparse.ArgumentParser,
+    *,
+    default: str | None = None,
+    required: bool = False,
+    extra_help: str = "",
+) -> None:
+    """Register ``--provider-type`` on *parser* exactly once.
+
+    The valid choices are derived from the
+    :class:`~orb.infrastructure.registry.cli_spec_registry.CLISpecRegistry`
+    so new providers are reflected automatically without any edit here.
+
+    When the registry is empty the argument is registered without ``choices``
+    (any value is accepted) so that early-bootstrap callers (e.g. unit tests
+    that never perform full provider initialisation) still work.
+
+    Args:
+        parser: The :class:`argparse.ArgumentParser` (or sub-parser) to
+            register the argument on.
+        default: Value to use when the flag is omitted.  ``None`` means the
+            attribute is absent from the resulting :class:`argparse.Namespace`
+            unless the user supplies a value.
+        required: When ``True`` argparse will error if the flag is omitted.
+        extra_help: Additional text appended to the stock help string.
+    """
+    choices: Sequence[str] | None = _registered_provider_types()
+
+    base_help = "Restrict to all active instances of a provider type (e.g. aws, k8s)"
+    help_text = f"{base_help}{'. ' + extra_help if extra_help else ''}"
+
+    kwargs: dict = {
+        "dest": "provider_type",
+        "metavar": "TYPE",
+        "help": help_text,
+        "default": default,
+        "required": required,
+    }
+    if choices:
+        kwargs["choices"] = list(choices)
+
+    parser.add_argument("--provider-type", **kwargs)
+
+
+def _registered_provider_types() -> list[str]:
+    """Return the sorted list of provider types known to the CLI spec registry.
+
+    Returns an empty list when the registry has not been populated yet (e.g.
+    in unit tests that skip the full bootstrap).
+    """
+    try:
+        from orb.infrastructure.registry.cli_spec_registry import CLISpecRegistry
+
+        return sorted(CLISpecRegistry.all().keys())
+    except Exception:  # pragma: no cover — defensive
+        return []

--- a/src/orb/config/default_config.json
+++ b/src/orb/config/default_config.json
@@ -33,16 +33,6 @@
       "audit_logs": "audit_logs",
       "metrics_logs": "metrics_logs"
     },
-    "fleet_types": {
-      "instant": "instant",
-      "request": "request",
-      "maintain": "maintain"
-    },
-    "price_types": {
-      "ondemand": "ondemand",
-      "spot": "spot",
-      "heterogeneous": "heterogeneous"
-    },
     "statuses": {
       "request": {
         "pending": "pending",
@@ -72,22 +62,14 @@
       }
     },
     "patterns": {
-      "ec2_instance": "^i-[a-f0-9]+$",
-      "spot_fleet": "^sfr-[a-f0-9]+$",
-      "ec2_fleet": "^fleet-[a-f0-9]+$",
-      "asg": "^[a-zA-Z0-9_-]+$",
-      "instance_type": "^[a-z][0-9][a-z]?\\.[a-z0-9]+$",
-      "region": "^[a-z]{2}-[a-z]+-\\d$",
-      "request_id": "^(req|ret)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+      "request_id": "^(req|ret)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+      "tag_key": "^[\\w\\s+=.@-]+$",
+      "cidr_block": "^(\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2}$"
     },
     "prefixes": {
       "default": "",
       "request": "req-",
       "return_prefix": "ret-",
-      "launch_template": "",
-      "instance": "",
-      "fleet": "",
-      "asg": "",
       "tag": ""
     }
   },
@@ -221,7 +203,7 @@
   },
   "server": {
     "enabled": false,
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "port": 8000,
     "workers": 1,
     "reload": false,
@@ -229,6 +211,7 @@
     "docs_url": "/docs",
     "redoc_url": "/redoc",
     "openapi_url": "/openapi.json",
+    "trusted_hosts": ["localhost", "127.0.0.1", "::1", "testserver"],
     "auth": {
       "enabled": false,
       "strategy": "none",
@@ -241,7 +224,7 @@
     "cors": {
       "enabled": true,
       "origins": [
-        "*"
+        "http://localhost:8000"
       ],
       "methods": [
         "GET",
@@ -272,16 +255,11 @@
     "recovery_timeout": 60,
     "half_open_max_calls": 3
   },
-"resource": {
+  "resource": {
     "prefixes": {
       "default": "",
       "request": "req-",
       "return_prefix": "ret-",
-      "launch_template": "",
-      "instance": "",
-      "fleet": "",
-      "spot_fleet": "",
-      "asg": "",
       "tag": ""
     }
   }

--- a/src/orb/config/schemas/common_schema.py
+++ b/src/orb/config/schemas/common_schema.py
@@ -6,7 +6,18 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class ResourcePrefixConfig(BaseModel):
-    """Resource prefix configuration."""
+    """Resource prefix configuration.
+
+    The generic keys (default, request, return_prefix, tag) are provider-agnostic.
+    The AWS-specific keys (launch_template, instance, fleet, spot_fleet, asg) are
+    kept here because ``ConfigurationAdapter.get_resource_prefix(key)`` dispatches
+    through ``hasattr(prefixes, key)`` and AWS handler code passes AWS resource-type
+    strings.  Their default values are empty strings and they are absent from the
+    packaged default_config.json.
+    TODO: move launch_template/instance/fleet/spot_fleet/asg to AWSNamingConfig
+    and replace ``get_resource_prefix`` with an AWS-specific accessor so this
+    shared schema is free of AWS vocabulary.
+    """
 
     default: str = Field("", description="Default prefix for all resources")
     request: str = Field("req-", description="Prefix for acquire request IDs")
@@ -34,7 +45,17 @@ class ResourceConfig(BaseModel):
 
 
 class PrefixConfig(BaseModel):
-    """Prefix configuration."""
+    """Naming prefix configuration used by the shared NamingConfig.
+
+    The generic keys (default, request, return_prefix, tag) are provider-agnostic.
+    The AWS-specific keys (launch_template, instance, fleet, asg) are kept for the
+    same reason as ResourcePrefixConfig: the hasattr-based dispatch in
+    ConfigurationAdapter.get_resource_prefix requires them as typed fields.
+    Their default values are empty strings and they are absent from the packaged
+    default_config.json.
+    TODO: remove launch_template/instance/fleet/asg once get_resource_prefix
+    gains an AWS-specific code path.
+    """
 
     default: str = Field("", description="Default prefix for all resources")
     request: str = Field("req-", description="Prefix for acquire request IDs")
@@ -110,36 +131,23 @@ class NamingConfig(BaseModel):
         },
         description="Table names for SQL databases",
     )
-    fleet_types: dict[str, str] = Field(
-        default_factory=lambda: {
-            "instant": "instant",
-            "request": "request",
-            "maintain": "maintain",
-        },
-        description="Fleet types for EC2 Fleet and Spot Fleet",
-    )
-    price_types: dict[str, str] = Field(
-        default_factory=lambda: {
-            "ondemand": "ondemand",
-            "spot": "spot",
-            "heterogeneous": "heterogeneous",
-        },
-        description="Price types for templates",
-    )
     statuses: StatusValuesConfig = Field(default_factory=lambda: StatusValuesConfig())
     patterns: dict[str, str] = Field(
         default_factory=lambda: {
-            "ec2_instance": r"^i-[a-f0-9]+$",
-            "spot_fleet": r"^sfr-[a-f0-9]+$",
-            "ec2_fleet": r"^fleet-[a-f0-9]+$",
-            "asg": r"^[a-zA-Z0-9_-]+$",
-            "instance_type": r"^[a-z][0-9][a-z]?\.[a-z0-9]+$",
-            "region": r"^[a-z]{2}-[a-z]+-\d$",
+            # No shared "region" pattern: region format varies by provider
+            # (AWS: us-east-1, GCP: us-central1, Azure: eastus).
+            # Providers that need region validation contribute their own pattern.
             "request_id": r"^(req|ret)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
             "tag_key": r"^[\w\s+=.@-]+$",
             "cidr_block": r"^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$",
+            # AWS-specific patterns (spot_fleet, ec2_fleet, asg, ec2_instance,
+            # instance_type) belong on AWSNamingConfig, not here.
         },
-        description="Validation patterns for various resources",
+        description=(
+            "Provider-agnostic validation patterns for shared resource identifiers. "
+            "AWS-specific patterns (spot_fleet, ec2_fleet, asg, ec2_instance, "
+            "instance_type) belong on the AWS provider's AWSNamingConfig, not here."
+        ),
     )
     prefixes: PrefixConfig = Field(default_factory=lambda: PrefixConfig())  # type: ignore[call-arg]
 

--- a/src/orb/config/schemas/server_schema.py
+++ b/src/orb/config/schemas/server_schema.py
@@ -90,6 +90,15 @@ class IAMAuthSubConfig(BaseModel):
     The IAMAuthStrategy enforces this by requiring the environment variable
     ``ORB_IAM_ASSUME_PERMISSIONS_DEV_ONLY=true`` to be set alongside the config flag;
     without it the flag is ignored and permissions are denied by default.
+
+    **Security note — admin_arns:**
+    ``admin_arns`` is an explicit allowlist of fully-qualified AWS ARNs that are
+    granted the ``admin`` role.  ARNs are compared using **exact equality** after
+    normalising both sides to lowercase.  Do NOT rely on the default
+    ``admin_role_patterns`` mechanism for production deployments — it grants admin to
+    any principal whose resource-name segment matches a short pattern string (e.g.
+    ``"Admin"``), which does not scope to a specific AWS account.  Use ``admin_arns``
+    to bind admin access to specific, account-scoped principals instead.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -102,6 +111,18 @@ class IAMAuthSubConfig(BaseModel):
         description=(
             "DEV/TEST ONLY — grant all required_actions without AWS evaluation. "
             "Has no effect unless ORB_IAM_ASSUME_PERMISSIONS_DEV_ONLY=true is also set."
+        ),
+    )
+    admin_arns: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Explicit allowlist of fully-qualified ARNs that receive the admin role. "
+            "Matched by exact equality (case-normalised) against the caller ARN returned "
+            "by sts:GetCallerIdentity.  When non-empty this list is the COMPLETE set of "
+            "admin principals — the unconditional :root grant does NOT apply.  Include "
+            "the root ARN explicitly (e.g. 'arn:aws:iam::123456789012:root') if root "
+            "must have admin access.  When empty, the legacy name-pattern + :root "
+            "fallback is used instead."
         ),
     )
 
@@ -205,7 +226,9 @@ class CORSConfig(BaseModel):
         ["http://localhost:8000"],
         description=(
             "Allowed CORS origins.  Default is single-origin embedded-mode. "
-            "Operators binding to 0.0.0.0 MUST set this to their actual client origins."
+            "Operators binding to 0.0.0.0 MUST set this to the actual client origins "
+            "they trust; leaving the default while network-exposing the server will "
+            "block all cross-origin browser requests from non-loopback clients."
         ),
     )
     methods: list[str] = Field(
@@ -258,6 +281,31 @@ class CORSConfig(BaseModel):
         return self
 
 
+class DocsConfig(BaseModel):
+    """Configuration for the interactive API documentation endpoints.
+
+    When ``require_auth`` is True (the default) and ``server.auth.enabled`` is
+    also True, the ``/docs``, ``/redoc``, and ``/openapi.json`` endpoints are
+    protected by the auth middleware just like any other API endpoint.
+
+    Set ``require_auth=False`` (or keep ``server.auth.enabled=False``) to leave
+    the docs endpoints public — useful for open-source deployments or clusters
+    that are not externally reachable.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    require_auth: bool = Field(
+        True,
+        description=(
+            "Gate /docs, /redoc, and /openapi.json behind authentication when "
+            "auth is enabled.  When False (or when auth is globally disabled) "
+            "these endpoints remain publicly accessible.  Default True so that "
+            "enabling auth does not accidentally expose the full route map."
+        ),
+    )
+
+
 class ServerConfig(BaseModel):
     """REST API server configuration."""
 
@@ -281,6 +329,10 @@ class ServerConfig(BaseModel):
     docs_url: str = Field("/docs", description="Swagger UI URL")
     redoc_url: str = Field("/redoc", description="ReDoc URL")
     openapi_url: str = Field("/openapi.json", description="OpenAPI schema URL")
+    docs: DocsConfig = Field(
+        default_factory=DocsConfig,  # type: ignore[call-arg]
+        description="Documentation endpoint security settings",
+    )
 
     # Authentication and CORS
     #
@@ -299,12 +351,13 @@ class ServerConfig(BaseModel):
     # Security
     require_https: bool = Field(False, description="Require HTTPS for all requests")
     trusted_hosts: list[str] = Field(
-        ["localhost", "127.0.0.1", "testserver", "test"],
+        ["localhost", "127.0.0.1", "::1", "testserver", "test"],
         description=(
-            "Trusted host headers.  Default allows loopback + the "
-            "``testserver`` / ``test`` hostnames used by Starlette's "
-            "TestClient and httpx AsyncClient(base_url=...) fixtures.  "
-            "Operators binding to 0.0.0.0 MUST add their actual public hostname(s) here."
+            "Trusted Host header values.  Default allows loopback (IPv4 and IPv6) "
+            "plus the ``testserver`` / ``test`` hostnames used by Starlette's "
+            "TestClient and httpx AsyncClient(base_url=...) fixtures.  Operators "
+            "binding to 0.0.0.0 MUST add their public hostname(s) here; any "
+            "request whose Host header is not in this list will be rejected with 400."
         ),
     )
     trusted_proxies: list[str] = Field(

--- a/src/orb/domain/machine/aggregate.py
+++ b/src/orb/domain/machine/aggregate.py
@@ -40,7 +40,7 @@ class Machine(AggregateRoot):
     template_id: str
     request_id: Optional[str] = None
     return_request_id: Optional[str] = None
-    provider_type: str = Field(default="aws")
+    provider_type: str
     provider_name: str
     # provider_api is required at the domain level — every machine MUST
     # know which provider API produced it (EC2Fleet / ASG / SpotFleet /
@@ -73,10 +73,9 @@ class Machine(AggregateRoot):
 
     # Lifecycle timestamps
     launch_time: Optional[datetime] = None
-    """AWS-reported timestamp when the instance actually started running.
+    """Provider-reported timestamp when the instance actually started running.
     Set when the machine transitions to RUNNING status (sourced from the
-    cloud provider, e.g. EC2 LaunchTime). Used for uptime calculations,
-    DTOs, and external consumers."""
+    cloud provider). Used for uptime calculations, DTOs, and external consumers."""
     provisioning_started_at: Optional[datetime] = None
     """ORB-internal timestamp recording when this broker initiated the
     launch sequence (i.e. when start_launching() was called and the

--- a/src/orb/domain/services/template_validation_domain_service.py
+++ b/src/orb/domain/services/template_validation_domain_service.py
@@ -192,12 +192,6 @@ class TemplateValidationDomainService:
             return
 
         fleet_type = getattr(template, "fleet_type", None)
-        if not fleet_type:
-            fleet_type = (
-                template.provider_data.get("aws", {}).get("fleet_type")
-                if template.provider_data
-                else None
-            )
 
         if not fleet_type:
             return

--- a/src/orb/domain/template/template_aggregate.py
+++ b/src/orb/domain/template/template_aggregate.py
@@ -1,10 +1,13 @@
 """Template configuration value object - core template domain logic."""
 
+import logging
 import warnings
 from datetime import datetime
 from typing import Any, Optional
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
+
+logger = logging.getLogger(__name__)
 
 
 class Template(BaseModel):
@@ -25,6 +28,7 @@ class Template(BaseModel):
     machine_type: Optional[str] = Field(
         default=None,
         validation_alias=AliasChoices("machine_type", "instance_type"),
+        deprecated="use 'machine_type' instead of 'instance_type'",
     )
     image_id: Optional[str] = None
     max_instances: int = 1
@@ -61,6 +65,7 @@ class Template(BaseModel):
     machine_role: Optional[str] = Field(
         default=None,
         validation_alias=AliasChoices("machine_role", "instance_profile"),
+        deprecated="use 'machine_role' instead of 'instance_profile'",
     )  # IAM role, service principal, or service account
 
     # Advanced configuration (extensible)
@@ -82,6 +87,42 @@ class Template(BaseModel):
     # Active status flag
     is_active: bool = True
 
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_deprecated_field_names(cls, data: Any) -> Any:
+        """House pattern for operator-facing Pydantic field deprecation.
+
+        This is the canonical way to emit operator-visible deprecation warnings
+        for renamed fields in this codebase.  It runs on the raw input dict
+        before Pydantic applies AliasChoices, so it fires on EVERY entry point:
+        ``model_validate()``, YAML/JSON deserialization, and ``__init__`` kwargs.
+
+        Pattern:
+          1. Keep ``AliasChoices("new_name", "old_name")`` on the new field so
+             old data still deserializes without a hard error.
+          2. Add this ``model_validator(mode="before")`` to emit
+             ``logger.warning(...)`` for each deprecated key present in the raw
+             input.  The logger message appears in server logs where operators
+             can see it, unlike ``warnings.warn`` which is filtered in tests and
+             production by default.
+          3. Mark the new field with ``Field(..., deprecated="...")`` for
+             OpenAPI/JSON-schema visibility (requires Pydantic >= 2.7).
+          4. Keep ``warnings.warn(DeprecationWarning)`` in ``__init__`` as a
+             developer/test signal (visible via ``python -W`` or
+             ``pytest.warns``).
+        """
+        if not isinstance(data, dict):
+            return data
+        if "instance_type" in data and "machine_type" not in data:
+            logger.warning(
+                "Template field 'instance_type' is deprecated; use 'machine_type' instead."
+            )
+        if "instance_profile" in data and "machine_role" not in data:
+            logger.warning(
+                "Template field 'instance_profile' is deprecated; use 'machine_role' instead."
+            )
+        return data
+
     def __init__(self, **data: Any) -> None:
         """Initialize template with default values and validation.
 
@@ -91,30 +132,35 @@ class Template(BaseModel):
         Note:
             Sets default name from template_id if not provided.
             Sets default timestamps if not provided.
-            The deprecated ``instance_type`` keyword argument is accepted and
-            silently promoted to ``machine_type``; a DeprecationWarning is
-            emitted to encourage callers to update.
+            The deprecated ``instance_type`` kwarg is accepted and mapped to
+            ``machine_type`` by Pydantic's AliasChoices; a DeprecationWarning
+            is emitted here as a developer-visible signal (pytest.warns / -W),
+            while the operator-visible logger.warning is emitted by the
+            ``_warn_deprecated_field_names`` model_validator above.
+
+            IMPORTANT: do NOT pop the deprecated key here — popping before
+            calling ``super().__init__`` would hide the key from the
+            model_validator(mode="before"), preventing the logger.warning.
+            AliasChoices handles the field mapping after model_validator fires.
         """
-        # Promote deprecated instance_type kwarg → machine_type.
-        # validation_alias handles model_validate() paths; __init__ kwargs need
-        # explicit handling here because Pydantic v2 validation_alias is not
-        # applied to __init__ keyword arguments.
+        # Emit developer-facing DeprecationWarning for deprecated kwarg names.
+        # Do NOT pop the keys — leave them in data so that model_validator
+        # (mode="before") can see them and emit the operator-visible logger.warning.
+        # AliasChoices will map instance_type → machine_type and
+        # instance_profile → machine_role during Pydantic's validation pass.
         if "instance_type" in data and "machine_type" not in data:
             warnings.warn(
                 "Template field 'instance_type' is deprecated; use 'machine_type' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            data["machine_type"] = data.pop("instance_type")
 
-        # Promote deprecated instance_profile kwarg → machine_role.
         if "instance_profile" in data and "machine_role" not in data:
             warnings.warn(
                 "Template field 'instance_profile' is deprecated; use 'machine_role' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            data["machine_role"] = data.pop("instance_profile")
 
         # Set default name if not provided
         if "name" not in data and "template_id" in data:

--- a/src/orb/domain/template/template_aggregate.py
+++ b/src/orb/domain/template/template_aggregate.py
@@ -1,9 +1,10 @@
 """Template configuration value object - core template domain logic."""
 
+import warnings
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
 
 
 class Template(BaseModel):
@@ -21,7 +22,10 @@ class Template(BaseModel):
     description: Optional[str] = None
 
     # Instance configuration
-    instance_type: Optional[str] = None
+    machine_type: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("machine_type", "instance_type"),
+    )
     image_id: Optional[str] = None
     max_instances: int = 1
 
@@ -54,7 +58,10 @@ class Template(BaseModel):
     # Access and security (generic concepts)
     key_name: Optional[str] = None  # SSH key, etc.
     user_data: Optional[str] = None  # cloud-init, etc.
-    instance_profile: Optional[str] = None  # IAM role, service principal
+    machine_role: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("machine_role", "instance_profile"),
+    )  # IAM role, service principal, or service account
 
     # Advanced configuration (extensible)
     monitoring_enabled: Optional[bool] = None
@@ -62,9 +69,6 @@ class Template(BaseModel):
     # Tags and metadata
     tags: dict[str, Any] = Field(default_factory=dict)
     metadata: dict[str, Any] = Field(default_factory=dict)
-
-    # Provider-specific data (keyed by provider name, e.g. {"aws": {...}})
-    provider_data: dict[str, Any] = Field(default_factory=dict)
 
     # Provider configuration (multi-provider support)
     provider_type: Optional[str] = None
@@ -87,7 +91,31 @@ class Template(BaseModel):
         Note:
             Sets default name from template_id if not provided.
             Sets default timestamps if not provided.
+            The deprecated ``instance_type`` keyword argument is accepted and
+            silently promoted to ``machine_type``; a DeprecationWarning is
+            emitted to encourage callers to update.
         """
+        # Promote deprecated instance_type kwarg → machine_type.
+        # validation_alias handles model_validate() paths; __init__ kwargs need
+        # explicit handling here because Pydantic v2 validation_alias is not
+        # applied to __init__ keyword arguments.
+        if "instance_type" in data and "machine_type" not in data:
+            warnings.warn(
+                "Template field 'instance_type' is deprecated; use 'machine_type' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            data["machine_type"] = data.pop("instance_type")
+
+        # Promote deprecated instance_profile kwarg → machine_role.
+        if "instance_profile" in data and "machine_role" not in data:
+            warnings.warn(
+                "Template field 'instance_profile' is deprecated; use 'machine_role' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            data["machine_role"] = data.pop("instance_profile")
+
         # Set default name if not provided
         if "name" not in data and "template_id" in data:
             data["name"] = data["template_id"]
@@ -176,9 +204,9 @@ class Template(BaseModel):
         """Update configuration fields and return a new template instance."""
         return self.model_copy(update=configuration)
 
-    def update_instance_type(self, new_instance_type: str) -> "Template":
-        """Update the instance type and return a new template instance."""
-        return self.model_copy(update={"instance_type": new_instance_type})
+    def update_machine_type(self, new_machine_type: str) -> "Template":
+        """Update the machine type and return a new template instance."""
+        return self.model_copy(update={"machine_type": new_machine_type})
 
     def update_image_id(self, new_image_id: str) -> "Template":
         """Update the image ID and return a new template instance."""

--- a/src/orb/infrastructure/adapters/configuration_adapter.py
+++ b/src/orb/infrastructure/adapters/configuration_adapter.py
@@ -41,17 +41,12 @@ class ConfigurationAdapter(ConfigurationPort):
         """Get naming configuration for domain layer."""
         try:
             config = self._config_manager.get_typed(NamingConfig)
+            patterns: dict[str, Any] = {
+                "request_id": config.patterns.get("request_id", r"^(req-|ret-)[a-f0-9\-]{36}$"),
+                "cidr_block": config.patterns.get("cidr_block", r"^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$"),
+            }
             return {
-                "patterns": {
-                    "request_id": config.patterns.get("request_id", r"^(req-|ret-)[a-f0-9\-]{36}$"),
-                    "ec2_instance": config.patterns.get("ec2_instance", r"^i-[a-f0-9]{8,17}$"),
-                    "instance_type": config.patterns.get(
-                        "instance_type", r"^[a-z0-9]+\.[a-z0-9]+$"
-                    ),
-                    "cidr_block": config.patterns.get(
-                        "cidr_block", r"^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$"
-                    ),
-                },
+                "patterns": patterns,
                 "prefixes": {
                     "request": (
                         config.prefixes.request
@@ -70,7 +65,6 @@ class ConfigurationAdapter(ConfigurationPort):
             return {
                 "patterns": {
                     "request_id": r"^(req-|ret-)[a-f0-9\-]{36}$",
-                    "ec2_instance": r"^i-[a-f0-9]{8,17}$",
                     "instance_type": r"^[a-z0-9]+\.[a-z0-9]+$",
                     "cidr_block": r"^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$",
                 },

--- a/src/orb/infrastructure/scheduler/hostfactory/field_mappings.py
+++ b/src/orb/infrastructure/scheduler/hostfactory/field_mappings.py
@@ -63,7 +63,7 @@ class HostFactoryFieldMappings:
             "spotFleetRequestExpiry": "spot_fleet_request_expiry",
             "poolsCount": "pools_count",
             # AWS instance configuration
-            "instanceProfile": "instance_profile",
+            "instanceProfile": "machine_role",
             "launchTemplateId": "launch_template_id",
             "userDataScript": "user_data",
         },

--- a/src/orb/infrastructure/storage/repositories/machine_repository.py
+++ b/src/orb/infrastructure/storage/repositories/machine_repository.py
@@ -188,9 +188,13 @@ class MachineSerializer(BaseEntitySerializer):
             _pd = {**_nested, **_pd}
             data["provider_data"] = _pd
 
-        # provider_type: Machine.provider_type now has Field(default="aws"), so
-        # model_validate will supply the default when the key is absent.
-        # No fixup needed here.
+        # LEGACY DEFAULT: provider_type was absent in records written before
+        # multi-provider support.  Machine.provider_type has no Field default
+        # (making it required) so we must inject "aws" here for those rows so
+        # model_validate does not reject them.  Rows that already carry the
+        # field are untouched.
+        if "provider_type" not in data:
+            data["provider_type"] = "aws"
 
         return data
 

--- a/src/orb/infrastructure/storage/repositories/template_repository.py
+++ b/src/orb/infrastructure/storage/repositories/template_repository.py
@@ -55,8 +55,6 @@ class TemplateSerializer(BaseEntitySerializer):
             data["machine_types_ondemand"] = {}
         if data.get("machine_types_priority") is None:
             data["machine_types_priority"] = {}
-        if data.get("provider_data") is None:
-            data["provider_data"] = {}
         return data
 
     def _normalize_machine_types(self, data: dict) -> dict[str, int]:
@@ -96,7 +94,7 @@ class TemplateSerializer(BaseEntitySerializer):
                 "encryption_key": template.encryption_key,
                 "key_name": template.key_name,
                 "user_data": template.user_data,
-                "instance_profile": template.instance_profile,
+                "machine_role": template.machine_role,
                 "monitoring_enabled": template.monitoring_enabled,
                 "price_type": template.price_type,
                 "allocation_strategy": template.allocation_strategy,
@@ -174,7 +172,7 @@ class TemplateSerializer(BaseEntitySerializer):
                 "encryption_key": data.get("encryption_key"),
                 "key_name": data.get("keyName", data.get("key_name", data.get("key_pair_name"))),
                 "user_data": data.get("user_data"),
-                "instance_profile": data.get("instance_profile"),
+                "machine_role": data.get("machine_role") or data.get("instance_profile"),
                 "monitoring_enabled": data.get("monitoring_enabled"),
                 "price_type": data.get("price_type", "ondemand"),
                 "allocation_strategy": data.get("allocation_strategy", "lowest_price"),

--- a/src/orb/infrastructure/storage/sql/models.py
+++ b/src/orb/infrastructure/storage/sql/models.py
@@ -189,7 +189,7 @@ class TemplateModel(Base):
     # Access
     key_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     user_data: Mapped[str | None] = mapped_column(Text, nullable=True)
-    instance_profile: Mapped[str | None] = mapped_column(Text, nullable=True)
+    machine_role: Mapped[str | None] = mapped_column(Text, nullable=True, name="instance_profile")
     launch_template_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Advanced

--- a/src/orb/interface/template_command_handlers.py
+++ b/src/orb/interface/template_command_handlers.py
@@ -169,10 +169,6 @@ async def handle_create_template(
         )
 
     image_id = template_config.get("image_id") or template_config.get("imageId")
-    if not image_id:
-        return InterfaceResponse(
-            data={"success": False, "error": "image_id is required in template file"}, exit_code=1
-        )
 
     if getattr(args, "validate_only", False):
         return {
@@ -194,6 +190,8 @@ async def handle_create_template(
                 image_id=image_id,
                 name=template_config.get("name"),
                 description=template_config.get("description"),
+                machine_type=template_config.get("machine_type")
+                or template_config.get("machineType"),
                 instance_type=template_config.get("instance_type")
                 or template_config.get("instanceType"),
                 tags=template_config.get("tags", {}),
@@ -291,6 +289,8 @@ async def handle_update_template(
                 template_id=resolved_template_id,
                 name=template_config.get("name"),
                 description=template_config.get("description"),
+                machine_type=template_config.get("machine_type")
+                or template_config.get("machineType"),
                 instance_type=template_config.get("instance_type"),
                 image_id=template_config.get("image_id"),
                 configuration=template_config,

--- a/src/orb/providers/aws/auth/iam_strategy.py
+++ b/src/orb/providers/aws/auth/iam_strategy.py
@@ -44,6 +44,7 @@ class IAMAuthStrategy(AuthPort):
         enabled: bool = True,
         assume_permissions: bool = False,
         admin_role_patterns: Optional[frozenset[str]] = None,
+        admin_arns: Optional[list[str]] = None,
     ) -> None:
         """
         Initialize IAM authentication strategy.
@@ -56,9 +57,21 @@ class IAMAuthStrategy(AuthPort):
             enabled: Whether this strategy is enabled
             assume_permissions: If True, grant all required_actions without evaluation.
                 Only use in development/testing. Defaults to False (deny-all).
+            admin_role_patterns: Frozenset of resource-name strings that trigger the
+                admin role (matched by exact set-membership against the last ARN path
+                segment).  Ignored when ``admin_arns`` is non-empty.
+            admin_arns: Explicit allowlist of fully-qualified ARNs that receive the
+                admin role.  Matched by exact equality after lowercasing both sides.
+                When non-empty, ``admin_role_patterns`` is bypassed for admin checks.
         """
         self._logger = logger
         self._admin_role_patterns = admin_role_patterns or self._DEFAULT_ADMIN_ROLE_PATTERNS
+        # Normalise to lowercase frozenset for O(1) exact-match lookup.
+        # The only operation performed is `caller_arn_lower in self._admin_arns`,
+        # which is a set __contains__ check — never a substring search.
+        self._admin_arns: frozenset[str] = (
+            frozenset(a.lower() for a in admin_arns) if admin_arns else frozenset()
+        )
         self.region = region
         self.profile = profile
         # None means "operator did not configure required_actions" → apply defaults.
@@ -241,6 +254,7 @@ class IAMAuthStrategy(AuthPort):
         assume_permissions: bool = (
             getattr(iam_cfg, "assume_permissions", False) if iam_cfg is not None else False
         )
+        admin_arns: list[str] = getattr(iam_cfg, "admin_arns", []) if iam_cfg is not None else []
 
         # Intentional service-locator: from_auth_config is called by the
         # AuthRegistry as ``strategy_factory.from_auth_config(auth_config)``
@@ -264,6 +278,7 @@ class IAMAuthStrategy(AuthPort):
             required_actions=required_actions,
             enabled=True,
             assume_permissions=assume_permissions,
+            admin_arns=admin_arns,
         )
 
     def get_strategy_name(self) -> str:
@@ -411,10 +426,39 @@ class IAMAuthStrategy(AuthPort):
         try:
             arn = identity.get("Arn", "")
 
-            # Check if user is an admin based on ARN patterns
-            resource_name = arn.split("/")[-1] if "/" in arn else ""
-            if arn.endswith(":root") or resource_name in self._admin_role_patterns:
-                roles.append("admin")
+            # Determine admin status.
+            #
+            # When an explicit ARN allowlist is configured, use it exclusively and
+            # require an exact match (case-normalised).  This prevents two classes
+            # of bypass:
+            #   1. Substring bypass — `if admin_arn in caller_arn` would pass for
+            #      any caller whose serialised ARN contains the target as a substring
+            #      (e.g. `arn:aws:iam::EVIL:role/arn:aws:iam::ADMIN:role/OrbAdmin`).
+            #   2. Cross-account bypass — the legacy name-pattern check only inspects
+            #      the resource segment (e.g. "Admin") and does not verify the account
+            #      ID, so a principal named "Admin" in any account would match.
+            #
+            # The frozenset.__contains__ check below is an exact equality test, not
+            # a substring search.  Both sides are lowercased so the comparison is
+            # case-insensitive (IAM ARN account/service fields are case-insensitive;
+            # resource names are case-sensitive but normalising avoids misconfiguration).
+            if self._admin_arns:
+                # Explicit allowlist path — exact match only.
+                # When admin_arns is configured, it is the COMPLETE set of admin
+                # principals.  The unconditional :root grant does NOT apply here;
+                # include the root ARN explicitly in admin_arns if root must have
+                # admin access.  This prevents a cross-account bypass where any
+                # :root credential from any AWS account would otherwise be granted
+                # admin regardless of the configured allowlist.
+                caller_arn_lower = arn.lower()
+                if caller_arn_lower in self._admin_arns:
+                    roles.append("admin")
+            else:
+                # Legacy name-pattern path — kept for backward compatibility when no
+                # explicit admin_arns allowlist is configured.
+                resource_name = arn.split("/")[-1] if "/" in arn else ""
+                if arn.endswith(":root") or resource_name in self._admin_role_patterns:
+                    roles.append("admin")
 
             # Check if it's a service account (role-based)
             if ":role/" in arn:

--- a/src/orb/providers/aws/configuration/naming_config.py
+++ b/src/orb/providers/aws/configuration/naming_config.py
@@ -56,6 +56,10 @@ class AWSNamingConfig(BaseModel):
         r"^\d{12}$",
         description="Regex pattern for AWS account IDs",
     )
+    region: str = Field(
+        r"^[a-z]{2}-[a-z]+-\d$",
+        description="Regex pattern for AWS region names (e.g. us-east-1, eu-west-2)",
+    )
     limits: AWSLimitsConfig = Field(
         default_factory=AWSLimitsConfig,  # type: ignore[call-arg]
         description="AWS service limits and constraints",

--- a/src/orb/providers/aws/configuration/template_extension.py
+++ b/src/orb/providers/aws/configuration/template_extension.py
@@ -31,7 +31,7 @@ class AWSTemplateExtensionConfig(BaseModel):
     fleet_role: Optional[str] = Field(None, description="IAM role for Spot Fleet")
     key_name: Optional[str] = Field(None, description="Default key name")
     user_data_script: Optional[str] = Field(None, description="User data script")
-    instance_profile: Optional[str] = Field(None, description="Instance profile")
+    machine_role: Optional[str] = Field(None, description="IAM instance profile / machine role")
 
     # AWS pricing and allocation defaults
     max_spot_price: Optional[float] = Field(None, description="Maximum price for Spot instances")

--- a/src/orb/providers/aws/domain/template/aws_template_aggregate.py
+++ b/src/orb/providers/aws/domain/template/aws_template_aggregate.py
@@ -213,6 +213,11 @@ class AWSTemplate(Template):
     fleet_role: Optional[str] = None
     user_data: Optional[str] = None
 
+    # AWS EC2 instance type string (distinct from Template.machine_type, which is the
+    # provider-agnostic compute-sizing token).  Set when a specific single EC2 instance
+    # type is configured rather than a weighted machine_types map.
+    aws_instance_type: Optional[AWSInstanceType] = None
+
     # AWS instance configuration
     volume_type: Optional[str] = "gp3"  # gp2, gp3, io1, io2, standard
 
@@ -413,7 +418,7 @@ class AWSTemplate(Template):
             "root_device_volume_size": self.root_device_volume_size,
             "volume_type": self.volume_type,
             "iops": self.iops,
-            "instance_profile": self.instance_profile,
+            "machine_role": self.machine_role,
             "spot_fleet_request_expiry": self.spot_fleet_request_expiry,
             "percent_on_demand": self.percent_on_demand,
             "pools_count": self.pools_count,
@@ -430,13 +435,17 @@ class AWSTemplate(Template):
     @classmethod
     def from_aws_format(cls, data: dict[str, Any]) -> "AWSTemplate":
         """Create AWS template from AWS-specific format."""
+        # Build a raw EC2 instance type string from the input dict (vm_type, instance_type,
+        # or empty).  This becomes ``aws_instance_type`` on AWSTemplate — the EC2-specific
+        # concept — rather than the generic ``machine_type`` base field.
+        raw_instance_type = str(data.get("vm_type", data.get("instance_type", "")))
         # Convert AWS format to core format first
         core_data = {
             "template_id": data.get("template_id"),
             "name": data.get("name", data.get("template_id")),
-            "instance_type": AWSInstanceType(
-                value=str(data.get("vm_type", data.get("instance_type", "")))
-            ),
+            "aws_instance_type": AWSInstanceType(value=raw_instance_type)
+            if raw_instance_type
+            else None,
             "image_id": data.get("image_id"),
             "max_instances": data.get("max_number", data.get("max_instances", 1)),
             "subnet_ids": data.get(
@@ -467,7 +476,7 @@ class AWSTemplate(Template):
             or data.get("rootDeviceVolumeSize"),
             "volume_type": data.get("volume_type") or data.get("volumeType"),
             "iops": data.get("iops"),
-            "instance_profile": data.get("instance_profile"),
+            "machine_role": data.get("machine_role") or data.get("instance_profile"),
             "spot_fleet_request_expiry": data.get("spot_fleet_request_expiry"),
             "percent_on_demand": data.get("percent_on_demand"),
             "pools_count": data.get("pools_count"),

--- a/src/orb/providers/aws/infrastructure/adapters/aws_validation_adapter.py
+++ b/src/orb/providers/aws/infrastructure/adapters/aws_validation_adapter.py
@@ -220,9 +220,11 @@ class AWSValidationAdapter(BaseProviderValidationAdapter):
             warnings: List to append validation warnings to
             validated_fields: List to append validated field names to
         """
-        # Validate AMI ID format (skip check for SSM parameter paths)
+        # AWS requires image_id (AMI ID or SSM parameter path)
         image_id = template_config.get("image_id")
-        if image_id:
+        if not image_id:
+            errors.append("image_id is required for AWS templates")
+        else:
             validated_fields.append("image_id")
             if not image_id.startswith("/") and not image_id.startswith("ami-"):
                 errors.append(f"Invalid AWS AMI ID format: {image_id}")

--- a/src/orb/providers/aws/infrastructure/adapters/template_adapter.py
+++ b/src/orb/providers/aws/infrastructure/adapters/template_adapter.py
@@ -133,22 +133,6 @@ class AWSTemplateAdapter(TemplateAdapterPort):
         if not template.provider_api:
             template.provider_api = self._determine_provider_api(template)
 
-        # Extend with AWS-specific provider data
-        if not template.provider_data:
-            template.provider_data = {}
-
-        if "aws" not in template.provider_data:
-            template.provider_data["aws"] = {}
-
-        # Add AWS-specific provider data
-        template.provider_data["aws"].update(
-            {
-                "fleet_type": getattr(template, "fleet_type", None),
-                "supported_fields": self._AWS_SUPPORTED_FIELDS,
-                "validation_enabled": True,
-            }
-        )
-
         return template
 
     def resolve_template_references(self, template: Template) -> Template:

--- a/src/orb/providers/aws/infrastructure/handlers/shared/base_context_mixin.py
+++ b/src/orb/providers/aws/infrastructure/handlers/shared/base_context_mixin.py
@@ -105,8 +105,8 @@ class BaseContextMixin:
             # Optional configuration flags
             "has_key_name": hasattr(template, "key_name") and bool(template.key_name),
             "has_user_data": hasattr(template, "user_data") and bool(template.user_data),
-            "has_instance_profile": hasattr(template, "instance_profile")
-            and bool(template.instance_profile),
+            "has_instance_profile": hasattr(template, "machine_role")
+            and bool(template.machine_role),
             "has_ebs_optimized": hasattr(template, "ebs_optimized")
             and template.ebs_optimized is not None,  # type: ignore[attr-defined]
             "has_monitoring": hasattr(template, "monitoring_enabled")

--- a/src/orb/providers/aws/infrastructure/launch_template/manager.py
+++ b/src/orb/providers/aws/infrastructure/launch_template/manager.py
@@ -34,7 +34,7 @@ _OVERRIDE_FIELDS = frozenset(
         "security_group_ids",
         "key_name",
         "user_data",
-        "instance_profile",
+        "machine_role",
         "root_device_volume_size",
         "iops",
         "ebs_optimized",
@@ -358,9 +358,9 @@ class AWSLaunchTemplateManager:
                 "ascii"
             )
 
-        if aws_template.instance_profile:
+        if aws_template.machine_role:
             lt_data["IamInstanceProfile"] = {
-                "Name": self._extract_instance_profile_name(aws_template.instance_profile)
+                "Name": self._extract_instance_profile_name(aws_template.machine_role)
             }
 
         ebs_optimized = getattr(aws_template, "ebs_optimized", None)
@@ -625,8 +625,8 @@ class AWSLaunchTemplateManager:
                 else None
             ),
             "instance_profile": (
-                self._extract_instance_profile_name(template.instance_profile)
-                if hasattr(template, "instance_profile") and template.instance_profile
+                self._extract_instance_profile_name(template.machine_role)
+                if hasattr(template, "machine_role") and template.machine_role
                 else None
             ),
             "ebs_optimized": (getattr(template, "ebs_optimized", None)),
@@ -656,7 +656,7 @@ class AWSLaunchTemplateManager:
             "has_security_groups": bool(template.security_group_ids),
             "has_key_name": hasattr(template, "key_name") and bool(template.key_name),
             "has_user_data": hasattr(template, "user_data") and bool(template.user_data),
-            "has_instance_profile": bool(template.instance_profile),
+            "has_instance_profile": bool(template.machine_role),
             "has_ebs_optimized": getattr(template, "ebs_optimized", None) is not None,
             "has_monitoring": hasattr(template, "monitoring_enabled")
             and template.monitoring_enabled is not None,
@@ -765,9 +765,9 @@ class AWSLaunchTemplateManager:
             )
             launch_template_data["UserData"] = encoded_user_data
 
-        if aws_template.instance_profile:
+        if aws_template.machine_role:
             # Extract instance profile name from ARN if needed
-            instance_profile_name = aws_template.instance_profile
+            instance_profile_name = aws_template.machine_role
             if instance_profile_name.startswith("arn:aws:iam::"):
                 # Extract the role name from the ARN
                 # ARN format: arn:aws:iam::account-id:role/role-name

--- a/src/orb/providers/aws/scheduler/hostfactory_field_mapping.py
+++ b/src/orb/providers/aws/scheduler/hostfactory_field_mapping.py
@@ -29,7 +29,7 @@ class AWSFieldMapping:
         "spotFleetRequestExpiry": "spot_fleet_request_expiry",
         "poolsCount": "pools_count",
         # AWS instance configuration
-        "instanceProfile": "instance_profile",
+        "instanceProfile": "machine_role",
         "launchTemplateId": "launch_template_id",
         "userDataScript": "user_data",
     }

--- a/src/orb/providers/aws/services/instance_operation_service.py
+++ b/src/orb/providers/aws/services/instance_operation_service.py
@@ -68,7 +68,7 @@ class AWSInstanceOperationService:
                 "iops",
                 "fleet_role",
                 "fleet_type",
-                "instance_profile",
+                "machine_role",
                 "key_name",
                 "user_data",
             ]:

--- a/src/orb/providers/aws/strategy/aws_provider_strategy.py
+++ b/src/orb/providers/aws/strategy/aws_provider_strategy.py
@@ -801,6 +801,19 @@ class AWSProviderStrategy(ProviderStrategy):
         }
 
     @classmethod
+    def get_resource_id_pattern(cls) -> Optional[str]:
+        """Return the AWS EC2 instance-ID regex pattern.
+
+        AWS instance IDs always follow the ``i-`` prefix convention followed by
+        exactly 8 (legacy) or 17 (modern) lowercase hex characters.  The length
+        bound prevents unbounded backtracking and rejects obviously malformed IDs.
+
+        Returns:
+            Regex pattern string matching AWS EC2 instance IDs.
+        """
+        return r"^i-[a-f0-9]{8,17}$"
+
+    @classmethod
     def get_cli_infrastructure_defaults(cls, args: Any) -> dict[str, Any]:
         """Extract AWS-specific infrastructure defaults from parsed CLI args."""
         result: dict[str, Any] = {}

--- a/src/orb/providers/base/exceptions/__init__.py
+++ b/src/orb/providers/base/exceptions/__init__.py
@@ -1,0 +1,33 @@
+"""Shared provider exception hierarchy.
+
+Import from here, not from the internal module:
+
+::
+
+    from orb.providers.base.exceptions import (
+        ProviderError,
+        ProviderConfigError,
+        ProviderAuthError,
+        ProviderQuotaError,
+        ProviderTransientError,
+        ProviderPermanentError,
+    )
+"""
+
+from orb.providers.base.exceptions.provider_error import (
+    ProviderAuthError,
+    ProviderConfigError,
+    ProviderError,
+    ProviderPermanentError,
+    ProviderQuotaError,
+    ProviderTransientError,
+)
+
+__all__: list[str] = [
+    "ProviderError",
+    "ProviderConfigError",
+    "ProviderAuthError",
+    "ProviderQuotaError",
+    "ProviderTransientError",
+    "ProviderPermanentError",
+]

--- a/src/orb/providers/base/exceptions/provider_error.py
+++ b/src/orb/providers/base/exceptions/provider_error.py
@@ -1,0 +1,295 @@
+"""Shared provider exception hierarchy for cross-provider consistency.
+
+Every provider (AWS, k8s, Azure, GCP, OCI, …) should raise exceptions from
+this hierarchy rather than inventing ad-hoc exception types.  The common base
+carries ``provider_type`` so error-handling code at the application layer can
+branch by provider without inspecting the concrete subclass.
+
+Hierarchy
+---------
+``ProviderError``                 -- base; all provider errors (is_retryable=False)
+  ``ProviderConfigError``         -- bad or missing configuration at setup time
+  ``ProviderAuthError``           -- authentication / authorisation failures
+  ``ProviderQuotaError``          -- quota, rate-limit, or capacity ceiling hit (is_retryable=True)
+  ``ProviderTransientError``      -- retryable transient failure (is_retryable=True)
+  ``ProviderPermanentError``      -- non-retryable permanent failure
+
+Retry axis
+----------
+Every exception in this hierarchy carries an ``is_retryable`` boolean that
+indicates whether a retry is appropriate.  Retry logic can use a single
+attribute check rather than maintaining a hard-coded mapping of class names:
+
+::
+
+    if isinstance(exc, ProviderError) and exc.is_retryable:
+        schedule_retry(exc)
+
+Leaf classes override ``_default_is_retryable`` to set their default;
+callers may also pass ``is_retryable`` explicitly to override the class
+default for unusual cases.
+
+Serialisation safety
+--------------------
+``to_dict()`` includes ``underlying_exception`` (via ``repr()``) which may
+contain connection strings, ARNs, or other secrets.  Use ``safe_to_dict()``
+for any output that leaves the process boundary (HTTP responses, audit logs
+sent to external systems).  ``to_dict()`` is retained for internal structured
+logging where the full context is valuable.
+
+Provider packages sub-class exactly one of these five leaf types (or
+``ProviderError`` directly when none fits) and add their own extra fields.
+
+Example
+-------
+::
+
+    from orb.providers.base.exceptions import ProviderAuthError
+
+    raise ProviderAuthError(
+        "IAM role does not have ec2:RunInstances",
+        provider_type="aws",
+        provider_name="prod-us-east-1",
+        underlying_exception=original_boto_error,
+    )
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class ProviderError(Exception):
+    """Base exception for all provider errors.
+
+    All provider-specific exception classes must inherit from this class
+    (directly or through one of its subclasses) so that callers can catch
+    any provider error with a single ``except ProviderError`` clause.
+
+    Attributes
+    ----------
+    provider_type:
+        Short identifier for the provider that raised the error
+        (e.g. ``"aws"``, ``"k8s"``, ``"azure"``).  Always present.
+    provider_name:
+        Optional human-readable name for the specific provider instance
+        (e.g. ``"prod-us-east-1"``).  ``None`` when not applicable.
+    underlying_exception:
+        The original exception that caused this error, when applicable.
+        Stored so callers can inspect or re-raise the root cause without
+        losing it to the wrapper.
+    is_retryable:
+        Whether retrying the operation is appropriate for this error.
+        Leaf classes set a class-level default via ``_default_is_retryable``;
+        callers may override by passing ``is_retryable`` explicitly.
+        Retry logic should check this attribute rather than using isinstance
+        checks on leaf classes::
+
+            if isinstance(exc, ProviderError) and exc.is_retryable:
+                schedule_retry(exc)
+    """
+
+    #: Class-level default for ``is_retryable``.  Leaf classes override this.
+    _default_is_retryable: bool = False
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider_type: str,
+        provider_name: Optional[str] = None,
+        underlying_exception: Optional[BaseException] = None,
+        details: Optional[dict[str, Any]] = None,
+        is_retryable: Optional[bool] = None,
+    ) -> None:
+        """Initialise a provider error.
+
+        Parameters
+        ----------
+        message:
+            Human-readable description of what went wrong.
+        provider_type:
+            Short provider identifier.  Required so application-layer error
+            handlers can route the error without ``isinstance`` checks on
+            provider-specific subclasses.
+        provider_name:
+            Optional name of the specific provider instance.
+        underlying_exception:
+            Original exception that triggered this one, if any.
+        details:
+            Arbitrary key/value context for structured logging or API
+            responses.  Merged into ``to_dict()`` output.
+        is_retryable:
+            Override the class default for ``is_retryable``.  Pass ``True``
+            or ``False`` to force a specific value; omit (``None``) to use
+            the leaf class default.
+        """
+        super().__init__(message)
+        self.message = message
+        self.provider_type = provider_type
+        self.provider_name = provider_name
+        self.underlying_exception = underlying_exception
+        self.details: dict[str, Any] = details or {}
+        self.is_retryable: bool = (
+            is_retryable if is_retryable is not None else self._default_is_retryable
+        )
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serialisable representation of this error for internal logging.
+
+        WARNING: This method includes ``underlying_exception`` via ``repr()``,
+        which may contain sensitive information such as connection strings,
+        ARNs, or credentials embedded in exception messages.  Do NOT use this
+        method for HTTP responses or any output that crosses a trust boundary.
+        Use ``safe_to_dict()`` instead for external-facing serialisation.
+
+        Sub-classes should call ``super().to_dict()`` and update the returned
+        dict with their own fields:
+
+        ::
+
+            def to_dict(self) -> dict[str, Any]:
+                result = super().to_dict()
+                result["quota_name"] = self.quota_name
+                return result
+        """
+        result: dict[str, Any] = {
+            "error_type": type(self).__name__,
+            "message": self.message,
+            "provider_type": self.provider_type,
+            "is_retryable": self.is_retryable,
+        }
+        if self.provider_name is not None:
+            result["provider_name"] = self.provider_name
+        if self.underlying_exception is not None:
+            result["underlying_exception"] = repr(self.underlying_exception)
+        if self.details:
+            result["details"] = self.details
+        return result
+
+    def safe_to_dict(self) -> dict[str, Any]:
+        """Return a serialisable representation safe for external-facing output.
+
+        Identical to ``to_dict()`` except that ``underlying_exception`` is
+        always omitted.  Use this variant for HTTP error responses, audit logs
+        shipped to external systems, or any output that crosses a trust
+        boundary, to prevent accidental leakage of connection strings, ARNs,
+        or other secrets that may appear in underlying exception messages.
+
+        Sub-classes that override ``to_dict()`` should also override this
+        method (or call ``super().safe_to_dict()`` and add their own fields
+        without ``underlying_exception``).
+        """
+        result: dict[str, Any] = {
+            "error_type": type(self).__name__,
+            "message": self.message,
+            "provider_type": self.provider_type,
+            "is_retryable": self.is_retryable,
+        }
+        if self.provider_name is not None:
+            result["provider_name"] = self.provider_name
+        if self.details:
+            result["details"] = self.details
+        return result
+
+    def __repr__(self) -> str:
+        parts = [f"provider_type={self.provider_type!r}"]
+        if self.provider_name:
+            parts.append(f"provider_name={self.provider_name!r}")
+        return f"{type(self).__name__}({self.message!r}, {', '.join(parts)})"
+
+
+# ---------------------------------------------------------------------------
+# Leaf exception types
+# ---------------------------------------------------------------------------
+
+
+class ProviderConfigError(ProviderError):
+    """Raised when provider configuration is absent, incomplete, or invalid.
+
+    Raise this at setup / initialisation time when the provider cannot be
+    configured correctly.  Examples:
+
+    * A required config key is missing (no ``region`` for AWS).
+    * A config value fails schema validation.
+    * A referenced secret or credentials file does not exist.
+
+    This error is **not** retryable — the operator must fix the config.
+    """
+
+    _default_is_retryable: bool = False
+
+
+class ProviderAuthError(ProviderError):
+    """Raised when authentication or authorisation against the provider fails.
+
+    Examples:
+
+    * Expired or revoked credentials.
+    * The caller's identity lacks a required permission (403 / AccessDenied).
+    * Token refresh failed.
+
+    This error is generally **not** retryable without operator intervention
+    (credential rotation / IAM policy update), though short-lived token
+    expiry may be retryable after a refresh cycle.
+    """
+
+    _default_is_retryable: bool = False
+
+
+class ProviderQuotaError(ProviderError):
+    """Raised when a provider quota, rate limit, or capacity ceiling is hit.
+
+    Examples:
+
+    * vCPU quota exhausted (AWS ``VcpuLimitExceeded``).
+    * API calls throttled (AWS ``RequestLimitExceeded``, k8s 429).
+    * Node pool capacity unavailable.
+
+    Quota and rate-limit errors are treated as retryable: the quota may
+    increase, the throttle window may expire, or a back-off retry may
+    succeed.  Set ``is_retryable=False`` explicitly for hard quota ceilings
+    that require operator action before any retry can succeed.
+    """
+
+    _default_is_retryable: bool = True
+
+
+class ProviderTransientError(ProviderError):
+    """Raised for retryable transient provider failures.
+
+    Use this when the underlying provider signals that the error is
+    temporary and a retry is likely to succeed:
+
+    * HTTP 503 Service Unavailable.
+    * Connection timeout or TCP reset.
+    * AWS ``ServiceUnavailable`` or ``InternalError``.
+    * k8s API server temporarily unreachable.
+
+    The caller (retry middleware, resilience layer) should catch this
+    class specifically to drive retry logic, or check ``is_retryable``
+    for a provider-neutral approach.
+    """
+
+    _default_is_retryable: bool = True
+
+
+class ProviderPermanentError(ProviderError):
+    """Raised for non-retryable permanent provider failures.
+
+    Use this when retrying will never help:
+
+    * The requested resource does not exist (404).
+    * The request is malformed (400 / ``ValidationError``).
+    * A hard permission denial that cannot change without operator action.
+    * Attempting to mutate an immutable resource.
+
+    The caller should surface this directly to the end user or dead-letter
+    queue rather than retrying.
+    """
+
+    _default_is_retryable: bool = False

--- a/src/orb/providers/base/strategy/provider_strategy.py
+++ b/src/orb/providers/base/strategy/provider_strategy.py
@@ -423,6 +423,24 @@ class ProviderStrategy(ABC):
         return {}
 
     @classmethod
+    def get_resource_id_pattern(cls) -> Optional[str]:
+        """Return a regex pattern that validates provider-specific resource IDs.
+
+        Return ``None`` (default) when the provider does not enforce a
+        resource-ID naming convention.  Return a regex string when the
+        provider issues predictable IDs that should be validated at the
+        storage / API boundary — e.g. AWS's ``i-<hex>`` instance IDs.
+
+        Declared as a ``@classmethod`` so callers can retrieve the pattern from
+        the class directly — no instance (and therefore no live credentials or
+        I/O) is required.
+
+        Returns:
+            Regex pattern string, or ``None`` if no pattern is enforced.
+        """
+        return None
+
+    @classmethod
     def get_cli_infrastructure_defaults(cls, args: Any) -> dict[str, Any]:
         """Extract provider-specific infrastructure defaults from parsed CLI args.
 

--- a/src/orb/providers/k8s/domain/template/k8s_template_aggregate.py
+++ b/src/orb/providers/k8s/domain/template/k8s_template_aggregate.py
@@ -3,18 +3,17 @@
 Mirrors :class:`orb.providers.aws.domain.template.aws_template_aggregate.AWSTemplate`
 for the kubernetes provider.  ``K8sTemplate`` is a strongly-typed
 ``Template`` subclass: kubernetes-specific operator-supplied fields live as
-flat first-class attributes rather than as opaque entries under
-``Template.provider_data['k8s']``.
+flat first-class attributes on the subclass.
 
 Generic provisioning concepts continue to be expressed on the parent
 ``Template``:
 
-* ``image_id``         — container image string consumed by the spec builders.
-* ``tags``             — operator tags; merged into the pod ``metadata.labels``
+* ``image_id``       — container image string consumed by the spec builders.
+* ``tags``           — operator tags; merged into the pod ``metadata.labels``
   surface at spec-build time.
-* ``max_instances``    — quota cap; the per-request replica count comes from
+* ``max_instances``  — quota cap; the per-request replica count comes from
   ``request.requested_count``.
-* ``instance_profile`` — falls back as the ``serviceAccountName`` when
+* ``machine_role``   — falls back as the ``serviceAccountName`` when
   :attr:`K8sTemplate.service_account` is not set.
 
 Upcasting an arbitrary ``Template`` to a ``K8sTemplate`` is safe via
@@ -561,11 +560,10 @@ class K8sTemplate(Template):
            backwards compatibility with operators who set kubernetes fields
            via the DTO surface rather than via the typed template
            directly.
-        2. Fall back to :attr:`Template.instance_profile` for
+        2. Fall back to :attr:`Template.machine_role` for
            :attr:`service_account` when the latter is unset.  This honours
-           the documented mapping of the generic ``instance_profile``
-           field (see :class:`Template` line 57) onto the kubernetes
-           ``serviceAccountName`` concept.
+           the documented mapping of the generic ``machine_role``
+           field onto the kubernetes ``serviceAccountName`` concept.
         """
         # Promote provider_config dict entries onto typed fields.
         pc = getattr(self, "provider_config", None)
@@ -632,9 +630,9 @@ class K8sTemplate(Template):
             if self.volumes is None and pc.get("volumes") is not None:
                 object.__setattr__(self, "volumes", _coerce_volumes(pc.get("volumes")))
 
-        # Service-account fallback to the generic instance_profile.
-        if self.service_account is None and self.instance_profile:
-            object.__setattr__(self, "service_account", self.instance_profile)
+        # Service-account fallback to the generic machine_role.
+        if self.service_account is None and self.machine_role:
+            object.__setattr__(self, "service_account", self.machine_role)
 
         return self
 

--- a/src/orb/providers/k8s/infrastructure/adapters/template_adapter.py
+++ b/src/orb/providers/k8s/infrastructure/adapters/template_adapter.py
@@ -124,13 +124,11 @@ class K8sTemplateAdapter(TemplateAdapterPort):
         return errors
 
     def extend_template_fields(self, template: Template) -> Template:
-        """Attach kubernetes-specific provider data to *template* in place.
+        """Set kubernetes-specific defaults on *template*.
 
-        With the typed :class:`K8sTemplate` aggregate in place, the
-        kubernetes provider does not need to mirror operator-supplied
-        fields into ``template.provider_data["k8s"]`` — handlers read
-        the typed fields directly.  We still default ``provider_api``
-        to ``"Pod"`` when the template arrives without one.
+        With the typed :class:`K8sTemplate` aggregate in place, handlers read
+        typed fields directly.  We default ``provider_api`` to ``"Pod"``
+        when the template arrives without one.
         """
         if not template.provider_api:
             template.provider_api = self.get_provider_api()

--- a/src/orb/sdk/client.py
+++ b/src/orb/sdk/client.py
@@ -777,7 +777,14 @@ class ORBClient:
         from orb.application.services.orchestration.dtos import CreateTemplateInput
 
         # Named kwargs extracted explicitly; everything else goes into configuration
-        _explicit = {"name", "description", "instance_type", "tags", "configuration"}
+        _explicit = {
+            "name",
+            "description",
+            "machine_type",
+            "instance_type",
+            "tags",
+            "configuration",
+        }
         extra = {k: v for k, v in kwargs.items() if k not in _explicit}
         configuration = {**extra, **kwargs.get("configuration", {})}
 
@@ -789,6 +796,7 @@ class ORBClient:
                 image_id=image_id,
                 name=kwargs.get("name"),
                 description=kwargs.get("description"),
+                machine_type=kwargs.get("machine_type"),
                 instance_type=kwargs.get("instance_type"),
                 tags=kwargs.get("tags", {}),
                 configuration=configuration,
@@ -818,7 +826,14 @@ class ORBClient:
         )
 
         # Named kwargs extracted explicitly; everything else goes into configuration
-        _explicit = {"name", "description", "instance_type", "image_id", "configuration"}
+        _explicit = {
+            "name",
+            "description",
+            "machine_type",
+            "instance_type",
+            "image_id",
+            "configuration",
+        }
         extra = {k: v for k, v in kwargs.items() if k not in _explicit}
         configuration = {**extra, **kwargs.get("configuration", {})}
 
@@ -828,6 +843,7 @@ class ORBClient:
                 template_id=template_id,
                 name=kwargs.get("name"),
                 description=kwargs.get("description"),
+                machine_type=kwargs.get("machine_type"),
                 instance_type=kwargs.get("instance_type"),
                 image_id=kwargs.get("image_id"),
                 configuration=configuration,

--- a/tests/api/middleware/test_auth_middleware.py
+++ b/tests/api/middleware/test_auth_middleware.py
@@ -184,6 +184,88 @@ class TestAuthMiddlewareTrustedProxy:
         assert result == "10.0.0.1"
 
 
+class TestDocsAuthGating:
+    """When auth is enabled, docs endpoints are gated unless docs.require_auth=False."""
+
+    def _make_app_with_excluded(self, excluded_paths: list) -> FastAPI:
+        """Build a test app with the given excluded_paths and require_auth=True."""
+        app = FastAPI()
+        auth_port = _make_auth_port(authenticated=False)  # always returns INVALID
+        app.add_middleware(
+            AuthMiddleware,
+            auth_port=auth_port,
+            require_auth=True,
+            excluded_paths=excluded_paths,
+        )
+
+        @app.get("/docs")
+        def docs():
+            return {"page": "docs"}
+
+        @app.get("/redoc")
+        def redoc():
+            return {"page": "redoc"}
+
+        @app.get("/openapi.json")
+        def openapi():
+            return {"openapi": "3.0.0"}
+
+        @app.get("/health")
+        def health():
+            return {"status": "ok"}
+
+        return app
+
+    def test_docs_blocked_when_not_excluded_and_auth_enabled(self):
+        """With require_auth=True and docs NOT in excluded_paths, /docs returns 401."""
+        # Simulate docs.require_auth=True: excluded_paths has /health but NOT /docs
+        client = TestClient(
+            self._make_app_with_excluded(["/health", "/favicon.ico"]),
+            raise_server_exceptions=False,
+        )
+        resp = client.get("/docs")
+        assert resp.status_code == 401
+
+    def test_redoc_blocked_when_not_excluded_and_auth_enabled(self):
+        """/redoc returns 401 when auth is enabled and not in excluded_paths."""
+        client = TestClient(
+            self._make_app_with_excluded(["/health", "/favicon.ico"]),
+            raise_server_exceptions=False,
+        )
+        resp = client.get("/redoc")
+        assert resp.status_code == 401
+
+    def test_openapi_json_blocked_when_not_excluded_and_auth_enabled(self):
+        """/openapi.json returns 401 when auth is enabled and not in excluded_paths."""
+        client = TestClient(
+            self._make_app_with_excluded(["/health", "/favicon.ico"]),
+            raise_server_exceptions=False,
+        )
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 401
+
+    def test_docs_public_when_excluded(self):
+        """When docs are explicitly excluded (docs.require_auth=False), /docs is public."""
+        client = TestClient(
+            self._make_app_with_excluded(
+                ["/health", "/favicon.ico", "/docs", "/redoc", "/openapi.json"]
+            ),
+            raise_server_exceptions=False,
+        )
+        # Auth port returns INVALID but /docs is excluded → no auth check → 200
+        resp = client.get("/docs")
+        assert resp.status_code == 200
+
+    def test_health_always_public(self):
+        """/health is in the excluded list and must return 200 regardless of auth."""
+        client = TestClient(
+            self._make_app_with_excluded(["/health", "/favicon.ico"]),
+            raise_server_exceptions=False,
+        )
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+
 class TestLoopbackTokenNonAscii:
     """Non-ASCII bearer tokens must be denied cleanly without raising UnicodeEncodeError."""
 

--- a/tests/api/routers/test_info.py
+++ b/tests/api/routers/test_info.py
@@ -1,0 +1,114 @@
+"""Tests for the /info endpoint — authentication config must not be disclosed."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Minimal fixture: replicate the /info handler without the full create_app
+# machinery so the test has no dependency on DI containers or middleware.
+# ---------------------------------------------------------------------------
+
+
+def _make_info_app() -> FastAPI:
+    """Return a FastAPI test app that contains only the /info handler."""
+    from orb._package import __version__
+
+    app = FastAPI()
+
+    @app.get("/info")
+    async def info() -> dict:
+        return {
+            "service": "open-resource-broker",
+            "version": __version__,
+            "description": "REST API for Open Resource Broker",
+        }
+
+    return app
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(_make_info_app())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestInfoEndpoint:
+    """GET /info must return service metadata without disclosing auth config."""
+
+    def test_returns_200(self, client: TestClient) -> None:
+        """The endpoint responds with HTTP 200."""
+        resp = client.get("/info")
+        assert resp.status_code == 200
+
+    def test_body_is_json(self, client: TestClient) -> None:
+        """The response body is valid JSON."""
+        resp = client.get("/info")
+        # content-type must be application/json
+        assert "application/json" in resp.headers.get("content-type", "")
+
+    def test_service_field_present(self, client: TestClient) -> None:
+        """The 'service' key is present and identifies the broker."""
+        resp = client.get("/info")
+        body = resp.json()
+        assert body.get("service") == "open-resource-broker"
+
+    def test_version_field_present(self, client: TestClient) -> None:
+        """The 'version' key is present and non-empty."""
+        resp = client.get("/info")
+        body = resp.json()
+        assert "version" in body
+        assert body["version"]  # non-empty string
+
+    def test_description_field_present(self, client: TestClient) -> None:
+        """The 'description' key is present."""
+        resp = client.get("/info")
+        body = resp.json()
+        assert "description" in body
+
+    def test_auth_enabled_not_disclosed(self, client: TestClient) -> None:
+        """'auth_enabled' must NOT appear in the /info response.
+
+        Revealing whether authentication is active tells an attacker whether
+        there is any credential-based access control to probe.
+        """
+        resp = client.get("/info")
+        body = resp.json()
+        assert "auth_enabled" not in body, (
+            "auth_enabled must not be disclosed in the /info response"
+        )
+
+    def test_auth_strategy_not_disclosed(self, client: TestClient) -> None:
+        """'auth_strategy' must NOT appear in the /info response.
+
+        Revealing the active auth strategy narrows the attack surface for
+        credential-stuffing by telling an attacker exactly which auth method
+        to target.
+        """
+        resp = client.get("/info")
+        body = resp.json()
+        assert "auth_strategy" not in body, (
+            "auth_strategy must not be disclosed in the /info response"
+        )
+
+    def test_no_extra_auth_fields_in_response(self, client: TestClient) -> None:
+        """The response contains only the expected safe fields."""
+        resp = client.get("/info")
+        body = resp.json()
+        allowed_keys = {"service", "version", "description"}
+        unexpected = set(body.keys()) - allowed_keys
+        assert not unexpected, f"Unexpected fields in /info response: {unexpected}"
+
+    def test_unauthenticated_access_succeeds(self, client: TestClient) -> None:
+        """Anonymous callers can reach /info without credentials (public health-like endpoint)."""
+        # No Authorization header — request must still succeed with 200.
+        resp = client.get("/info", headers={})
+        assert resp.status_code == 200

--- a/tests/e2e/test_critical_path_e2e.py
+++ b/tests/e2e/test_critical_path_e2e.py
@@ -982,12 +982,21 @@ class TestConfigurationManagement:
         assert "version" in data
 
     def test_info_endpoint_returns_service_info(self, client: TestClient):
-        """GET /info returns service information."""
+        """GET /info returns service metadata without disclosing auth configuration.
+
+        The security-hardened /info endpoint intentionally omits auth_enabled and
+        auth_strategy so that unauthenticated callers cannot discover the active
+        auth method and tailor attacks accordingly (see fix(security) commit bb4b4d27).
+        """
         response = client.get("/info")
         assert response.status_code == 200
         data = response.json()
         assert data["service"] == "open-resource-broker"
-        assert data["auth_enabled"] is False
+        assert "version" in data
+        assert "description" in data
+        # auth_enabled must NOT be disclosed to unauthenticated callers
+        assert "auth_enabled" not in data
+        assert "auth_strategy" not in data
 
     def test_template_refresh_triggers_cache_reload(self, app, client: TestClient):
         """POST /api/v1/templates/refresh reloads template cache."""

--- a/tests/infrastructure/storage/components/test_sql_query_builder.py
+++ b/tests/infrastructure/storage/components/test_sql_query_builder.py
@@ -1,0 +1,343 @@
+"""Tests for SQLQueryBuilder component.
+
+Verifies that SQLQueryBuilder can be instantiated and that every abstract method
+declared on QueryManager is overridden and behaves correctly.
+"""
+
+import pytest
+
+from orb.infrastructure.storage.components.resource_manager import QueryManager
+from orb.infrastructure.storage.components.sql_query_builder import QueryType, SQLQueryBuilder
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+COLUMNS = {
+    "id": "TEXT PRIMARY KEY",
+    "name": "TEXT",
+    "status": "TEXT",
+    "created_at": "TEXT",
+}
+
+
+@pytest.fixture()
+def builder() -> SQLQueryBuilder:
+    """Return a fully-initialised SQLQueryBuilder for a 'resources' table."""
+    return SQLQueryBuilder("resources", COLUMNS)
+
+
+# ---------------------------------------------------------------------------
+# Abstract-contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestQueryManagerAbstractContract:
+    """Verify the abstract/concrete relationship between QueryManager and SQLQueryBuilder."""
+
+    def test_query_manager_is_abstract(self) -> None:
+        """QueryManager cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            QueryManager()  # type: ignore[abstract]
+
+    def test_sql_query_builder_is_instantiable(self, builder: SQLQueryBuilder) -> None:
+        """SQLQueryBuilder can be instantiated without TypeError."""
+        # If any abstract method were still abstract this line would raise
+        # TypeError: Can't instantiate abstract class …
+        assert builder is not None
+
+    def test_sql_query_builder_is_a_query_manager(self, builder: SQLQueryBuilder) -> None:
+        """SQLQueryBuilder is a proper subtype of QueryManager."""
+        assert isinstance(builder, QueryManager)
+
+    def test_build_query_is_implemented(self, builder: SQLQueryBuilder) -> None:
+        """build_query is a concrete method (not abstract)."""
+        assert not getattr(builder.build_query, "__isabstractmethod__", False)
+
+    def test_execute_query_is_implemented(self, builder: SQLQueryBuilder) -> None:
+        """execute_query is overridden on SQLQueryBuilder."""
+        assert not getattr(builder.execute_query, "__isabstractmethod__", False)
+
+    def test_validate_query_is_implemented(self, builder: SQLQueryBuilder) -> None:
+        """validate_query is a concrete method (not abstract)."""
+        assert not getattr(builder.validate_query, "__isabstractmethod__", False)
+
+
+# ---------------------------------------------------------------------------
+# build_query — QueryManager dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestBuildQuery:
+    """Tests for the QueryManager.build_query dispatch method."""
+
+    def test_build_query_create_table(self, builder: SQLQueryBuilder) -> None:
+        result = builder.build_query({"type": "CREATE_TABLE"})
+        assert "CREATE TABLE IF NOT EXISTS resources" in result
+
+    def test_build_query_select_all(self, builder: SQLQueryBuilder) -> None:
+        result = builder.build_query({"type": "SELECT_ALL"})
+        assert result == "SELECT * FROM resources"
+
+    def test_build_query_select_by_id(self, builder: SQLQueryBuilder) -> None:
+        result = builder.build_query({"type": "SELECT_BY_ID", "id_column": "id"})
+        assert "WHERE id = :id" in result
+
+    def test_build_query_insert(self, builder: SQLQueryBuilder) -> None:
+        data = {"id": "x1", "name": "Alice", "status": "active", "created_at": "2024-01-01"}
+        result = builder.build_query({"type": "INSERT", "data": data})
+        assert "INSERT INTO resources" in result
+        assert ":id" in result
+
+    def test_build_query_update(self, builder: SQLQueryBuilder) -> None:
+        data = {"name": "Bob", "status": "inactive"}
+        result = builder.build_query(
+            {"type": "UPDATE", "data": data, "id_column": "id", "entity_id": "x1"}
+        )
+        assert "UPDATE resources SET" in result
+        assert "WHERE id = :entity_id" in result
+
+    def test_build_query_delete(self, builder: SQLQueryBuilder) -> None:
+        result = builder.build_query({"type": "DELETE", "id_column": "id"})
+        assert "DELETE FROM resources WHERE id = :id" in result
+
+    def test_build_query_unknown_type_raises_value_error(self, builder: SQLQueryBuilder) -> None:
+        with pytest.raises(ValueError, match="Unknown query type"):
+            builder.build_query({"type": "NONSENSE"})
+
+    def test_build_query_case_insensitive_type(self, builder: SQLQueryBuilder) -> None:
+        """query_spec['type'] is uppercased before dispatch."""
+        result = builder.build_query({"type": "select_all"})
+        assert result == "SELECT * FROM resources"
+
+
+# ---------------------------------------------------------------------------
+# execute_query — intentionally raises NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteQuery:
+    """execute_query satisfies the abstract slot but delegates to the connection manager."""
+
+    def test_execute_query_raises_not_implemented_error(self, builder: SQLQueryBuilder) -> None:
+        """SQLQueryBuilder is build-only; direct execution must be rejected."""
+        with pytest.raises(NotImplementedError, match="SQLConnectionManager"):
+            builder.execute_query("SELECT * FROM resources")
+
+    def test_execute_query_raises_with_parameters(self, builder: SQLQueryBuilder) -> None:
+        """execute_query rejects execution regardless of parameters."""
+        with pytest.raises(NotImplementedError):
+            builder.execute_query("SELECT * FROM resources WHERE id = :id", {"id": "x1"})
+
+
+# ---------------------------------------------------------------------------
+# validate_query — QueryManager.validate_query override
+# ---------------------------------------------------------------------------
+
+
+class TestValidateQuery:
+    """Tests for the validate_query override."""
+
+    def test_valid_select_query(self, builder: SQLQueryBuilder) -> None:
+        assert builder.validate_query("SELECT * FROM resources") is True
+
+    def test_valid_insert_query(self, builder: SQLQueryBuilder) -> None:
+        assert builder.validate_query("INSERT INTO resources (id) VALUES (:id)") is True
+
+    def test_valid_update_query(self, builder: SQLQueryBuilder) -> None:
+        assert builder.validate_query("UPDATE resources SET name = :name WHERE id = :id") is True
+
+    def test_valid_delete_query(self, builder: SQLQueryBuilder) -> None:
+        assert builder.validate_query("DELETE FROM resources WHERE id = :id") is True
+
+    def test_valid_create_query(self, builder: SQLQueryBuilder) -> None:
+        assert builder.validate_query("CREATE TABLE IF NOT EXISTS resources (id TEXT)") is True
+
+    def test_empty_string_is_invalid(self, builder: SQLQueryBuilder) -> None:
+        assert builder.validate_query("") is False
+
+    def test_whitespace_only_is_invalid(self, builder: SQLQueryBuilder) -> None:
+        assert builder.validate_query("   ") is False
+
+    def test_no_keyword_is_invalid(self, builder: SQLQueryBuilder) -> None:
+        assert builder.validate_query("resources WHERE id = 1") is False
+
+    def test_unbalanced_single_quote_is_invalid(self, builder: SQLQueryBuilder) -> None:
+        assert builder.validate_query("SELECT * FROM resources WHERE name = 'unclosed") is False
+
+    def test_balanced_quotes_are_valid(self, builder: SQLQueryBuilder) -> None:
+        assert builder.validate_query("SELECT * FROM resources WHERE name = 'Alice'") is True
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+class TestSQLQueryBuilderInitialization:
+    """Verify constructor-time validation and attribute setup."""
+
+    def test_stores_table_name(self, builder: SQLQueryBuilder) -> None:
+        assert builder.table_name == "resources"
+
+    def test_stores_columns(self, builder: SQLQueryBuilder) -> None:
+        assert "id" in builder.columns
+        assert "name" in builder.columns
+
+    def test_rejects_invalid_table_name(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            SQLQueryBuilder("bad-table!", {"id": "TEXT"})
+
+    def test_rejects_invalid_column_name(self) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            SQLQueryBuilder("mytable", {"bad col": "TEXT"})
+
+    def test_logger_is_set(self, builder: SQLQueryBuilder) -> None:
+        assert builder.logger is not None
+
+
+# ---------------------------------------------------------------------------
+# Individual build methods
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCreateTable:
+    def test_contains_create_table_statement(self, builder: SQLQueryBuilder) -> None:
+        sql = builder.build_create_table()
+        assert "CREATE TABLE IF NOT EXISTS resources" in sql
+
+    def test_includes_all_columns(self, builder: SQLQueryBuilder) -> None:
+        sql = builder.build_create_table()
+        for col in COLUMNS:
+            assert col in sql
+
+
+class TestBuildInsert:
+    def test_returns_query_and_params(self, builder: SQLQueryBuilder) -> None:
+        data = {"id": "u1", "name": "Alice", "status": "active", "created_at": "2024-01-01"}
+        query, params = builder.build_insert(data)
+        assert "INSERT INTO resources" in query
+        assert params == data
+
+    def test_filters_unknown_columns(self, builder: SQLQueryBuilder) -> None:
+        data = {"id": "u1", "unknown_col": "value"}
+        query, params = builder.build_insert(data)
+        assert "unknown_col" not in query
+        assert "unknown_col" not in params
+
+    def test_raises_when_no_valid_columns(self, builder: SQLQueryBuilder) -> None:
+        with pytest.raises(ValueError, match="No valid columns"):
+            builder.build_insert({"totally_unknown": "x"})
+
+
+class TestBuildSelectById:
+    def test_returns_query_and_param_name(self, builder: SQLQueryBuilder) -> None:
+        query, param = builder.build_select_by_id("id")
+        assert "WHERE id = :id" in query
+        assert param == "id"
+
+    def test_rejects_invalid_id_column(self, builder: SQLQueryBuilder) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            builder.build_select_by_id("bad col!")
+
+
+class TestBuildSelectAll:
+    def test_returns_select_star(self, builder: SQLQueryBuilder) -> None:
+        assert builder.build_select_all() == "SELECT * FROM resources"
+
+
+class TestBuildUpdate:
+    def test_returns_query_and_params(self, builder: SQLQueryBuilder) -> None:
+        data = {"name": "Bob", "status": "inactive"}
+        query, params = builder.build_update(data, "id", "u1")
+        assert "UPDATE resources SET" in query
+        assert "WHERE id = :entity_id" in query
+        assert params["entity_id"] == "u1"
+
+    def test_excludes_id_column_from_set_clause(self, builder: SQLQueryBuilder) -> None:
+        data = {"id": "u1", "name": "Bob"}
+        query, _params = builder.build_update(data, "id", "u1")
+        # The SET clause must not contain id = :id
+        assert "SET id" not in query
+
+    def test_raises_when_no_valid_update_columns(self, builder: SQLQueryBuilder) -> None:
+        with pytest.raises(ValueError, match="No valid columns"):
+            builder.build_update({"unknown_col": "x"}, "id", "u1")
+
+
+class TestBuildDelete:
+    def test_returns_query_and_param_name(self, builder: SQLQueryBuilder) -> None:
+        query, param = builder.build_delete("id")
+        assert "DELETE FROM resources WHERE id = :id" in query
+        assert param == "id"
+
+    def test_rejects_invalid_id_column(self, builder: SQLQueryBuilder) -> None:
+        with pytest.raises(ValueError, match="Invalid SQL identifier"):
+            builder.build_delete("bad col!")
+
+
+class TestBuildExists:
+    def test_returns_limit_1_query(self, builder: SQLQueryBuilder) -> None:
+        query, param = builder.build_exists("id")
+        assert "SELECT 1 FROM resources WHERE id = :id LIMIT 1" in query
+        assert param == "id"
+
+
+class TestBuildCount:
+    def test_returns_count_star_query(self, builder: SQLQueryBuilder) -> None:
+        assert builder.build_count() == "SELECT COUNT(*) FROM resources"
+
+
+class TestBuildSelectByCriteria:
+    def test_empty_criteria_returns_select_all(self, builder: SQLQueryBuilder) -> None:
+        query, params = builder.build_select_by_criteria({})
+        assert query == "SELECT * FROM resources"
+        assert params == {}
+
+    def test_simple_equality_criterion(self, builder: SQLQueryBuilder) -> None:
+        query, params = builder.build_select_by_criteria({"status": "active"})
+        assert "WHERE" in query
+        assert "status = :status_eq" in query
+        assert params["status_eq"] == "active"
+
+    def test_in_operator(self, builder: SQLQueryBuilder) -> None:
+        query, params = builder.build_select_by_criteria({"status": {"$in": ["active", "pending"]}})
+        assert "IN" in query
+        assert params["status_in_0"] == "active"
+        assert params["status_in_1"] == "pending"
+
+    def test_like_operator(self, builder: SQLQueryBuilder) -> None:
+        query, params = builder.build_select_by_criteria({"name": {"$like": "Al%"}})
+        assert "LIKE :name_like" in query
+        assert params["name_like"] == "Al%"
+
+    def test_unknown_columns_are_ignored(self, builder: SQLQueryBuilder) -> None:
+        query, _params = builder.build_select_by_criteria({"unknown_col": "x"})
+        # Falls back to SELECT all when all criteria columns are unknown
+        assert query == "SELECT * FROM resources"
+
+
+class TestBuildBatchInsert:
+    def test_returns_query_and_params_list(self, builder: SQLQueryBuilder) -> None:
+        data_list = [
+            {"id": "u1", "name": "Alice", "status": "active", "created_at": "2024-01-01"},
+            {"id": "u2", "name": "Bob", "status": "inactive", "created_at": "2024-01-02"},
+        ]
+        query, params_list = builder.build_batch_insert(data_list)
+        assert "INSERT INTO resources" in query
+        assert len(params_list) == 2
+
+    def test_raises_on_empty_list(self, builder: SQLQueryBuilder) -> None:
+        with pytest.raises(ValueError, match="No data provided"):
+            builder.build_batch_insert([])
+
+
+class TestQueryTypeEnum:
+    """Verify the QueryType enum values used by build_query dispatch."""
+
+    def test_enum_values(self) -> None:
+        assert QueryType.SELECT == "SELECT"
+        assert QueryType.INSERT == "INSERT"
+        assert QueryType.UPDATE == "UPDATE"
+        assert QueryType.DELETE == "DELETE"
+        assert QueryType.CREATE_TABLE == "CREATE TABLE"

--- a/tests/integration/api/test_api_endpoints.py
+++ b/tests/integration/api/test_api_endpoints.py
@@ -101,7 +101,9 @@ class TestAPIEndpoints:
         assert data["service"] == "open-resource-broker"
         assert data["version"] == __version__
         assert "description" in data
-        assert "auth_enabled" in data
+        # auth_enabled deliberately absent — /info does not disclose
+        # auth configuration to unauthenticated callers.
+        assert "auth_enabled" not in data
 
     def test_openapi_schema(self, client):
         """Test OpenAPI schema endpoint."""

--- a/tests/integration/api/test_authentication_flows.py
+++ b/tests/integration/api/test_authentication_flows.py
@@ -45,9 +45,10 @@ class TestAuthenticationFlows:
         response = client.get("/info")
         assert response.status_code == 200
         data = response.json()
-        assert data["auth_enabled"] is False
-        # auth_strategy is no longer surfaced in the /info response; verify only
-        # that the key is absent rather than asserting a specific value.
+        # auth_enabled and auth_strategy are no longer surfaced on /info —
+        # they were dropped to avoid disclosing auth configuration to
+        # unauthenticated callers.  Verify absence.
+        assert "auth_enabled" not in data
         assert "auth_strategy" not in data
 
     def test_bearer_token_auth_flow(self):
@@ -190,7 +191,8 @@ class TestAuthenticationFlows:
         assert context.client_ip == "127.0.0.1"
 
     def test_excluded_paths(self):
-        """Test that excluded paths bypass authentication."""
+        """Test that /health bypasses auth and docs endpoints are gated when auth is enabled."""
+
         server_config = ServerConfig(  # type: ignore[call-arg]
             enabled=True,
             auth=AuthConfig(  # type: ignore[call-arg]
@@ -204,13 +206,42 @@ class TestAuthenticationFlows:
         app = create_fastapi_app(server_config)
         client = TestClient(app)
 
-        # Test excluded paths (should work without auth)
-        excluded_paths = ["/health", "/docs", "/redoc", "/openapi.json"]
+        # /health is always public regardless of auth configuration.
+        response = client.get("/health")
+        assert response.status_code != 401, "/health should never require authentication"
 
-        for path in excluded_paths:
+        # When auth is enabled and docs.require_auth=True (default), docs endpoints
+        # are protected.  They should return 401 without credentials.
+        for path in ["/docs", "/redoc", "/openapi.json"]:
             response = client.get(path)
-            # Should not return 401 (may return 404 if endpoint doesn't exist)
-            assert response.status_code != 401, f"Path {path} should be excluded from auth"
+            assert response.status_code == 401, (
+                f"Path {path} should require authentication when auth is enabled "
+                "and docs.require_auth=True (default)"
+            )
+
+    def test_excluded_paths_docs_public_when_require_auth_false(self):
+        """Docs endpoints are public when docs.require_auth=False."""
+        from orb.config.schemas.server_schema import DocsConfig
+
+        server_config = ServerConfig(  # type: ignore[call-arg]
+            enabled=True,
+            auth=AuthConfig(  # type: ignore[call-arg]
+                enabled=True,
+                strategy="bearer_token",
+                bearer_token={"secret_key": "test-secret-key-minimum-32-bytes!"},
+            ),
+            cors=CORSConfig(origins=["*"]),  # type: ignore[call-arg]
+            docs=DocsConfig(require_auth=False),  # type: ignore[call-arg]
+        )
+
+        app = create_fastapi_app(server_config)
+        client = TestClient(app)
+
+        for path in ["/docs", "/redoc", "/openapi.json"]:
+            response = client.get(path)
+            assert response.status_code != 401, (
+                f"Path {path} should be public when docs.require_auth=False"
+            )
 
     def test_cors_headers(self):
         """Test CORS headers are properly set."""

--- a/tests/integration/test_configuration_defaults.py
+++ b/tests/integration/test_configuration_defaults.py
@@ -57,13 +57,13 @@ def test_template_defaults_integration():
         print(f"   - Template ID: {template.template_id}")
         print(f"   - Subnet IDs: {template.subnet_ids}")
         print(f"   - Security Groups: {template.security_group_ids}")
-        print(f"   - Instance Type: {template.instance_type}")
+        print(f"   - Machine Type: {template.machine_type}")
         print(f"   - Provider API: {template.provider_api}")
 
         # Verify defaults were applied
         assert template.subnet_ids, "subnet_ids should have defaults applied"
         assert template.security_group_ids, "security_group_ids should have defaults applied"
-        assert template.instance_type, "instance_type should have defaults applied"
+        assert template.machine_type, "machine_type should have defaults applied"
 
         print("PASS: Configuration defaults successfully applied to missing fields")
 

--- a/tests/providers/aws/live/conftest.py
+++ b/tests/providers/aws/live/conftest.py
@@ -28,10 +28,17 @@ def pytest_collection_modifyitems(config, items):
     ``pytestmark`` only works at module-level — conftest-level constants
     are not picked up by pytest's marker discovery. The collection hook
     is the canonical place to bulk-apply markers across a directory.
+
+    ``items`` is the FULL collected list across the pytest session, not
+    just this subtree — filter to items whose path lives under this
+    conftest's directory so we do NOT accidentally mark tests outside
+    this live subtree as serial.
     """
+    subtree = str(Path(__file__).resolve().parent)
     marker = pytest.mark.serial
     for item in items:
-        item.add_marker(marker)
+        if str(item.path).startswith(subtree):
+            item.add_marker(marker)
 
 
 def _find_repo_root(start: Path) -> Path:

--- a/tests/providers/aws/mocked/test_run_instances_gaps.py
+++ b/tests/providers/aws/mocked/test_run_instances_gaps.py
@@ -89,8 +89,8 @@ def _make_launch_template_manager(aws_client: AWSClient) -> AWSLaunchTemplateMan
             lt_data["UserData"] = base64.b64encode(template.user_data.encode()).decode()
         if template.key_name:
             lt_data["KeyName"] = template.key_name
-        if template.instance_profile:
-            lt_data["IamInstanceProfile"] = {"Arn": template.instance_profile}
+        if template.machine_role:
+            lt_data["IamInstanceProfile"] = {"Arn": template.machine_role}
         try:
             resp = aws_client.ec2_client.create_launch_template(
                 LaunchTemplateName=lt_name,
@@ -287,7 +287,7 @@ class TestRunInstancesGaps:
         verify it is present in the launch template version data instead.
         """
         profile_arn = "arn:aws:iam::123456789012:instance-profile/test-profile"
-        template = _run_instances_template(subnet_id, sg_id, instance_profile=profile_arn)
+        template = _run_instances_template(subnet_id, sg_id, machine_role=profile_arn)
         request = _make_request(request_id="req-iam-001")
 
         result = handler.acquire_hosts(request, template)

--- a/tests/providers/aws/unit/strategy/test_aws_provider_strategy_resource_id_pattern.py
+++ b/tests/providers/aws/unit/strategy/test_aws_provider_strategy_resource_id_pattern.py
@@ -1,0 +1,118 @@
+"""Tests for AWSProviderStrategy.get_resource_id_pattern()."""
+
+import re
+
+from orb.providers.aws.strategy.aws_provider_strategy import AWSProviderStrategy
+from orb.providers.base.strategy.provider_strategy import ProviderStrategy
+
+_PATTERN = AWSProviderStrategy.get_resource_id_pattern()
+
+
+# ---------------------------------------------------------------------------
+# Contract
+# ---------------------------------------------------------------------------
+
+
+def test_returns_non_none():
+    """AWS must override the base None default and return a pattern string."""
+    assert _PATTERN is not None
+
+
+def test_return_type_is_str():
+    """Pattern must be a plain string, not bytes or another type."""
+    assert isinstance(_PATTERN, str)
+
+
+def test_overrides_base_class_default():
+    """AWSProviderStrategy must return a different value than the base class."""
+    assert _PATTERN != ProviderStrategy.get_resource_id_pattern()
+
+
+def test_callable_on_class_without_instance():
+    """Must be callable at class level — no boto3 session, config, or I/O needed."""
+    # No AWSProviderConfig constructed here, no AWS credentials required.
+    result = AWSProviderStrategy.get_resource_id_pattern()
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Pattern correctness — AWS instance IDs
+# ---------------------------------------------------------------------------
+
+
+def test_matches_8_char_hex_instance_id():
+    """Standard 8-char hex suffix instance ID (older format)."""
+    assert re.fullmatch(_PATTERN, "i-0abcdef1")  # type: ignore[arg-type]
+
+
+def test_matches_17_char_hex_instance_id():
+    """17-char hex suffix instance ID (current nitro format)."""
+    assert re.fullmatch(_PATTERN, "i-0abcdef12345678a")  # type: ignore[arg-type]
+
+
+def test_matches_typical_production_instance_id():
+    """Typical production-style instance ID used in AWS documentation."""
+    assert re.fullmatch(_PATTERN, "i-0abcdef12345")  # type: ignore[arg-type]
+
+
+def test_rejects_missing_i_prefix():
+    """IDs without the 'i-' prefix must not match."""
+    assert not re.fullmatch(_PATTERN, "0abcdef1234567890")  # type: ignore[arg-type]
+
+
+def test_rejects_azure_style_id():
+    """Azure VM IDs (subscription-scoped ARM paths) must not match."""
+    assert not re.fullmatch(  # type: ignore[arg-type]
+        _PATTERN,
+        "/subscriptions/abc/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
+    )
+
+
+def test_rejects_gcp_numeric_id():
+    """GCP instance numeric IDs must not match."""
+    assert not re.fullmatch(_PATTERN, "1234567890123456789")  # type: ignore[arg-type]
+
+
+def test_rejects_arbitrary_string():
+    """Arbitrary non-ID strings must not match."""
+    assert not re.fullmatch(_PATTERN, "not-an-id")  # type: ignore[arg-type]
+
+
+def test_rejects_uppercase_hex():
+    """AWS instance IDs use lowercase hex only; uppercase must be rejected."""
+    assert not re.fullmatch(_PATTERN, "i-0ABCDEF1")  # type: ignore[arg-type]
+
+
+def test_rejects_empty_string():
+    """Empty string must not match."""
+    assert not re.fullmatch(_PATTERN, "")  # type: ignore[arg-type]
+
+
+def test_rejects_id_with_g_char():
+    """Characters outside [a-f0-9] after the prefix must be rejected."""
+    assert not re.fullmatch(_PATTERN, "i-0abcdefg")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Length bounds — AWS IDs are exactly 8 (legacy) or 17 (modern) hex chars
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_too_short_hex_suffix():
+    """Fewer than 8 hex chars after 'i-' must be rejected."""
+    assert not re.fullmatch(_PATTERN, "i-abc")  # type: ignore[arg-type]
+
+
+def test_rejects_too_long_hex_suffix():
+    """More than 17 hex chars after 'i-' must be rejected (not a valid AWS ID)."""
+    assert not re.fullmatch(_PATTERN, "i-" + "a" * 20)  # type: ignore[arg-type]
+
+
+def test_rejects_exactly_7_hex_chars():
+    """7 hex chars after 'i-' is one short of the minimum 8 — must be rejected."""
+    assert not re.fullmatch(_PATTERN, "i-" + "a" * 7)  # type: ignore[arg-type]
+
+
+def test_rejects_exactly_18_hex_chars():
+    """18 hex chars is one over the maximum 17 — must be rejected."""
+    assert not re.fullmatch(_PATTERN, "i-" + "a" * 18)  # type: ignore[arg-type]

--- a/tests/providers/aws/unit/test_base_context_mixin.py
+++ b/tests/providers/aws/unit/test_base_context_mixin.py
@@ -194,7 +194,7 @@ class TestBaseContextMixin:
         self.template.machine_types = {"t3.medium": 1, "t3.large": 2}
         self.template.key_name = "my-key"
         self.template.user_data = "#!/bin/bash"
-        self.template.instance_profile = "my-profile"
+        self.template.machine_role = "my-profile"
         self.template.ebs_optimized = True
         self.template.monitoring_enabled = False
 

--- a/tests/providers/aws/unit/test_base_context_mixin.py
+++ b/tests/providers/aws/unit/test_base_context_mixin.py
@@ -214,6 +214,7 @@ class TestBaseContextMixin:
         self.template.subnet_ids = None
         self.template.security_group_ids = None
         self.template.instance_types = None
+        self.template.machine_role = None
 
         result = self.mixin._prepare_standard_flags(self.template)
 

--- a/tests/providers/aws/unit/test_iam_strategy.py
+++ b/tests/providers/aws/unit/test_iam_strategy.py
@@ -628,6 +628,274 @@ def test_iam_required_actions_none_applies_defaults(monkeypatch):
     assert "ec2:TerminateInstances" in strategy.required_actions
 
 
+# ---------------------------------------------------------------------------
+# admin_arns allowlist — exact-match security tests
+# ---------------------------------------------------------------------------
+
+
+def _make_strategy_with_admin_arns(admin_arns: list[str]) -> Any:
+    """Build IAMAuthStrategy with a specific admin_arns allowlist."""
+    from orb.providers.aws.auth.iam_strategy import IAMAuthStrategy
+
+    logger = _make_logger()
+
+    with patch("orb.providers.aws.auth.iam_strategy.AWSSessionFactory") as mock_factory:
+        mock_session = MagicMock()
+        mock_sts = MagicMock()
+        mock_iam = MagicMock()
+        mock_session.client.side_effect = lambda svc, **kw: mock_sts if svc == "sts" else mock_iam
+        mock_factory.create_session.return_value = mock_session
+
+        strategy = IAMAuthStrategy(
+            logger=logger,
+            region="us-east-1",
+            admin_arns=admin_arns,
+        )
+
+    strategy.sts_client = mock_sts
+    strategy.iam_client = mock_iam
+    return strategy
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_arns_exact_match_grants_admin():
+    """A caller whose ARN exactly matches an admin_arns entry receives the admin role."""
+    admin_arn = "arn:aws:iam::123456789012:role/OrbAdmin"
+    strategy = _make_strategy_with_admin_arns([admin_arn])
+
+    roles = await strategy._determine_roles(
+        {"Arn": admin_arn},
+        [],
+    )
+
+    assert "admin" in roles
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_arns_case_insensitive_match_grants_admin():
+    """Matching is case-insensitive — mixed-case caller ARN still passes."""
+    strategy = _make_strategy_with_admin_arns(["arn:aws:iam::123456789012:role/orbadmin"])
+
+    # Caller ARN uses different casing — should still match after normalisation.
+    roles = await strategy._determine_roles(
+        {"Arn": "arn:aws:iam::123456789012:role/OrbAdmin"},
+        [],
+    )
+
+    assert "admin" in roles
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_arns_substring_bypass_rejected_prefix_attack():
+    """
+    Substring-bypass attempt: caller ARN that STARTS WITH the admin ARN is rejected.
+
+    A naive `if admin_arn in caller_arn` check would pass this because the admin
+    ARN string is a substring of the longer attacker ARN.  The exact-match check
+    must reject it.
+    """
+    admin_arn = "arn:aws:iam::123456789012:role/OrbAdmin"
+    attacker_arn = admin_arn + "_malicious_suffix"
+
+    strategy = _make_strategy_with_admin_arns([admin_arn])
+
+    roles = await strategy._determine_roles(
+        {"Arn": attacker_arn},
+        [],
+    )
+
+    assert "admin" not in roles
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_arns_substring_bypass_rejected_suffix_attack():
+    """
+    Substring-bypass attempt: caller ARN that CONTAINS the admin ARN as a segment
+    is rejected.
+
+    Example: attacker creates a role whose name embeds the admin ARN verbatim.
+    The set membership check (`caller_arn_lower in admin_arns_set`) is an exact
+    equality test and must not treat either string as a substring of the other.
+    """
+    admin_arn = "arn:aws:iam::123456789012:role/OrbAdmin"
+    # Attacker encodes the admin ARN inside their own ARN path segment.
+    attacker_arn = f"arn:aws:iam::999999999999:role/{admin_arn}"
+
+    strategy = _make_strategy_with_admin_arns([admin_arn])
+
+    roles = await strategy._determine_roles(
+        {"Arn": attacker_arn},
+        [],
+    )
+
+    assert "admin" not in roles
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_arns_different_account_rejected():
+    """
+    A principal with the same role name but from a different AWS account is rejected.
+
+    This tests the cross-account bypass that the legacy name-pattern check is
+    vulnerable to (it only inspects the resource segment, not the account ID).
+    """
+    admin_arn = "arn:aws:iam::123456789012:role/OrbAdmin"
+    # Same role name, different account ID.
+    other_account_arn = "arn:aws:iam::999999999999:role/OrbAdmin"
+
+    strategy = _make_strategy_with_admin_arns([admin_arn])
+
+    roles = await strategy._determine_roles(
+        {"Arn": other_account_arn},
+        [],
+    )
+
+    assert "admin" not in roles
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_arns_empty_list_falls_back_to_role_patterns():
+    """
+    When admin_arns is empty, the legacy name-pattern fallback still works.
+
+    This ensures backward compatibility for deployments that have not yet
+    configured an explicit admin_arns allowlist.
+    """
+    strategy = _make_strategy_with_admin_arns([])
+
+    # Legacy pattern: ARN whose resource name is "Admin" matches _DEFAULT_ADMIN_ROLE_PATTERNS.
+    roles = await strategy._determine_roles(
+        {"Arn": "arn:aws:iam::123456789012:user/Admin"},
+        [],
+    )
+
+    assert "admin" in roles
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_admin_arns_non_admin_caller_is_not_elevated():
+    """A caller not in the admin_arns allowlist does not receive the admin role."""
+    admin_arn = "arn:aws:iam::123456789012:role/OrbAdmin"
+    unrelated_arn = "arn:aws:iam::123456789012:role/ReadOnlyRole"
+
+    strategy = _make_strategy_with_admin_arns([admin_arn])
+
+    roles = await strategy._determine_roles(
+        {"Arn": unrelated_arn},
+        [],
+    )
+
+    assert "admin" not in roles
+
+
+@pytest.mark.unit
+def test_admin_arns_stored_as_lowercase_frozenset():
+    """
+    admin_arns are normalised to lowercase at construction time and stored in a
+    frozenset.  This guarantees the runtime lookup is a set __contains__ call
+    (exact equality) rather than any form of substring search.
+    """
+    mixed_case_arn = "arn:aws:IAM::123456789012:role/OrbAdmin"
+    strategy = _make_strategy_with_admin_arns([mixed_case_arn])
+
+    assert isinstance(strategy._admin_arns, frozenset)
+    assert mixed_case_arn.lower() in strategy._admin_arns
+    # The original mixed-case form must NOT appear — only the lowercased one.
+    assert mixed_case_arn not in strategy._admin_arns
+
+
+@pytest.mark.unit
+def test_from_auth_config_passes_admin_arns():
+    """from_auth_config propagates admin_arns from IAMAuthSubConfig."""
+    from orb.config.schemas.server_schema import AuthConfig, IAMAuthSubConfig, ProviderAuthSubConfig
+
+    admin_arn = "arn:aws:iam::123456789012:role/OrbAdmin"
+    auth_config = AuthConfig(  # type: ignore[call-arg]
+        strategy="iam",
+        provider_auth=ProviderAuthSubConfig(  # type: ignore[call-arg]
+            iam=IAMAuthSubConfig(admin_arns=[admin_arn])  # type: ignore[call-arg]
+        ),
+    )
+
+    with patch("orb.providers.aws.auth.iam_strategy.AWSSessionFactory") as mock_factory:
+        mock_session = MagicMock()
+        mock_session.client.return_value = MagicMock()
+        mock_factory.create_session.return_value = mock_session
+
+        from orb.providers.aws.auth.iam_strategy import IAMAuthStrategy
+
+        strategy = IAMAuthStrategy.from_auth_config(auth_config)
+
+    assert admin_arn.lower() in strategy._admin_arns
+
+
+# ---------------------------------------------------------------------------
+# admin_arns allowlist — :root unconditional bypass regression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_root_arn_does_not_bypass_admin_arns_allowlist():
+    """
+    When admin_arns is non-empty, a :root ARN from any account must NOT receive
+    admin unless it is explicitly listed.
+
+    The old code granted admin unconditionally to any :root credential even when
+    an explicit allowlist was configured, violating the "exact allowlist" contract.
+    """
+    # Only this specific role is in the allowlist — root is deliberately NOT listed.
+    admin_arn = "arn:aws:iam::123456789012:role/DevAdmin"
+    strategy = _make_strategy_with_admin_arns([admin_arn])
+
+    # Attacker presents :root credentials from a different AWS account.
+    root_arn = "arn:aws:iam::999999999999:root"
+
+    roles = await strategy._determine_roles({"Arn": root_arn}, [])
+
+    assert "admin" not in roles, (
+        ":root must not bypass the admin_arns allowlist — "
+        "include the root ARN explicitly if root needs admin access."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_root_arn_in_admin_arns_allowlist_is_granted_admin():
+    """
+    When the :root ARN is explicitly included in admin_arns it must be granted admin.
+    Operators who need root admin access should list the ARN explicitly.
+    """
+    root_arn = "arn:aws:iam::123456789012:root"
+    strategy = _make_strategy_with_admin_arns([root_arn])
+
+    roles = await strategy._determine_roles({"Arn": root_arn}, [])
+
+    assert "admin" in roles
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_root_arn_legacy_path_still_grants_admin_when_no_allowlist():
+    """
+    When admin_arns is empty (no explicit allowlist), the legacy :root fallback
+    continues to work for backward compatibility.
+    """
+    strategy = _make_strategy_with_admin_arns([])
+
+    root_arn = "arn:aws:iam::123456789012:root"
+    roles = await strategy._determine_roles({"Arn": root_arn}, [])
+
+    assert "admin" in roles
+
+
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_iam_check_permissions_empty_required_actions_returns_empty_granted():

--- a/tests/providers/aws/unit/test_launch_template_manager.py
+++ b/tests/providers/aws/unit/test_launch_template_manager.py
@@ -193,7 +193,7 @@ class TestAWSLaunchTemplateManager:
 
     def test_create_launch_template_data_iam_instance_profile(self):
         """Test launch template data creation with IAM instance profile."""
-        self.aws_template.instance_profile = "test-instance-profile"
+        self.aws_template.machine_role = "test-instance-profile"
 
         data = self.manager._create_launch_template_data_legacy(self.aws_template, self.request)
 

--- a/tests/providers/k8s/live/conftest.py
+++ b/tests/providers/k8s/live/conftest.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from pathlib import Path
 from typing import Generator
 
 import pytest
@@ -40,13 +41,17 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     ``pytestmark`` at module level is not picked up by conftest-level
     discovery; the collection hook is the canonical place to bulk-apply
     markers across a directory subtree.
-    """
-    import pathlib
 
-    live_dir = str(pathlib.Path(__file__).parent)
+    ``items`` is the FULL collected list across the pytest session, not
+    just this subtree — filter to items whose path lives under this
+    conftest's directory so we do NOT accidentally mark
+    unit/mocked/contract tests as serial when the parent
+    ``tests/providers/k8s`` directory is collected as a whole.
+    """
+    subtree = str(Path(__file__).resolve().parent)
     marker = pytest.mark.serial
     for item in items:
-        if str(item.fspath).startswith(live_dir):
+        if str(item.path).startswith(subtree):
             item.add_marker(marker)
 
 

--- a/tests/providers/k8s/unit/configuration/test_template_extension.py
+++ b/tests/providers/k8s/unit/configuration/test_template_extension.py
@@ -131,10 +131,13 @@ class TestExtensionRegistration:
     """Verify the DTO config is wired into ``TemplateExtensionRegistry``."""
 
     def test_extension_registered_after_bootstrap(self) -> None:
-        """Running k8s extension registration wires the DTO config into the registry."""
-        # Registration is an explicit call, not an import side-effect — invoke it
-        # directly so the test is self-contained and order-independent (it must not
-        # rely on another test having bootstrapped the global registry first).
+        """Calling the explicit lifecycle hook registers the DTO config.
+
+        Module-level auto-registration was removed to keep import-time
+        side effects predictable; extension registration now runs through
+        the explicit ``initialize_k8s_provider`` path (or the standalone
+        ``register_k8s_extensions`` helper for tests).
+        """
         from orb.infrastructure.registry.template_extension_registry import (
             TemplateExtensionRegistry,
         )

--- a/tests/providers/k8s/unit/domain/template/test_k8s_template.py
+++ b/tests/providers/k8s/unit/domain/template/test_k8s_template.py
@@ -5,7 +5,7 @@ Covers:
 * the generic ``Template.image_id`` is the single source of truth for
   the container image; shadow fields are gone.
 * :attr:`K8sTemplate.service_account` falls back to
-  :attr:`Template.instance_profile` via the ``after`` model-validator.
+  :attr:`Template.machine_role` via the ``after`` model-validator.
 * :meth:`K8sTemplate.resolve_pod_labels` projects ``Template.tags`` into
   string-keyed string-valued k8s labels, dropping ``None`` entries.
 * :meth:`upcast_to_k8s_template` is a clean round-trip from a generic
@@ -103,30 +103,45 @@ def test_extension_config_does_not_define_container_image() -> None:
 
 
 # ---------------------------------------------------------------------------
-# service_account fallback to instance_profile
+# service_account fallback to machine_role
 # ---------------------------------------------------------------------------
 
 
-def test_service_account_falls_back_to_instance_profile() -> None:
+def test_service_account_falls_back_to_machine_role() -> None:
     t = K8sTemplate(
         template_id="tpl",
         image_id="busybox:latest",
-        instance_profile="my-svc-acct",
+        machine_role="my-svc-acct",
     )
     assert t.service_account == "my-svc-acct"
 
 
-def test_explicit_service_account_wins_over_instance_profile() -> None:
+def test_service_account_falls_back_to_machine_role_via_deprecated_instance_profile() -> None:
+    """Old instance_profile kwarg still works via the DeprecationWarning path."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        t = K8sTemplate(
+            template_id="tpl",
+            image_id="busybox:latest",
+            instance_profile="my-svc-acct",
+        )
+        assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
+    assert t.service_account == "my-svc-acct"
+
+
+def test_explicit_service_account_wins_over_machine_role() -> None:
     t = K8sTemplate(
         template_id="tpl",
         image_id="busybox:latest",
-        instance_profile="instance-profile-name",
+        machine_role="machine-role-name",
         service_account="explicit-sa",
     )
     assert t.service_account == "explicit-sa"
 
 
-def test_no_instance_profile_leaves_service_account_unset() -> None:
+def test_no_machine_role_leaves_service_account_unset() -> None:
     t = K8sTemplate(template_id="tpl", image_id="busybox:latest")
     assert t.service_account is None
 
@@ -164,7 +179,7 @@ def test_upcast_from_generic_template_round_trips_cleanly() -> None:
         image_id="busybox:latest",
         max_instances=4,
         tags={"team": "ml"},
-        instance_profile="svc-acct",
+        machine_role="svc-acct",
     )
     k8s = upcast_to_k8s_template(base)
     assert isinstance(k8s, K8sTemplate)

--- a/tests/providers/k8s/unit/handlers/test_statefulset_handler.py
+++ b/tests/providers/k8s/unit/handlers/test_statefulset_handler.py
@@ -31,7 +31,6 @@ from orb.domain.request.aggregate import Request
 from orb.domain.request.value_objects import RequestId, RequestType
 from orb.domain.template.template_aggregate import Template
 from orb.providers.k8s.configuration.config import K8sProviderConfig
-from orb.providers.k8s.exceptions.k8s_exceptions import K8sError
 from orb.providers.k8s.infrastructure.handlers.statefulset_handler import K8sStatefulSetHandler
 
 # ---------------------------------------------------------------------------
@@ -247,15 +246,19 @@ async def test_release_hosts_selective_highest_ordinal_no_warning() -> None:
 
 
 @pytest.mark.asyncio
-async def test_release_hosts_selective_non_highest_ordinal_refused() -> None:
-    """When the victims are not the top-of-stack ordinals, the handler
-    raises K8sError and issues no scale patch.
+async def test_release_hosts_selective_non_highest_ordinal_raises_and_does_not_scale() -> None:
+    """When the victims include non-highest ordinals, the handler refuses
+    the request with ``K8sError`` and does NOT patch the StatefulSet.
 
-    Commit b4a77b1a deliberately changed this behaviour: silently evicting
-    different pods (the controller always picks the highest-ordinal set)
-    would cause data loss, so the handler refuses the request and tells
-    the caller which victims to supply instead.
+    The controller only supports scale-down from the top of the ordinal
+    stack; the previous warn-and-scale behaviour silently mutated a
+    different pod than the caller asked for, so the current
+    implementation raises instead — see the sibling test module
+    ``test_statefulset_release_reject.py`` for the guard function's own
+    unit coverage.
     """
+    from orb.providers.k8s.exceptions.k8s_exceptions import K8sError
+
     core_v1 = MagicMock()
     apps_v1 = MagicMock()
     apps_v1.read_namespaced_stateful_set.return_value = _make_statefulset_status(spec_replicas=5)
@@ -271,30 +274,22 @@ async def test_release_hosts_selective_non_highest_ordinal_refused() -> None:
     )
 
     # current=5, victims=[ordinal-1, ordinal-2] — non-highest ordinals.
-    # The controller would evict ordinals 3 and 4 instead, so the handler
-    # refuses rather than silently releasing the wrong pods.
-    with pytest.raises(K8sError) as exc_info:
+    with pytest.raises(K8sError, match="selective release refused"):
         await handler.release_hosts(["orb-deadbeef-1", "orb-deadbeef-2"], request.provider_data)
 
-    # The error message must mention the correct top-of-stack victims.
-    assert "orb-deadbeef-3" in str(exc_info.value) or "orb-deadbeef-4" in str(exc_info.value)
-
-    # Refusal happens before any scale patch — the StatefulSet must be
-    # left untouched.
+    # Nothing was mutated — neither a scale patch nor a pod deletion.
     apps_v1.patch_namespaced_stateful_set_scale.assert_not_called()
-
-    # Pods are NEVER deleted directly.
     core_v1.delete_namespaced_pod.assert_not_called()
     apps_v1.delete_namespaced_stateful_set.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_release_hosts_selective_unparseable_victim_names_refused() -> None:
+async def test_release_hosts_selective_unparseable_victim_names_raises() -> None:
     """Victim names that do not parse as ``<statefulset>-<ordinal>`` are
-    refused with K8sError — an unparseable name cannot be the top-of-
-    stack ordinal, so honouring the request would silently evict the
-    wrong pods.
-    """
+    treated as non-top-of-stack and therefore refused, since the
+    controller cannot guarantee they will be the ones evicted."""
+    from orb.providers.k8s.exceptions.k8s_exceptions import K8sError
+
     core_v1 = MagicMock()
     apps_v1 = MagicMock()
     apps_v1.read_namespaced_stateful_set.return_value = _make_statefulset_status(spec_replicas=3)
@@ -309,15 +304,10 @@ async def test_release_hosts_selective_unparseable_victim_names_refused() -> Non
         namespace="orb-test",
     )
 
-    # Victim name does not match the StatefulSet's name prefix — its
-    # ordinal cannot be parsed, so the handler refuses rather than
-    # silently releasing the wrong pod.
-    with pytest.raises(K8sError):
+    with pytest.raises(K8sError, match="selective release refused"):
         await handler.release_hosts(["some-other-pod"], request.provider_data)
 
-    # Refusal happens before any scale patch.
     apps_v1.patch_namespaced_stateful_set_scale.assert_not_called()
-    # Pods are NEVER deleted directly.
     core_v1.delete_namespaced_pod.assert_not_called()
     apps_v1.delete_namespaced_stateful_set.assert_not_called()
 

--- a/tests/providers/k8s/unit/test_coverage_gaps.py
+++ b/tests/providers/k8s/unit/test_coverage_gaps.py
@@ -12,8 +12,8 @@ Scenarios tested (one section per gap):
    circuit in Wave 2; a smoke assertion confirms the test file exists.
 5. native_spec list-replacement — operator's ``spec.containers`` list
    fully replaces the default; the default container is dropped.
-6. service_account fallback to instance_profile — ``build_pod_spec``
-   puts ``serviceAccountName`` from ``instance_profile`` when
+6. service_account fallback to machine_role — ``build_pod_spec``
+   puts ``serviceAccountName`` from ``machine_role`` when
    ``service_account`` is not set.
 7. check_health with kubernetes extra absent — ``sys.modules`` patched to
    simulate missing ``kubernetes``; strategy returns unhealthy with a
@@ -359,7 +359,7 @@ def test_native_spec_containers_list_replaces_default() -> None:
 
 
 # ===========================================================================
-# 6. service_account fallback to instance_profile
+# 6. service_account fallback to machine_role
 # ===========================================================================
 
 
@@ -386,10 +386,10 @@ def test_build_pod_spec_uses_service_account_when_set() -> None:
     assert pod.spec.service_account_name == "explicit-sa"
 
 
-def test_build_pod_spec_falls_back_to_instance_profile() -> None:
-    """When service_account is absent, instance_profile is used as serviceAccountName.
+def test_build_pod_spec_falls_back_to_machine_role() -> None:
+    """When service_account is absent, machine_role is used as serviceAccountName.
 
-    ``K8sTemplate``'s model validator copies ``instance_profile`` into
+    ``K8sTemplate``'s model validator copies ``machine_role`` into
     ``service_account`` when the latter is not set; ``build_pod_spec``
     then writes it as ``spec.service_account_name``.
     """
@@ -401,7 +401,7 @@ def test_build_pod_spec_falls_back_to_instance_profile() -> None:
         image_id="busybox:latest",
         namespace="orb-test",
         max_instances=2,
-        instance_profile="fallback-sa",
+        machine_role="fallback-sa",
         # service_account is intentionally absent.
     )
     request = _make_request()
@@ -412,12 +412,12 @@ def test_build_pod_spec_falls_back_to_instance_profile() -> None:
         machine_id="orb-test-0001",
         namespace="orb-test",
     )
-    # The model validator promotes instance_profile -> service_account.
+    # The model validator promotes machine_role -> service_account.
     assert pod.spec.service_account_name == "fallback-sa"
 
 
 def test_build_pod_spec_no_service_account_when_both_absent() -> None:
-    """When neither service_account nor instance_profile is set, no serviceAccountName."""
+    """When neither service_account nor machine_role is set, no serviceAccountName."""
     from orb.providers.k8s.domain.template.k8s_template_aggregate import K8sTemplate
     from orb.providers.k8s.utilities.pod_spec import build_pod_spec
 
@@ -487,18 +487,18 @@ def test_check_health_returns_unhealthy_when_kubernetes_package_absent(
 
 
 @pytest.mark.asyncio
-async def test_job_release_logs_selective_release_not_supported() -> None:
-    """release_hosts with a partial machine_ids list must raise K8sError when
-    parallelism is known, refusing the subset release.
+async def test_job_release_refuses_selective_release() -> None:
+    """release_hosts with a partial machine_ids list must refuse.
 
-    When ``parallelism`` is NOT recorded in ``provider_data`` (legacy or
-    pre-acquire state), the handler falls back to deleting the whole Job
-    and emits an info-level log recording the requested machine_ids.
-
-    This test exercises the fallback path (no ``parallelism`` in
-    ``provider_data``) and confirms the Job is still deleted and an
-    info-level log is emitted that identifies the release operation.
+    A Job's atomic unit is the whole Job — deleting the Job takes down
+    every pod it spawned.  A caller asking to release only a subset of
+    pods is semantically incoherent; the handler raises ``K8sError``
+    instead of silently deleting the whole Job (the previous
+    log-and-continue behaviour was misleading).  See the sibling test
+    module ``test_job_release_reject.py`` for direct guard-function
+    coverage.
     """
+    from orb.providers.k8s.exceptions.k8s_exceptions import K8sError
     from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
 
     batch_v1 = MagicMock()
@@ -517,31 +517,22 @@ async def test_job_release_logs_selective_release_not_supported() -> None:
         requested_count=1,
         provider_api="Job",
     )
-    # Job release deletes the whole Job (selective release is unsupported).
-    # provider_data records parallelism=1 (as acquire_hosts stamps it), and the
-    # caller releases the single pod that covers the whole Job — a full release,
-    # which is honoured (a strict subset would be refused).
+    # Override provider_data with a stable job_name so we don't need to
+    # call acquire first.  ``parallelism`` records how many pods the Job
+    # was created with — the handler compares that against the length
+    # of ``machine_ids`` to detect a partial-release attempt.
     object.__setattr__(
         request,
         "provider_data",
-        {"namespace": "orb-test", "job_name": "orb-testreq1", "parallelism": 1},
+        {"namespace": "orb-test", "job_name": "orb-testreq1", "parallelism": 3},
     )
 
-    # Full release: the one machine_id covers the whole (parallelism=1) Job,
-    # so the handler deletes the entire Job.
-    await handler.release_hosts(["orb-testreq1-pod0"], request.provider_data)
+    # Selective release: caller only passes one of the three pods.
+    with pytest.raises(K8sError, match="selective release"):
+        await handler.release_hosts(["orb-testreq1-pod0"], request.provider_data)
 
-    # The whole Job must have been deleted.
-    batch_v1.delete_namespaced_job.assert_called_once()
-
-    # An info-level message must record the job release operation with the
-    # requested machine_ids (the log reads "deleting whole Job").
-    info_calls = logger.info.call_args_list
-    release_log = any("job release" in str(call).lower() for call in info_calls)
-    assert release_log, (
-        "Expected an info-level log message about the job release operation; "
-        f"info calls: {info_calls}"
-    )
+    # The Job must NOT have been deleted (guard refuses upfront).
+    batch_v1.delete_namespaced_job.assert_not_called()
 
 
 # ===========================================================================

--- a/tests/unit/api/test_templates_router.py
+++ b/tests/unit/api/test_templates_router.py
@@ -165,6 +165,90 @@ class TestTemplatesRouter:
         inp = orchestrator.execute.call_args.args[0]
         assert inp.description == "my desc"
 
+    def test_create_template_machine_type_passed_to_orchestrator(self, templates_app):
+        """Sending machine_type in create request propagates it as machine_type on the input DTO."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=CreateTemplateOutput(template_id="tpl-mt", created=True)
+        )
+        client = self._make_client(
+            templates_app, {get_create_template_orchestrator: lambda: orchestrator}
+        )
+
+        client.post("/templates/", json={"template_id": "tpl-mt", "machine_type": "m5.large"})
+
+        inp = orchestrator.execute.call_args.args[0]
+        assert inp.machine_type == "m5.large"
+        assert inp.instance_type is None
+
+    def test_create_template_instance_type_used_as_fallback(self, templates_app):
+        """Sending only instance_type (deprecated) still works; machine_type on DTO is None."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=CreateTemplateOutput(template_id="tpl-it", created=True)
+        )
+        client = self._make_client(
+            templates_app, {get_create_template_orchestrator: lambda: orchestrator}
+        )
+
+        client.post("/templates/", json={"template_id": "tpl-it", "instance_type": "t3.micro"})
+
+        inp = orchestrator.execute.call_args.args[0]
+        # machine_type should reflect the resolved value (from instance_type fallback in router)
+        assert inp.machine_type == "t3.micro"
+
+    def test_create_template_machine_type_wins_over_instance_type(self, templates_app):
+        """When both machine_type and instance_type are provided, machine_type takes precedence."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=CreateTemplateOutput(template_id="tpl-both", created=True)
+        )
+        client = self._make_client(
+            templates_app, {get_create_template_orchestrator: lambda: orchestrator}
+        )
+
+        client.post(
+            "/templates/",
+            json={
+                "template_id": "tpl-both",
+                "machine_type": "m5.xlarge",
+                "instance_type": "t3.micro",
+            },
+        )
+
+        inp = orchestrator.execute.call_args.args[0]
+        assert inp.machine_type == "m5.xlarge"
+
+    def test_update_template_machine_type_passed_to_orchestrator(self, templates_app):
+        """Sending machine_type in update request propagates it to the orchestrator."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=UpdateTemplateOutput(template_id="tpl-1", updated=True)
+        )
+        client = self._make_client(
+            templates_app, {get_update_template_orchestrator: lambda: orchestrator}
+        )
+
+        client.put("/templates/tpl-1", json={"machine_type": "c5.2xlarge"})
+
+        inp = orchestrator.execute.call_args.args[0]
+        assert inp.machine_type == "c5.2xlarge"
+
+    def test_update_template_instance_type_used_as_fallback(self, templates_app):
+        """Sending only instance_type (deprecated) in update still resolves to machine_type."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=UpdateTemplateOutput(template_id="tpl-1", updated=True)
+        )
+        client = self._make_client(
+            templates_app, {get_update_template_orchestrator: lambda: orchestrator}
+        )
+
+        client.put("/templates/tpl-1", json={"instance_type": "r5.large"})
+
+        inp = orchestrator.execute.call_args.args[0]
+        assert inp.machine_type == "r5.large"
+
     def test_create_template_returns_validation_errors_in_body(self, templates_app):
         orchestrator = AsyncMock()
         orchestrator.execute = AsyncMock(

--- a/tests/unit/application/commands/test_template_command_handlers.py
+++ b/tests/unit/application/commands/test_template_command_handlers.py
@@ -1,5 +1,6 @@
 """Unit tests for template command handlers — TDD for store-unification fix."""
 
+import logging
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -238,3 +239,86 @@ async def test_update_validation_errors_sets_updated_false() -> None:
     assert command.updated is False
     assert command.validation_errors == ["invalid field"]
     manager.save_template.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Deprecation warning tests — application-layer handler boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_handler_warns_on_instance_type(caplog) -> None:
+    """CreateTemplateHandler emits logger.warning when instance_type is used."""
+    manager = _make_manager(existing=None)
+    port = _make_template_port(manager)
+    handler = _make_create_handler(port)
+
+    command = CreateTemplateCommand(
+        template_id="tpl-dep-1",
+        provider_api="EC2Fleet",
+        image_id="ami-000",
+        instance_type="m5.xlarge",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="orb.application.commands.template_handlers"):
+        await handler.handle(command)
+
+    assert command.created is True
+    assert any(
+        "instance_type" in r.message and "deprecated" in r.message for r in caplog.records
+    ), f"Expected deprecation log for instance_type; got: {[r.message for r in caplog.records]}"
+
+    # Value is mapped into machine_types on the saved DTO
+    saved = manager.save_template.call_args[0][0]
+    assert saved.machine_types == {"m5.xlarge": 1}
+
+
+@pytest.mark.asyncio
+async def test_update_handler_warns_on_instance_type(caplog) -> None:
+    """UpdateTemplateHandler emits logger.warning when instance_type is used."""
+    existing = _make_dto()
+    manager = _make_manager(existing=existing)
+    port = _make_template_port(manager)
+    handler = _make_update_handler(port)
+
+    command = UpdateTemplateCommand(
+        template_id="tpl-dep-2",
+        instance_type="c5.2xlarge",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="orb.application.commands.template_handlers"):
+        await handler.handle(command)
+
+    assert command.updated is True
+    assert any(
+        "instance_type" in r.message and "deprecated" in r.message for r in caplog.records
+    ), f"Expected deprecation log for instance_type; got: {[r.message for r in caplog.records]}"
+
+    # Value is mapped into machine_types on the saved DTO
+    saved = manager.save_template.call_args[0][0]
+    assert saved.machine_types == {"c5.2xlarge": 1}
+
+
+@pytest.mark.asyncio
+async def test_create_handler_no_warn_without_instance_type(caplog) -> None:
+    """CreateTemplateHandler does NOT emit a deprecation log when machine_type is used."""
+    manager = _make_manager(existing=None)
+    port = _make_template_port(manager)
+    handler = _make_create_handler(port)
+
+    command = CreateTemplateCommand(
+        template_id="tpl-nodep-1",
+        provider_api="EC2Fleet",
+        image_id="ami-000",
+        machine_type="t3.medium",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="orb.application.commands.template_handlers"):
+        await handler.handle(command)
+
+    deprecation_records = [
+        r for r in caplog.records if "instance_type" in r.message and "deprecated" in r.message
+    ]
+    assert not deprecation_records, (
+        f"Unexpected deprecation log when using machine_type: {[r.message for r in deprecation_records]}"
+    )

--- a/tests/unit/application/services/orchestration/test_dashboard_summary.py
+++ b/tests/unit/application/services/orchestration/test_dashboard_summary.py
@@ -192,7 +192,7 @@ class TestDashboardSummaryOrchestrator:
 
     @pytest.mark.asyncio
     async def test_well_known_keys_present_even_when_count_is_zero(self):
-        """Missing well-known keys must be defaulted to 0."""
+        """Machine and request status keys are zero-padded; template keys come from actual data."""
         orchestrator = _make_orchestrator(
             machine_by_status={"running": 1},
             request_by_status={"pending": 1},

--- a/tests/unit/architecture/test_cli_infrastructure_boundary.py
+++ b/tests/unit/architecture/test_cli_infrastructure_boundary.py
@@ -38,6 +38,7 @@ _KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset(
         ("cli/main.py", "orb.infrastructure.di.container"),
         ("cli/factories/provider_command_factory.py", "orb.infrastructure.utilities.json_utils"),
         ("cli/args.py", "orb.infrastructure.registry.cli_spec_registry"),
+        ("cli/parsers/common_args.py", "orb.infrastructure.registry.cli_spec_registry"),
     }
 )
 

--- a/tests/unit/cli/test_common_args.py
+++ b/tests/unit/cli/test_common_args.py
@@ -109,11 +109,11 @@ class TestAddProviderTypeArg:
         """Simulates a new provider type being registered before build time."""
         from orb.infrastructure.registry.cli_spec_registry import CLISpecRegistry
 
-        original_specs = dict(CLISpecRegistry._specs)
+        original_specs = dict(CLISpecRegistry._store)
         try:
             # Install a fake spec so the registry returns an extra type.
             fake_spec = object()
-            CLISpecRegistry._specs["fake-provider"] = fake_spec  # type: ignore[assignment]
+            CLISpecRegistry._store["fake-provider"] = fake_spec  # type: ignore[assignment]
 
             parser = _fresh_parser()
             add_provider_type_arg(parser)
@@ -124,15 +124,15 @@ class TestAddProviderTypeArg:
             assert action.choices is not None
             assert "fake-provider" in action.choices
         finally:
-            CLISpecRegistry._specs = original_specs
+            CLISpecRegistry._store = original_specs
 
     def test_no_choices_without_registry_entries(self):
         """When the registry is empty, choices is None (open-ended)."""
         from orb.infrastructure.registry.cli_spec_registry import CLISpecRegistry
 
-        original_specs = dict(CLISpecRegistry._specs)
+        original_specs = dict(CLISpecRegistry._store)
         try:
-            CLISpecRegistry._specs = {}
+            CLISpecRegistry._store = {}
 
             parser = _fresh_parser()
             add_provider_type_arg(parser)
@@ -142,7 +142,7 @@ class TestAddProviderTypeArg:
             )
             assert action.choices is None
         finally:
-            CLISpecRegistry._specs = original_specs
+            CLISpecRegistry._store = original_specs
 
     def test_extra_help_is_appended(self):
         parser = _fresh_parser()
@@ -265,10 +265,10 @@ class TestRegisteredProviderTypes:
     def test_tolerates_empty_registry(self):
         from orb.infrastructure.registry.cli_spec_registry import CLISpecRegistry
 
-        original = dict(CLISpecRegistry._specs)
+        original = dict(CLISpecRegistry._store)
         try:
-            CLISpecRegistry._specs = {}
+            CLISpecRegistry._store = {}
             result = _registered_provider_types()
             assert result == []
         finally:
-            CLISpecRegistry._specs = original
+            CLISpecRegistry._store = original

--- a/tests/unit/cli/test_common_args.py
+++ b/tests/unit/cli/test_common_args.py
@@ -1,0 +1,274 @@
+"""Tests for the shared CLI argument helpers in orb.cli.parsers.common_args.
+
+Covers:
+  - add_provider_type_arg produces a parser that accepts each registered type
+  - add_provider_type_arg rejects unknown values when choices are populated
+  - choices reflect registry contents (dynamic registration)
+  - regression guard: build_parser() raises no argparse conflict error
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from orb.cli.parsers.common_args import _registered_provider_types, add_provider_type_arg
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fresh_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser()
+
+
+def _parse(parser: argparse.ArgumentParser, args: list[str]) -> argparse.Namespace:
+    return parser.parse_args(args)
+
+
+# ---------------------------------------------------------------------------
+# add_provider_type_arg unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAddProviderTypeArg:
+    def test_adds_provider_type_argument(self):
+        parser = _fresh_parser()
+        add_provider_type_arg(parser)
+        all_opts = [
+            opt for action in parser._actions for opt in getattr(action, "option_strings", [])
+        ]
+        assert "--provider-type" in all_opts
+
+    def test_dest_is_provider_type(self):
+        parser = _fresh_parser()
+        add_provider_type_arg(parser)
+        action = next(
+            a for a in parser._actions if "--provider-type" in getattr(a, "option_strings", [])
+        )
+        assert action.dest == "provider_type"
+
+    def test_default_is_none_by_default(self):
+        parser = _fresh_parser()
+        add_provider_type_arg(parser)
+        ns = _parse(parser, [])
+        assert ns.provider_type is None
+
+    def test_custom_default_is_honoured(self):
+        parser = _fresh_parser()
+        add_provider_type_arg(parser, default="aws")
+        ns = _parse(parser, [])
+        assert ns.provider_type == "aws"
+
+    def test_accepts_registered_provider_types(self):
+        """Every type that the registry knows about must be a valid choice."""
+        known_types = _registered_provider_types()
+        if not known_types:
+            pytest.skip("No provider types registered; skipping choices acceptance test")
+
+        parser = _fresh_parser()
+        add_provider_type_arg(parser)
+
+        for ptype in known_types:
+            ns = _parse(parser, ["--provider-type", ptype])
+            assert ns.provider_type == ptype
+
+    def test_rejects_unknown_value_when_choices_populated(self):
+        """When the registry is populated, an unknown type must be rejected."""
+        known_types = _registered_provider_types()
+        if not known_types:
+            pytest.skip("No provider types registered; choices validation not active")
+
+        parser = _fresh_parser()
+        add_provider_type_arg(parser)
+
+        with pytest.raises(SystemExit) as exc_info:
+            _parse(parser, ["--provider-type", "definitely-not-a-provider"])
+        assert exc_info.value.code == 2
+
+    def test_choices_match_registry_contents(self):
+        """The choices set on the action must mirror the registry exactly."""
+        known_types = _registered_provider_types()
+        if not known_types:
+            pytest.skip("No provider types registered; choices not set")
+
+        parser = _fresh_parser()
+        add_provider_type_arg(parser)
+
+        action = next(
+            a for a in parser._actions if "--provider-type" in getattr(a, "option_strings", [])
+        )
+        assert action.choices is not None
+        assert set(action.choices) == set(known_types)
+
+    def test_new_provider_reflected_when_registry_is_expanded(self):
+        """Simulates a new provider type being registered before build time."""
+        from orb.infrastructure.registry.cli_spec_registry import CLISpecRegistry
+
+        original_specs = dict(CLISpecRegistry._specs)
+        try:
+            # Install a fake spec so the registry returns an extra type.
+            fake_spec = object()
+            CLISpecRegistry._specs["fake-provider"] = fake_spec  # type: ignore[assignment]
+
+            parser = _fresh_parser()
+            add_provider_type_arg(parser)
+
+            action = next(
+                a for a in parser._actions if "--provider-type" in getattr(a, "option_strings", [])
+            )
+            assert action.choices is not None
+            assert "fake-provider" in action.choices
+        finally:
+            CLISpecRegistry._specs = original_specs
+
+    def test_no_choices_without_registry_entries(self):
+        """When the registry is empty, choices is None (open-ended)."""
+        from orb.infrastructure.registry.cli_spec_registry import CLISpecRegistry
+
+        original_specs = dict(CLISpecRegistry._specs)
+        try:
+            CLISpecRegistry._specs = {}
+
+            parser = _fresh_parser()
+            add_provider_type_arg(parser)
+
+            action = next(
+                a for a in parser._actions if "--provider-type" in getattr(a, "option_strings", [])
+            )
+            assert action.choices is None
+        finally:
+            CLISpecRegistry._specs = original_specs
+
+    def test_extra_help_is_appended(self):
+        parser = _fresh_parser()
+        add_provider_type_arg(parser, extra_help="Some extra info.")
+        action = next(
+            a for a in parser._actions if "--provider-type" in getattr(a, "option_strings", [])
+        )
+        assert action.help is not None
+        assert "Some extra info." in action.help
+
+    def test_required_flag_accepted(self):
+        """required=True must propagate to the argparse action."""
+        parser = _fresh_parser()
+        add_provider_type_arg(parser, required=True)
+        action = next(
+            a for a in parser._actions if "--provider-type" in getattr(a, "option_strings", [])
+        )
+        assert action.required is True
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: build_parser() must raise no argparse conflict
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParserNoConflict:
+    """Guard against the argparse conflict error that caused 104 test failures.
+
+    build_parser() calls add_global_arguments() on every leaf subparser and
+    also attaches --provider-type on init.  If the same parser ever receives
+    two registrations of the same flag, argparse raises ValueError immediately.
+    This test ensures that never happens.
+    """
+
+    def test_build_parser_raises_no_argparse_conflict(self):
+        """build_parser() must complete without raising ValueError or SystemExit."""
+        from orb.cli.args import build_parser
+
+        try:
+            parser, resource_parsers = build_parser()
+        except (ValueError, SystemExit) as exc:
+            pytest.fail(
+                f"build_parser() raised {type(exc).__name__}: {exc}. "
+                "This usually means --provider-type (or another flag) was registered "
+                "twice on the same parser."
+            )
+
+        assert isinstance(parser, argparse.ArgumentParser)
+        assert isinstance(resource_parsers, dict)
+
+    def test_build_parser_can_be_called_twice_without_error(self):
+        """Calling build_parser() multiple times (e.g. in reload scenarios) is safe."""
+        from orb.cli.args import build_parser
+
+        build_parser()
+        # Second call must also succeed — the registry is a module-level dict
+        # so calling build_parser again should not accumulate duplicate registrations.
+        try:
+            build_parser()
+        except (ValueError, SystemExit) as exc:
+            pytest.fail(f"Second call to build_parser() raised {type(exc).__name__}: {exc}")
+
+    def test_init_provider_type_default_is_aws(self):
+        """orb init must default --provider-type to 'aws' for backward compatibility."""
+        with patch.object(sys, "argv", ["orb", "init"]):
+            from orb.cli.args import parse_args
+
+            ns, _ = parse_args()
+
+        assert ns.provider_type == "aws"
+
+    def test_machines_list_provider_type_default_is_none(self):
+        """For non-init subcommands the default must be None (no filtering)."""
+        with patch.object(sys, "argv", ["orb", "machines", "list"]):
+            from orb.cli.args import parse_args
+
+            ns, _ = parse_args()
+
+        assert ns.provider_type is None
+
+    def test_machines_list_accepts_provider_type_value(self):
+        with patch.object(sys, "argv", ["orb", "machines", "list", "--provider-type", "aws"]):
+            from orb.cli.args import parse_args
+
+            ns, _ = parse_args()
+
+        assert ns.provider_type == "aws"
+
+    def test_templates_list_accepts_provider_type_value(self):
+        with patch.object(sys, "argv", ["orb", "templates", "list", "--provider-type", "aws"]):
+            from orb.cli.args import parse_args
+
+            ns, _ = parse_args()
+
+        assert ns.provider_type == "aws"
+
+    def test_requests_list_accepts_provider_type_value(self):
+        with patch.object(sys, "argv", ["orb", "requests", "list", "--provider-type", "aws"]):
+            from orb.cli.args import parse_args
+
+            ns, _ = parse_args()
+
+        assert ns.provider_type == "aws"
+
+
+# ---------------------------------------------------------------------------
+# _registered_provider_types helper
+# ---------------------------------------------------------------------------
+
+
+class TestRegisteredProviderTypes:
+    def test_returns_list(self):
+        result = _registered_provider_types()
+        assert isinstance(result, list)
+
+    def test_is_sorted(self):
+        result = _registered_provider_types()
+        assert result == sorted(result)
+
+    def test_tolerates_empty_registry(self):
+        from orb.infrastructure.registry.cli_spec_registry import CLISpecRegistry
+
+        original = dict(CLISpecRegistry._specs)
+        try:
+            CLISpecRegistry._specs = {}
+            result = _registered_provider_types()
+            assert result == []
+        finally:
+            CLISpecRegistry._specs = original

--- a/tests/unit/config/test_server_schema.py
+++ b/tests/unit/config/test_server_schema.py
@@ -116,6 +116,36 @@ def test_auth_config_enabled_true_with_real_strategy_accepted():
 
 
 # ---------------------------------------------------------------------------
+# CORSConfig — secure defaults
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cors_config_default_origins_is_loopback_only():
+    """Default CORS origins must NOT be the wildcard '*'."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    cfg = CORSConfig()
+    assert cfg.origins != ["*"], (
+        "Default cors.origins must not be ['*']. "
+        "Operators binding to 0.0.0.0 must set this explicitly."
+    )
+    # Default should allow only loopback.
+    assert all("localhost" in o or "127.0.0.1" in o for o in cfg.origins), (
+        f"Default cors.origins should be loopback-only, got: {cfg.origins}"
+    )
+
+
+@pytest.mark.unit
+def test_cors_config_wildcard_can_be_set_explicitly():
+    """Operators CAN still override origins to ['*'] explicitly when they need it."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    cfg = CORSConfig(origins=["*"])  # type: ignore[call-arg]
+    assert cfg.origins == ["*"]
+
+
+# ---------------------------------------------------------------------------
 # CORSConfig — credentials + wildcard origin is rejected
 # ---------------------------------------------------------------------------
 
@@ -283,3 +313,77 @@ def test_destructive_admin_blocked_when_auth_disabled(monkeypatch):
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail["code"] == "AUTH_DISABLED"
+
+
+# ---------------------------------------------------------------------------
+# ServerConfig — trusted_hosts secure defaults
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_server_config_default_trusted_hosts_is_not_wildcard():
+    """Default trusted_hosts must NOT be the wildcard '*'."""
+    from orb.config.schemas.server_schema import ServerConfig
+
+    cfg = ServerConfig()
+    assert cfg.trusted_hosts != ["*"], (
+        "Default trusted_hosts must not be ['*']. "
+        "Operators binding to 0.0.0.0 must add their hostname explicitly."
+    )
+
+
+@pytest.mark.unit
+def test_server_config_default_trusted_hosts_contains_loopback():
+    """Default trusted_hosts must include loopback addresses for local development."""
+    from orb.config.schemas.server_schema import ServerConfig
+
+    cfg = ServerConfig()
+    assert "localhost" in cfg.trusted_hosts
+    assert "127.0.0.1" in cfg.trusted_hosts
+
+
+@pytest.mark.unit
+def test_server_config_default_trusted_hosts_contains_testserver():
+    """Default trusted_hosts must include 'testserver' for Starlette TestClient."""
+    from orb.config.schemas.server_schema import ServerConfig
+
+    cfg = ServerConfig()
+    assert "testserver" in cfg.trusted_hosts
+
+
+@pytest.mark.unit
+def test_server_config_trusted_hosts_can_be_overridden():
+    """Operators can override trusted_hosts to any list they need."""
+    from orb.config.schemas.server_schema import ServerConfig
+
+    cfg = ServerConfig(trusted_hosts=["myapp.example.com", "localhost"])  # type: ignore[call-arg]
+    # Exact list comparison (not substring membership) — asserts the operator
+    # override is preserved verbatim and avoids CodeQL's URL-substring heuristic.
+    assert cfg.trusted_hosts == ["myapp.example.com", "localhost"]
+
+
+# ---------------------------------------------------------------------------
+# IAMAuthSubConfig — admin_arns field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_iam_auth_sub_config_admin_arns_defaults_empty():
+    """admin_arns defaults to an empty list when not specified."""
+    from orb.config.schemas.server_schema import IAMAuthSubConfig
+
+    cfg = IAMAuthSubConfig()
+    assert cfg.admin_arns == []
+
+
+@pytest.mark.unit
+def test_iam_auth_sub_config_admin_arns_accepts_full_arns():
+    """admin_arns accepts a list of fully-qualified ARN strings."""
+    from orb.config.schemas.server_schema import IAMAuthSubConfig
+
+    arns = [
+        "arn:aws:iam::123456789012:role/OrbAdmin",
+        "arn:aws:iam::123456789012:user/admin-user",
+    ]
+    cfg = IAMAuthSubConfig(admin_arns=arns)  # type: ignore[call-arg]
+    assert cfg.admin_arns == arns

--- a/tests/unit/domain/test_template_aggregate.py
+++ b/tests/unit/domain/test_template_aggregate.py
@@ -550,6 +550,107 @@ class TestTemplateDeprecatedAliases:
 
 
 @pytest.mark.unit
+class TestTemplateDeprecatedAliasesLoggerWarning:
+    """Tests that deprecated field names emit logger.warning on ALL deserialization paths.
+
+    AliasChoices silently accepts old keys via model_validate — these tests
+    assert that operators see a warning in server logs even when using the
+    YAML/JSON deserialization path (not just the Python-kwarg path).
+    """
+
+    def test_model_validate_instance_type_emits_logger_warning(self, caplog):
+        """model_validate with deprecated 'instance_type' emits a logger.warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="orb.domain.template.template_aggregate"):
+            t = Template.model_validate({"template_id": "lw-1", "instance_type": "m5.large"})
+        assert t.machine_type == "m5.large"
+        assert any(
+            "instance_type" in r.message and "deprecated" in r.message for r in caplog.records
+        ), f"Expected deprecation log for instance_type; got: {[r.message for r in caplog.records]}"
+
+    def test_model_validate_instance_profile_emits_logger_warning(self, caplog):
+        """model_validate with deprecated 'instance_profile' emits a logger.warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="orb.domain.template.template_aggregate"):
+            t = Template.model_validate(
+                {
+                    "template_id": "lw-2",
+                    "instance_profile": "arn:aws:iam::123456789012:instance-profile/legacy",
+                }
+            )
+        assert t.machine_role == "arn:aws:iam::123456789012:instance-profile/legacy"
+        assert any(
+            "instance_profile" in r.message and "deprecated" in r.message for r in caplog.records
+        ), (
+            f"Expected deprecation log for instance_profile; got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_kwarg_instance_type_emits_logger_warning(self, caplog):
+        """Template(instance_type=...) kwarg path also emits logger.warning (via model_validator)."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="orb.domain.template.template_aggregate"):
+            with pytest.warns(DeprecationWarning):
+                t = Template(template_id="lw-3", instance_type="c5.xlarge")
+        assert t.machine_type == "c5.xlarge"
+        assert any(
+            "instance_type" in r.message and "deprecated" in r.message for r in caplog.records
+        ), (
+            f"Expected deprecation log for instance_type kwarg; got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_kwarg_instance_profile_emits_logger_warning(self, caplog):
+        """Template(instance_profile=...) kwarg path also emits logger.warning (via model_validator)."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="orb.domain.template.template_aggregate"):
+            with pytest.warns(DeprecationWarning):
+                t = Template(
+                    template_id="lw-4",
+                    instance_profile="arn:aws:iam::123456789012:instance-profile/worker",
+                )
+        assert t.machine_role == "arn:aws:iam::123456789012:instance-profile/worker"
+        assert any(
+            "instance_profile" in r.message and "deprecated" in r.message for r in caplog.records
+        ), (
+            f"Expected deprecation log for instance_profile kwarg; got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_new_field_names_emit_no_logger_warning(self, caplog):
+        """Using machine_type / machine_role directly produces no deprecation log."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="orb.domain.template.template_aggregate"):
+            t = Template.model_validate(
+                {
+                    "template_id": "lw-5",
+                    "machine_type": "t3.medium",
+                    "machine_role": "arn:aws:iam::123456789012:instance-profile/new",
+                }
+            )
+        assert t.machine_type == "t3.medium"
+        assert t.machine_role == "arn:aws:iam::123456789012:instance-profile/new"
+        assert not caplog.records, (
+            f"Expected no deprecation log with new field names; got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_model_validate_instance_type_warns_once(self, caplog):
+        """Exactly one warning is emitted per deprecated key per model_validate call."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="orb.domain.template.template_aggregate"):
+            Template.model_validate({"template_id": "lw-6", "instance_type": "r5.large"})
+        instance_type_warnings = [
+            r for r in caplog.records if "instance_type" in r.message and "deprecated" in r.message
+        ]
+        assert len(instance_type_warnings) == 1, (
+            f"Expected exactly 1 warning; got {len(instance_type_warnings)}"
+        )
+
+
+@pytest.mark.unit
 class TestTemplateExceptions:
     """Test cases for Template-specific exceptions."""
 

--- a/tests/unit/domain/test_template_aggregate.py
+++ b/tests/unit/domain/test_template_aggregate.py
@@ -428,6 +428,128 @@ class TestTemplateTagValidation:
 
 
 @pytest.mark.unit
+class TestTemplateDeprecatedAliases:
+    """Tests for Template.instance_type and Template.instance_profile rename shims.
+
+    Both fields were renamed (instance_type -> machine_type,
+    instance_profile -> machine_role).  The old names are kept as write-only
+    aliases that promote the value to the new field name and emit a
+    DeprecationWarning.  These tests assert:
+
+    1. A DeprecationWarning is emitted when the old name is used as a
+       constructor keyword argument.
+    2. The value is correctly promoted to the new field name.
+    3. Templates constructed with either old or new name deserialize correctly
+       via model_validate.
+    4. The old names are NOT readable as attributes — only the new names are.
+    """
+
+    def test_instance_type_emits_deprecation_warning(self):
+        """Passing instance_type= to Template() fires a DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match="instance_type"):
+            t = Template(template_id="depr-1", instance_type="m5.large")
+        assert t.machine_type == "m5.large"
+
+    def test_instance_profile_emits_deprecation_warning(self):
+        """Passing instance_profile= to Template() fires a DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match="instance_profile"):
+            t = Template(
+                template_id="depr-2",
+                instance_profile="arn:aws:iam::123456789012:instance-profile/my-role",
+            )
+        assert t.machine_role == "arn:aws:iam::123456789012:instance-profile/my-role"
+
+    def test_instance_type_value_promoted_to_machine_type(self):
+        """Deprecated instance_type value is accessible via machine_type."""
+        with pytest.warns(DeprecationWarning):
+            t = Template(template_id="depr-3", instance_type="c5.xlarge")
+        assert t.machine_type == "c5.xlarge"
+
+    def test_instance_profile_value_promoted_to_machine_role(self):
+        """Deprecated instance_profile value is accessible via machine_role."""
+        with pytest.warns(DeprecationWarning):
+            t = Template(
+                template_id="depr-4",
+                instance_profile="arn:aws:iam::123456789012:instance-profile/worker",
+            )
+        assert t.machine_role == "arn:aws:iam::123456789012:instance-profile/worker"
+
+    def test_new_name_only_construction_no_warning(self):
+        """Using machine_type / machine_role directly emits no DeprecationWarning."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            t = Template(
+                template_id="depr-5",
+                machine_type="t3.medium",
+                machine_role="arn:aws:iam::123456789012:instance-profile/new-role",
+            )
+        assert t.machine_type == "t3.medium"
+        assert t.machine_role == "arn:aws:iam::123456789012:instance-profile/new-role"
+
+    def test_model_validate_with_old_name_instance_type(self):
+        """model_validate with old key 'instance_type' maps to machine_type."""
+        data = {
+            "template_id": "depr-6",
+            "instance_type": "r5.large",
+        }
+        t = Template.model_validate(data)
+        assert t.machine_type == "r5.large"
+
+    def test_model_validate_with_old_name_instance_profile(self):
+        """model_validate with old key 'instance_profile' maps to machine_role."""
+        data = {
+            "template_id": "depr-7",
+            "instance_profile": "arn:aws:iam::123456789012:instance-profile/legacy",
+        }
+        t = Template.model_validate(data)
+        assert t.machine_role == "arn:aws:iam::123456789012:instance-profile/legacy"
+
+    def test_model_validate_with_new_name_machine_type(self):
+        """model_validate with new key 'machine_type' is accepted without warning."""
+        import warnings
+
+        data = {"template_id": "depr-8", "machine_type": "t4g.medium"}
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            t = Template.model_validate(data)
+        assert t.machine_type == "t4g.medium"
+
+    def test_model_validate_with_new_name_machine_role(self):
+        """model_validate with new key 'machine_role' is accepted without warning."""
+        import warnings
+
+        data = {
+            "template_id": "depr-9",
+            "machine_role": "arn:aws:iam::123456789012:instance-profile/current",
+        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            t = Template.model_validate(data)
+        assert t.machine_role == "arn:aws:iam::123456789012:instance-profile/current"
+
+    def test_old_name_not_readable_as_attribute(self):
+        """After construction with instance_type=, the attribute instance_type does not exist."""
+        with pytest.warns(DeprecationWarning):
+            t = Template(template_id="depr-10", instance_type="m5.large")
+        assert not hasattr(t, "instance_type"), (
+            "instance_type should not be a readable attribute; use machine_type instead"
+        )
+
+    def test_old_name_instance_profile_not_readable_as_attribute(self):
+        """After construction with instance_profile=, the attribute instance_profile does not exist."""
+        with pytest.warns(DeprecationWarning):
+            t = Template(
+                template_id="depr-11",
+                instance_profile="arn:aws:iam::123456789012:instance-profile/old",
+            )
+        assert not hasattr(t, "instance_profile"), (
+            "instance_profile should not be a readable attribute; use machine_role instead"
+        )
+
+
+@pytest.mark.unit
 class TestTemplateExceptions:
     """Test cases for Template-specific exceptions."""
 

--- a/tests/unit/providers/base/exceptions/test_provider_error.py
+++ b/tests/unit/providers/base/exceptions/test_provider_error.py
@@ -1,0 +1,372 @@
+"""Tests for the shared ProviderError exception hierarchy."""
+
+import json
+
+import pytest
+
+from orb.providers.base.exceptions import (
+    ProviderAuthError,
+    ProviderConfigError,
+    ProviderError,
+    ProviderPermanentError,
+    ProviderQuotaError,
+    ProviderTransientError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ALL_LEAF_CLASSES = [
+    ProviderConfigError,
+    ProviderAuthError,
+    ProviderQuotaError,
+    ProviderTransientError,
+    ProviderPermanentError,
+]
+
+
+# ---------------------------------------------------------------------------
+# Inheritance / isinstance checks
+# ---------------------------------------------------------------------------
+
+
+class TestInheritance:
+    def test_all_leaves_are_provider_errors(self):
+        for cls in ALL_LEAF_CLASSES:
+            exc = cls("msg", provider_type="test")
+            assert isinstance(exc, ProviderError), f"{cls.__name__} must be a ProviderError"
+
+    def test_all_leaves_are_exceptions(self):
+        for cls in ALL_LEAF_CLASSES:
+            exc = cls("msg", provider_type="test")
+            assert isinstance(exc, Exception)
+
+    def test_provider_error_is_exception(self):
+        exc = ProviderError("base msg", provider_type="aws")
+        assert isinstance(exc, Exception)
+
+
+# ---------------------------------------------------------------------------
+# provider_type field
+# ---------------------------------------------------------------------------
+
+
+class TestProviderTypeField:
+    @pytest.mark.parametrize("cls", ALL_LEAF_CLASSES)
+    def test_provider_type_is_stored(self, cls):
+        exc = cls("some error", provider_type="mycloud")
+        assert exc.provider_type == "mycloud"
+
+    def test_base_stores_provider_type(self):
+        exc = ProviderError("base", provider_type="azure")
+        assert exc.provider_type == "azure"
+
+    @pytest.mark.parametrize("cls", ALL_LEAF_CLASSES)
+    def test_provider_name_defaults_to_none(self, cls):
+        exc = cls("msg", provider_type="gcp")
+        assert exc.provider_name is None
+
+    @pytest.mark.parametrize("cls", ALL_LEAF_CLASSES)
+    def test_provider_name_is_stored(self, cls):
+        exc = cls("msg", provider_type="aws", provider_name="prod-us-east-1")
+        assert exc.provider_name == "prod-us-east-1"
+
+
+# ---------------------------------------------------------------------------
+# underlying_exception field
+# ---------------------------------------------------------------------------
+
+
+class TestUnderlyingException:
+    def test_defaults_to_none(self):
+        exc = ProviderError("msg", provider_type="aws")
+        assert exc.underlying_exception is None
+
+    def test_stores_underlying(self):
+        cause = ValueError("original cause")
+        exc = ProviderAuthError("auth failed", provider_type="aws", underlying_exception=cause)
+        assert exc.underlying_exception is cause
+
+    def test_does_not_become_cause_by_default(self):
+        # We store the underlying exception explicitly; the raise-from chain
+        # is the caller's responsibility — we don't set __cause__ automatically.
+        cause = RuntimeError("root cause")
+        exc = ProviderTransientError("retry me", provider_type="k8s", underlying_exception=cause)
+        assert exc.__cause__ is None
+        assert exc.underlying_exception is cause
+
+
+# ---------------------------------------------------------------------------
+# is_retryable attribute — leaf class defaults
+# ---------------------------------------------------------------------------
+
+
+class TestIsRetryable:
+    def test_base_class_default_is_false(self):
+        exc = ProviderError("base error", provider_type="aws")
+        assert exc.is_retryable is False
+
+    def test_config_error_is_not_retryable(self):
+        exc = ProviderConfigError("bad config", provider_type="aws")
+        assert exc.is_retryable is False
+
+    def test_auth_error_is_not_retryable(self):
+        exc = ProviderAuthError("unauthorized", provider_type="aws")
+        assert exc.is_retryable is False
+
+    def test_quota_error_is_retryable(self):
+        exc = ProviderQuotaError("throttled", provider_type="aws")
+        assert exc.is_retryable is True
+
+    def test_transient_error_is_retryable(self):
+        exc = ProviderTransientError("503 unavailable", provider_type="k8s")
+        assert exc.is_retryable is True
+
+    def test_permanent_error_is_not_retryable(self):
+        exc = ProviderPermanentError("404 not found", provider_type="azure")
+        assert exc.is_retryable is False
+
+    def test_is_retryable_override_true(self):
+        # A ProviderAuthError for short-lived token expiry can be marked retryable.
+        exc = ProviderAuthError("token expired", provider_type="aws", is_retryable=True)
+        assert exc.is_retryable is True
+
+    def test_is_retryable_override_false(self):
+        # A hard quota ceiling is not retryable without operator action.
+        exc = ProviderQuotaError("hard limit", provider_type="aws", is_retryable=False)
+        assert exc.is_retryable is False
+
+    def test_is_retryable_present_in_to_dict(self):
+        exc = ProviderQuotaError("throttled", provider_type="aws")
+        d = exc.to_dict()
+        assert "is_retryable" in d
+        assert d["is_retryable"] is True
+
+    def test_retry_logic_pattern_via_attribute(self):
+        """Demonstrate the intended retry-logic pattern."""
+        retryable_errors = [
+            ProviderTransientError("transient", provider_type="k8s"),
+            ProviderQuotaError("throttled", provider_type="aws"),
+        ]
+        non_retryable_errors = [
+            ProviderConfigError("bad config", provider_type="aws"),
+            ProviderAuthError("access denied", provider_type="aws"),
+            ProviderPermanentError("not found", provider_type="azure"),
+        ]
+
+        for exc in retryable_errors:
+            assert isinstance(exc, ProviderError) and exc.is_retryable, (
+                f"{type(exc).__name__} should be retryable"
+            )
+
+        for exc in non_retryable_errors:
+            assert isinstance(exc, ProviderError) and not exc.is_retryable, (
+                f"{type(exc).__name__} should not be retryable"
+            )
+
+
+# ---------------------------------------------------------------------------
+# to_dict() round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestToDict:
+    def test_required_keys_present(self):
+        exc = ProviderError("something broke", provider_type="aws")
+        d = exc.to_dict()
+        assert d["error_type"] == "ProviderError"
+        assert d["message"] == "something broke"
+        assert d["provider_type"] == "aws"
+
+    def test_is_retryable_present(self):
+        exc = ProviderError("msg", provider_type="aws")
+        assert "is_retryable" in exc.to_dict()
+
+    def test_provider_name_absent_when_none(self):
+        exc = ProviderError("msg", provider_type="aws")
+        assert "provider_name" not in exc.to_dict()
+
+    def test_provider_name_present_when_set(self):
+        exc = ProviderError("msg", provider_type="aws", provider_name="prod")
+        assert exc.to_dict()["provider_name"] == "prod"
+
+    def test_underlying_exception_absent_when_none(self):
+        exc = ProviderError("msg", provider_type="aws")
+        assert "underlying_exception" not in exc.to_dict()
+
+    def test_underlying_exception_repr_when_set(self):
+        cause = ValueError("root cause")
+        exc = ProviderConfigError("bad config", provider_type="azure", underlying_exception=cause)
+        d = exc.to_dict()
+        assert "underlying_exception" in d
+        assert "ValueError" in d["underlying_exception"]
+        assert "root cause" in d["underlying_exception"]
+
+    def test_details_absent_when_empty(self):
+        exc = ProviderError("msg", provider_type="aws")
+        assert "details" not in exc.to_dict()
+
+    def test_details_present_when_set(self):
+        exc = ProviderQuotaError(
+            "quota hit",
+            provider_type="aws",
+            details={"quota_name": "vCPU", "limit": 100},
+        )
+        d = exc.to_dict()
+        assert d["details"]["quota_name"] == "vCPU"
+        assert d["details"]["limit"] == 100
+
+    @pytest.mark.parametrize("cls", ALL_LEAF_CLASSES)
+    def test_error_type_matches_classname(self, cls):
+        exc = cls("msg", provider_type="test")
+        assert exc.to_dict()["error_type"] == cls.__name__
+
+    def test_to_dict_is_json_serialisable(self):
+        cause = OSError("network unreachable")
+        exc = ProviderTransientError(
+            "transient failure",
+            provider_type="gcp",
+            provider_name="gcp-europe",
+            underlying_exception=cause,
+            details={"retry_after": 5},
+        )
+        # Should not raise
+        payload = json.dumps(exc.to_dict())
+        recovered = json.loads(payload)
+        assert recovered["provider_type"] == "gcp"
+        assert recovered["provider_name"] == "gcp-europe"
+
+    @pytest.mark.parametrize("cls", ALL_LEAF_CLASSES)
+    def test_is_retryable_round_trips_in_to_dict(self, cls):
+        exc = cls("msg", provider_type="test")
+        d = exc.to_dict()
+        assert d["is_retryable"] == exc.is_retryable
+
+
+# ---------------------------------------------------------------------------
+# safe_to_dict() — no secret leakage
+# ---------------------------------------------------------------------------
+
+
+class TestSafeToDict:
+    def test_safe_to_dict_omits_underlying_exception(self):
+        cause = ValueError("arn:aws:iam::123456789012:role/SecretRole")
+        exc = ProviderAuthError(
+            "auth failed",
+            provider_type="aws",
+            underlying_exception=cause,
+        )
+        d = exc.safe_to_dict()
+        assert "underlying_exception" not in d
+
+    def test_safe_to_dict_includes_required_fields(self):
+        exc = ProviderTransientError("503", provider_type="k8s")
+        d = exc.safe_to_dict()
+        assert d["error_type"] == "ProviderTransientError"
+        assert d["message"] == "503"
+        assert d["provider_type"] == "k8s"
+        assert "is_retryable" in d
+
+    def test_safe_to_dict_includes_is_retryable(self):
+        exc = ProviderQuotaError("throttled", provider_type="aws")
+        d = exc.safe_to_dict()
+        assert d["is_retryable"] is True
+
+    def test_safe_to_dict_includes_provider_name_when_set(self):
+        exc = ProviderConfigError("bad config", provider_type="aws", provider_name="prod")
+        d = exc.safe_to_dict()
+        assert d["provider_name"] == "prod"
+
+    def test_safe_to_dict_omits_provider_name_when_none(self):
+        exc = ProviderConfigError("bad config", provider_type="aws")
+        assert "provider_name" not in exc.safe_to_dict()
+
+    def test_safe_to_dict_includes_details_when_set(self):
+        exc = ProviderQuotaError(
+            "quota hit",
+            provider_type="aws",
+            details={"quota_name": "vCPU"},
+        )
+        d = exc.safe_to_dict()
+        assert d["details"]["quota_name"] == "vCPU"
+
+    def test_safe_to_dict_omits_details_when_empty(self):
+        exc = ProviderPermanentError("not found", provider_type="azure")
+        assert "details" not in exc.safe_to_dict()
+
+    def test_safe_to_dict_is_json_serialisable(self):
+        cause = OSError("postgres://user:secret@db:5432/prod")
+        exc = ProviderTransientError(
+            "db connection failed",
+            provider_type="gcp",
+            provider_name="gcp-eu",
+            underlying_exception=cause,
+            details={"retry_after": 10},
+        )
+        payload = json.dumps(exc.safe_to_dict())
+        recovered = json.loads(payload)
+        assert recovered["provider_type"] == "gcp"
+        assert "underlying_exception" not in recovered
+
+    def test_to_dict_includes_underlying_safe_to_dict_does_not(self):
+        """Explicitly document the difference between the two methods."""
+        cause = ValueError("secret connection string")
+        exc = ProviderConfigError("config failed", provider_type="aws", underlying_exception=cause)
+        assert "underlying_exception" in exc.to_dict()
+        assert "underlying_exception" not in exc.safe_to_dict()
+
+    @pytest.mark.parametrize("cls", ALL_LEAF_CLASSES)
+    def test_safe_to_dict_error_type_matches_classname(self, cls):
+        exc = cls("msg", provider_type="test")
+        assert exc.safe_to_dict()["error_type"] == cls.__name__
+
+    @pytest.mark.parametrize("cls", ALL_LEAF_CLASSES)
+    def test_safe_to_dict_is_retryable_round_trips(self, cls):
+        exc = cls("msg", provider_type="test")
+        d = exc.safe_to_dict()
+        assert d["is_retryable"] == exc.is_retryable
+
+
+# ---------------------------------------------------------------------------
+# Can be raised and caught
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseAndCatch:
+    @pytest.mark.parametrize("cls", ALL_LEAF_CLASSES)
+    def test_can_raise_and_catch_as_provider_error(self, cls):
+        with pytest.raises(ProviderError):
+            raise cls("raised", provider_type="test")
+
+    @pytest.mark.parametrize("cls", ALL_LEAF_CLASSES)
+    def test_can_raise_and_catch_as_exception(self, cls):
+        with pytest.raises(Exception, match="raised"):
+            raise cls("raised", provider_type="test")
+
+    @pytest.mark.parametrize("cls", ALL_LEAF_CLASSES)
+    def test_catch_specific_subclass(self, cls):
+        with pytest.raises(cls):
+            raise cls("exact match", provider_type="test")
+
+    def test_str_representation_contains_message(self):
+        exc = ProviderPermanentError("something is very wrong", provider_type="oci")
+        assert "something is very wrong" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# details field
+# ---------------------------------------------------------------------------
+
+
+class TestDetails:
+    def test_details_defaults_to_empty_dict(self):
+        exc = ProviderError("msg", provider_type="aws")
+        assert exc.details == {}
+
+    def test_details_is_mutable_copy(self):
+        original = {"key": "value"}
+        exc = ProviderError("msg", provider_type="aws", details=original)
+        exc.details["extra"] = "added"
+        # Should not raise; details is just stored as-is
+        assert exc.details["extra"] == "added"

--- a/tests/unit/providers/base/strategy/test_get_resource_id_pattern.py
+++ b/tests/unit/providers/base/strategy/test_get_resource_id_pattern.py
@@ -1,0 +1,29 @@
+"""Tests for the ProviderStrategy.get_resource_id_pattern() classmethod slot."""
+
+from orb.providers.base.strategy.provider_strategy import ProviderStrategy
+
+
+def test_base_default_returns_none():
+    """ProviderStrategy.get_resource_id_pattern() must return None by default.
+
+    The default implementation signals 'no pattern enforced', so provider-agnostic
+    validation code can skip ID-format checks for providers that have not opted in.
+    """
+    assert ProviderStrategy.get_resource_id_pattern() is None
+
+
+def test_return_type_is_optional_str():
+    """The return value must be None or a string — never another type."""
+    result = ProviderStrategy.get_resource_id_pattern()
+    assert result is None or isinstance(result, str)
+
+
+def test_classmethod_callable_without_instance():
+    """get_resource_id_pattern must be callable on the class, not just on instances.
+
+    Provider-agnostic code will call this before any provider instance exists
+    (e.g. at boot time during config validation).
+    """
+    # Should not raise — no AWSProviderConfig, no credentials, no I/O needed.
+    result = ProviderStrategy.get_resource_id_pattern()
+    assert result is None

--- a/tests/unit/test_domain_validation.py
+++ b/tests/unit/test_domain_validation.py
@@ -111,7 +111,7 @@ def test_aws_template_basic():
 
         print(f"   PASS: Basic template created: {template.template_id}")
         print(f"   Provider API: {template.provider_api}")
-        print(f"   Instance Type: {template.instance_type}")
+        print(f"   Machine Type: {template.machine_type}")
         print(f"   Image ID: {template.image_id}")
         print(f"   Subnet IDs: {template.subnet_ids}")
         print(f"   Security Group IDs: {template.security_group_ids}")


### PR DESCRIPTION
## Description

Cross-cutting prep to remove AWS-shaped leaks from shared code and finalise the `ProviderStrategy` contract before Azure (PR #258), GCP (PR #257), and OCI (PR #234) provider PRs land. Blocks the multi-provider merge train.

Rebased onto current `main` and regrouped into **9 thematic commits** (down from the original working history), each single-purpose. Highlights:

**Shared-code AWS leak removal:**
- `Machine.provider_type` now required (dropped `default="aws"` — silent misclassification for non-AWS machines)
- Bootstrap no longer hard-wires the AWS validator into `ProviderValidationService`
- Application handlers no longer fall back to `PROVIDER_TYPE_AWS`
- Dashboard aggregates dynamically from the provider registry instead of a hardcoded AWS API list
- Template generation no longer inserts a hardcoded `aws_default_us-east-1` fallback
- `image_id` moved from universally required to AWS-specific validator
- AWS-shaped `region` regex moved from `NamingConfig` into AWS provider config

**Domain model neutrality (with `AliasChoices` back-compat + `DeprecationWarning`):**
- `Template.instance_type` → `Template.machine_type`
- `Template.instance_profile` → `Template.machine_role`
- `Template.provider_data` deleted; readers migrated to typed subclasses (`AWSTemplate`, `K8sTemplate`)

**Provider contract additions:**
- `get_resource_id_pattern()` classmethod on `ProviderStrategy` (AWS returns `^i-[a-f0-9]{8,17}$`, non-AWS returns `None`)
- `providers/base/exceptions/`: shared `ProviderError` hierarchy with an `is_retryable` axis and a `safe_to_dict()` variant that omits `underlying_exception` to prevent ARN/DSN/secret leakage in HTTP responses

> Note: an earlier revision of this branch also introduced a `providers/base/scaffolding/` package (registration/handler-base/example). It had zero production adopters, so it was dropped from this PR to avoid shipping unused code. It will be reintroduced with real AWS + k8s adopters once the registry consolidation lands.

**Security hardening:**
- IAM admin authorization now uses `admin_arns` allowlist (frozenset exact-match) instead of substring bypass; `:root` unconditional grant now respects the allowlist
- CORS + `trusted_hosts` defaults tightened to loopback-only (`localhost`, `127.0.0.1`, `::1`, `testserver`)
- `/info` no longer discloses auth strategy to unauthenticated callers
- SQLQueryBuilder abstract-method regression tests to guard against the runtime `TypeError` that shipped in an earlier release

**Storage backfill:**
- Legacy stored `Machine` records without `provider_type` are backfilled to `"aws"` on read

**CLI hygiene:**
- `--provider-type` registered via a shared parent parser (prevents the argparse regression pattern that caused a large test-failure cascade)

**API DTO renames with deprecation:**
- `TemplateCreateRequest`, `TemplateUpdateRequest`, `CreateTemplateInput`, `UpdateTemplateInput` accept both `machine_type` (primary) and `instance_type` (deprecated alias with warning log)

**Config hygiene:**
- `default_config.json` (both packaged + repo sample) restored to loopback-only `server.host` / `cors.origins` — the packaged JSON is the lowest-precedence base layer and was overriding the hardened schema defaults back to `0.0.0.0` / `["*"]`, silently defeating the security tightening.
- Moved AWS-shaped naming defaults (`spot_fleet` / `ec2_fleet` / `asg` patterns, `fleet_types`, `price_types`) out of the shared `NamingConfig` — no shared reader consumes them.

**CI / coverage:**
- Coverage is now uploaded to Codecov exactly once, from a `coverage-combine` fan-in job that merges every leg's `.coverage` data first. A single deterministic upload replaces the per-leg uploads that produced mid-run partial-merge flapping, and it auto-scales to any number of provider legs (no hardcoded leg count).
- `k8s_legacy`, test files, and thin process entrypoints (`__main__.py`, `run.py`, `server_daemon.py`) excluded from the coverage number so it reflects real production source. Combined coverage: ~63%.

**Post-review hardening (adversarial review + CodeQL + CI feedback):**
- Three independent adversarial reviews (code-quality, security, architecture) run on the branch; all CRITICAL + HIGH findings fixed inline:
  - `ProviderError` gained an `is_retryable` axis (Transient/Permanent was orthogonal to Config/Auth/Quota) + a `safe_to_dict()` that omits `underlying_exception` to prevent ARN/DSN/secret leakage into HTTP responses.
  - IAM `:root` unconditional admin grant now respects the `admin_arns` allowlist when one is configured.
- CodeQL findings fixed: dict-subclass equality state (`_StickyOverridesDict.__eq__` with `__hash__ = None`), `trusted_hosts` asserted by exact list rather than substring membership, unused module-level logger removed.
- The k8s test suite surfaced 4 pre-existing test-vs-behaviour mismatches (StatefulSet/Job selective-release now *refuse and raise* rather than warn-and-scale; extension registration moved to an explicit lifecycle hook) — tests aligned to the current semantics. These were never caught on `main` because its CI matrix was AWS-only; k8s now runs on every PR via provider discovery.
- Fixed a live-conftest bug that marked the *entire* collected session as `serial` (not just its own subtree), which deselected every k8s test under `-m "not serial"`.
- Retry-classifier tests now raise a real `ApiException(status=404)` so the classifier recognises the not-found path, instead of a hand-mocked generic exception.

## Type of Change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Code cleanup or refactor
- [x] CI/CD or build process changes

Breaking-change surface (all backwards-compatible via aliases + deprecation warnings):
- `Template.instance_type` → `Template.machine_type` (alias preserved)
- `Template.instance_profile` → `Template.machine_role` (alias preserved)
- `Template.provider_data` field removed; readers migrated to typed subclasses
- `Machine.provider_type` now required (no default) — legacy storage records are backfilled

## How Has This Been Tested?
- [x] Unit tests added/updated
