### PR TITLE
feat(k8s): status-poll perf, orphan-GC parallelism, contract-mock fix

### DIFF
--- a/src/orb/providers/k8s/configuration/config.py
+++ b/src/orb/providers/k8s/configuration/config.py
@@ -299,6 +299,22 @@ class K8sProviderConfig(BaseSettings, BaseProviderConfig):  # type: ignore[misc]
         ),
     )
 
+    # Controller-status cache
+    controller_status_cache_ttl_seconds: float = Field(
+        5.0,
+        description=(
+            "How long (in seconds) to serve a cached ``read_namespaced_*`` controller "
+            "response before re-issuing the GET to the API server.  Applied to "
+            "Deployment, StatefulSet and Job status polls.  At the default of 5 s, "
+            "1 000 concurrent requests polling every 5 s produce at most ~200 "
+            "controller GETs/s instead of the unthrottled ~200 GETs/s per workload.  "
+            "Set to 0 (or any value <= 0) to disable the cache entirely — every poll "
+            "will issue a direct GET.  Disabling prevents unbounded in-memory growth "
+            "in environments where the handler is polled at very high frequency; the "
+            "cache dict is not populated at all when TTL <= 0."
+        ),
+    )
+
     # Prometheus metrics
     metrics_enabled: bool = Field(
         True,

--- a/src/orb/providers/k8s/infrastructure/handlers/deployment_status.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/deployment_status.py
@@ -15,6 +15,8 @@ instance-dict mapping) — it carries no state of its own.
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import TYPE_CHECKING, Any, Optional
 
 from orb.domain.base.provider_fulfilment import CheckHostsStatusResult, ProviderFulfilment
@@ -29,6 +31,11 @@ class DeploymentStatusResolver:
 
     def __init__(self, handler: K8sDeploymentHandler) -> None:
         self._handler = handler
+        # Per-workload TTL cache:
+        #   (namespace, deployment_name) -> (view, fetch_monotonic_ts, stored_requested_count)
+        # Guarded by _cache_lock so concurrent check_hosts_status calls are safe.
+        self._controller_cache: dict[tuple[str, str], tuple[dict[str, Any], float, int]] = {}
+        self._cache_lock = threading.Lock()
 
     def check_hosts_status(self, request: Request) -> CheckHostsStatusResult:
         """Return per-pod details + the Deployment-driven fulfilment verdict.
@@ -56,7 +63,9 @@ class DeploymentStatusResolver:
             # fulfilment verdict on the Deployment status because the
             # controller's view is authoritative for selective scale.
             cached_instances = handler.apply_pod_timeouts(list(cached.instances))
-            controller_view = self.read_deployment_status(namespace, deployment_name)
+            controller_view = self._get_cached_deployment_status(
+                namespace, deployment_name, requested_count=request.requested_count
+            )
             fulfilment = self.compute_fulfilment(
                 cached_instances,
                 request.requested_count,
@@ -67,10 +76,14 @@ class DeploymentStatusResolver:
         selector = handler.build_label_selector(request)
 
         try:
+            # resource_version='0' serves from the apiserver reflector cache
+            # (sub-ms, ~500 ms staleness) instead of reading from etcd.
+            # Acceptable for status polls — not used on create/update paths.
             response = handler.with_retry(
                 handler.client.core_v1.list_namespaced_pod,
                 namespace=namespace,
                 label_selector=selector,
+                resource_version="0",
                 operation_name="list_namespaced_pod",
             )
         except Exception as exc:
@@ -97,13 +110,73 @@ class DeploymentStatusResolver:
             handler._instance_dict_for_pod(pod, namespace=namespace) for pod in pods
         ]
         instances = handler.apply_pod_timeouts(instances)
-        controller_view = self.read_deployment_status(namespace, deployment_name)
+        controller_view = self._get_cached_deployment_status(
+            namespace, deployment_name, requested_count=request.requested_count
+        )
         fulfilment = self.compute_fulfilment(
             instances,
             request.requested_count,
             controller_view=controller_view,
         )
         return CheckHostsStatusResult(instances=instances, fulfilment=fulfilment)
+
+    def _get_cached_deployment_status(
+        self, namespace: str, deployment_name: str, *, requested_count: int
+    ) -> dict[str, Any]:
+        """Return the controller view, serving from the TTL cache when fresh.
+
+        Cache semantics:
+
+        * **TTL disabled** — when ``controller_status_cache_ttl_seconds <= 0``
+          the cache is bypassed entirely (no store, no read) to avoid
+          unbounded dict growth during high-frequency polls.
+        * **Scale-down guard** — a cached entry is only served when the
+          *stored* ``requested_count`` equals the *current* ``requested_count``
+          AND the stored view shows the workload fully ready.  If the replica
+          target has changed since the entry was stored (e.g. scale 5 → 3),
+          the entry is treated as a miss and a fresh GET is issued.
+        * **TOCTOU guard** — the fetch timestamp is captured *before* the
+          blocking GET.  On store, an existing entry is only overwritten when
+          its timestamp is older than the new one, so a slow thread cannot
+          clobber a fresher entry with a stale view.
+
+        The TTL is controlled by
+        ``K8sProviderConfig.controller_status_cache_ttl_seconds`` (default 5 s).
+        """
+        ttl = self._handler.config.controller_status_cache_ttl_seconds
+
+        # TTL <= 0 means disabled — bypass cache entirely (Finding 5).
+        if ttl <= 0:
+            return self.read_deployment_status(namespace, deployment_name)
+
+        cache_key = (namespace, deployment_name)
+        now = time.monotonic()
+
+        with self._cache_lock:
+            entry = self._controller_cache.get(cache_key)
+            if entry is not None:
+                view, ts, stored_requested = entry  # type: ignore[misc]
+                ready = view.get("ready_replicas")
+                # Finding 1: only serve when stored requested_count matches current
+                # AND workload was fully ready when stored.
+                fully_ready = isinstance(ready, int) and ready >= stored_requested
+                if stored_requested == requested_count and fully_ready and now - ts < ttl:
+                    return view
+
+        # Cache miss, expired, workload not fully ready, or requested_count changed —
+        # fetch outside the lock to avoid blocking concurrent callers during the API
+        # GET.  Capture the timestamp BEFORE the GET (Finding 2 / TOCTOU guard).
+        fetch_ts = time.monotonic()
+        view = self.read_deployment_status(namespace, deployment_name)
+
+        with self._cache_lock:
+            existing = self._controller_cache.get(cache_key)
+            # Only overwrite if there is no existing entry or the existing entry
+            # is older than this fetch (Finding 2: don't clobber a newer entry).
+            if existing is None or existing[1] < fetch_ts:  # type: ignore[misc]
+                self._controller_cache[cache_key] = (view, fetch_ts, requested_count)  # type: ignore[assignment]
+
+        return view
 
     def read_deployment_status(self, namespace: str, deployment_name: str) -> dict[str, Any]:
         """Read ``availableReplicas``/``readyReplicas``/``conditions`` from the controller.

--- a/src/orb/providers/k8s/infrastructure/handlers/job_status.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/job_status.py
@@ -15,6 +15,8 @@ instance-dict mapping) — it carries no state of its own.
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import TYPE_CHECKING, Any, Optional
 
 from orb.domain.base.provider_fulfilment import CheckHostsStatusResult, ProviderFulfilment
@@ -29,6 +31,11 @@ class JobStatusResolver:
 
     def __init__(self, handler: K8sJobHandler) -> None:
         self._handler = handler
+        # Per-workload TTL cache:
+        #   (namespace, job_name) -> (view, fetch_monotonic_ts)
+        # Guarded by _cache_lock so concurrent check_hosts_status calls are safe.
+        self._controller_cache: dict[tuple[str, str], tuple[dict[str, Any], float]] = {}
+        self._cache_lock = threading.Lock()
 
     def check_hosts_status(self, request: Request) -> CheckHostsStatusResult:
         """Return per-pod details + the Job-driven fulfilment verdict.
@@ -56,7 +63,7 @@ class JobStatusResolver:
             # controller's view is authoritative for run-to-completion
             # semantics.
             cached_instances = handler.apply_pod_timeouts(list(cached.instances))
-            controller_view = self.read_job_status(namespace, job_name)
+            controller_view = self._get_cached_job_status(namespace, job_name)
             fulfilment = self.compute_fulfilment(
                 cached_instances,
                 request.requested_count,
@@ -67,10 +74,14 @@ class JobStatusResolver:
         selector = handler.build_label_selector(request)
 
         try:
+            # resource_version='0' serves from the apiserver reflector cache
+            # (sub-ms, ~500 ms staleness) instead of reading from etcd.
+            # Acceptable for status polls — not used on create/update paths.
             response = handler.with_retry(
                 handler.client.core_v1.list_namespaced_pod,
                 namespace=namespace,
                 label_selector=selector,
+                resource_version="0",
                 operation_name="list_namespaced_pod",
             )
         except Exception as exc:
@@ -97,13 +108,83 @@ class JobStatusResolver:
             handler._instance_dict_for_pod(pod, namespace=namespace) for pod in pods
         ]
         instances = handler.apply_pod_timeouts(instances)
-        controller_view = self.read_job_status(namespace, job_name)
+        controller_view = self._get_cached_job_status(namespace, job_name)
         fulfilment = self.compute_fulfilment(
             instances,
             request.requested_count,
             controller_view=controller_view,
         )
         return CheckHostsStatusResult(instances=instances, fulfilment=fulfilment)
+
+    @staticmethod
+    def _is_terminal(view: dict[str, Any]) -> bool:
+        """Return True when the Job has reached a terminal condition.
+
+        A Job is terminal when it has a ``Complete`` or ``Failed`` condition
+        with ``status=True``.  Both states are equally steady — neither
+        transitions further — so both are safe to cache.
+
+        Caching ``Failed`` prevents re-fetching the Job on every poll after it
+        fails (Finding 3: re-fetch loop / log flood fix).
+        """
+        return any(
+            (c.get("type") in ("Complete", "Failed") and c.get("status") == "True")
+            for c in (view.get("conditions") or [])
+            if isinstance(c, dict)
+        )
+
+    def _get_cached_job_status(self, namespace: str, job_name: str) -> dict[str, Any]:
+        """Return the controller view, serving from the TTL cache when fresh.
+
+        Cache semantics:
+
+        * **TTL disabled** — when ``controller_status_cache_ttl_seconds <= 0``
+          the cache is bypassed entirely (no store, no read) to avoid
+          unbounded dict growth during high-frequency polls (Finding 5).
+        * **Terminal-state gate** — the cached view is only served when the
+          Job has reached a terminal condition (``Complete`` OR ``Failed``).
+          While the job is still running, every poll issues a fresh GET so
+          the active→complete/failed transition is observed promptly.
+          Caching ``Failed`` avoids the re-fetch loop that floods logs when
+          the Job never recovers (Finding 3).
+        * **TOCTOU guard** — the fetch timestamp is captured *before* the
+          blocking GET.  On store, an existing entry is only overwritten when
+          its timestamp is older than the new one, so a slow thread cannot
+          clobber a fresher entry with a stale view (Finding 2).
+
+        The TTL is controlled by
+        ``K8sProviderConfig.controller_status_cache_ttl_seconds`` (default 5 s).
+        """
+        ttl = self._handler.config.controller_status_cache_ttl_seconds
+
+        # TTL <= 0 means disabled — bypass cache entirely (Finding 5).
+        if ttl <= 0:
+            return self.read_job_status(namespace, job_name)
+
+        cache_key = (namespace, job_name)
+        now = time.monotonic()
+
+        with self._cache_lock:
+            entry = self._controller_cache.get(cache_key)
+            if entry is not None:
+                view, ts = entry
+                if self._is_terminal(view) and now - ts < ttl:
+                    return view
+
+        # Cache miss, expired, or job not yet terminal — fetch outside the lock
+        # to avoid blocking concurrent callers during the API GET.  Capture
+        # the timestamp BEFORE the GET (Finding 2 / TOCTOU guard).
+        fetch_ts = time.monotonic()
+        view = self.read_job_status(namespace, job_name)
+
+        with self._cache_lock:
+            existing = self._controller_cache.get(cache_key)
+            # Only overwrite if there is no existing entry or the existing entry
+            # is older than this fetch (Finding 2: don't clobber a newer entry).
+            if existing is None or existing[1] < fetch_ts:
+                self._controller_cache[cache_key] = (view, fetch_ts)
+
+        return view
 
     def read_job_status(self, namespace: str, job_name: str) -> dict[str, Any]:
         """Read controller view from ``batch/v1 Job.status``.
@@ -129,6 +210,9 @@ class JobStatusResolver:
             )
         except Exception as exc:
             if handler.is_not_found(exc):
+                # Job not found is normal after release or before creation.
+                # Log at debug to avoid flooding on the terminal-state poll
+                # path where the Job has already been deleted (Finding 3).
                 handler._logger.debug(
                     "Job %s in %s not found — assuming pre-create or post-release",
                     job_name,

--- a/src/orb/providers/k8s/infrastructure/handlers/pod_status.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/pod_status.py
@@ -29,7 +29,12 @@ class PodStatusResolver:
     def __init__(self, handler: K8sPodHandler) -> None:
         self._handler = handler
 
-    def check_hosts_status(self, request: Request) -> CheckHostsStatusResult:
+    def check_hosts_status(
+        self,
+        request: Request,
+        *,
+        consistent_read: bool = False,
+    ) -> CheckHostsStatusResult:
         """Return per-pod details + the fulfilment verdict for ``request``.
 
         Cache-first read path: when a :class:`PodStateCache` has been
@@ -38,6 +43,18 @@ class PodStatusResolver:
         A cache miss (no entry) or a stale cache (any entry older than
         :attr:`K8sProviderConfig.stale_cache_timeout_seconds`)
         falls back to a single ``list_namespaced_pod`` call.
+
+        Parameters
+        ----------
+        request:
+            The request whose pods are being queried.
+        consistent_read:
+            When ``True``, omit ``resource_version='0'`` from the fallback
+            list call, forcing a consistent read from etcd instead of the
+            apiserver reflector cache.  Use on any path that must confirm
+            release completion — the ~500 ms reflector lag can otherwise
+            cause just-deleted pods to appear alive (Finding 4).  Defaults
+            to ``False`` (reflector-cached read) for normal status polls.
         """
         handler = self._handler
         cached = handler._read_from_cache(request)
@@ -49,12 +66,22 @@ class PodStatusResolver:
         namespace = handler._resolve_request_namespace(request)
         selector = handler.build_label_selector(request)
 
+        # resource_version='0' serves from the apiserver reflector cache
+        # (sub-ms, ~500 ms staleness) instead of reading from etcd.
+        # Acceptable for status polls — omitted when consistent_read=True
+        # (e.g. release-confirmation paths that need a strong read).
+        list_kwargs: dict[str, Any] = {
+            "namespace": namespace,
+            "label_selector": selector,
+            "operation_name": "list_namespaced_pod",
+        }
+        if not consistent_read:
+            list_kwargs["resource_version"] = "0"
+
         try:
             response = handler.with_retry(
                 handler.client.core_v1.list_namespaced_pod,
-                namespace=namespace,
-                label_selector=selector,
-                operation_name="list_namespaced_pod",
+                **list_kwargs,
             )
         except Exception as exc:
             handler._logger.error(

--- a/src/orb/providers/k8s/infrastructure/handlers/statefulset_status.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/statefulset_status.py
@@ -15,6 +15,8 @@ instance-dict mapping) — it carries no state of its own.
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import TYPE_CHECKING, Any, Optional
 
 from orb.domain.base.provider_fulfilment import CheckHostsStatusResult, ProviderFulfilment
@@ -29,6 +31,11 @@ class StatefulSetStatusResolver:
 
     def __init__(self, handler: K8sStatefulSetHandler) -> None:
         self._handler = handler
+        # Per-workload TTL cache:
+        #   (namespace, statefulset_name) -> (view, fetch_monotonic_ts, stored_requested_count)
+        # Guarded by _cache_lock so concurrent check_hosts_status calls are safe.
+        self._controller_cache: dict[tuple[str, str], tuple[dict[str, Any], float, int]] = {}
+        self._cache_lock = threading.Lock()
 
     def check_hosts_status(self, request: Request) -> CheckHostsStatusResult:
         """Return per-pod details + the StatefulSet-driven fulfilment verdict.
@@ -56,7 +63,9 @@ class StatefulSetStatusResolver:
             # fulfilment verdict on the StatefulSet status because the
             # controller's view is authoritative for selective scale.
             cached_instances = handler.apply_pod_timeouts(list(cached.instances))
-            controller_view = self.read_statefulset_status(namespace, statefulset_name)
+            controller_view = self._get_cached_statefulset_status(
+                namespace, statefulset_name, requested_count=request.requested_count
+            )
             fulfilment = self.compute_fulfilment(
                 cached_instances,
                 request.requested_count,
@@ -67,10 +76,14 @@ class StatefulSetStatusResolver:
         selector = handler.build_label_selector(request)
 
         try:
+            # resource_version='0' serves from the apiserver reflector cache
+            # (sub-ms, ~500 ms staleness) instead of reading from etcd.
+            # Acceptable for status polls — not used on create/update paths.
             response = handler.with_retry(
                 handler.client.core_v1.list_namespaced_pod,
                 namespace=namespace,
                 label_selector=selector,
+                resource_version="0",
                 operation_name="list_namespaced_pod",
             )
         except Exception as exc:
@@ -97,13 +110,73 @@ class StatefulSetStatusResolver:
             handler._instance_dict_for_pod(pod, namespace=namespace) for pod in pods
         ]
         instances = handler.apply_pod_timeouts(instances)
-        controller_view = self.read_statefulset_status(namespace, statefulset_name)
+        controller_view = self._get_cached_statefulset_status(
+            namespace, statefulset_name, requested_count=request.requested_count
+        )
         fulfilment = self.compute_fulfilment(
             instances,
             request.requested_count,
             controller_view=controller_view,
         )
         return CheckHostsStatusResult(instances=instances, fulfilment=fulfilment)
+
+    def _get_cached_statefulset_status(
+        self, namespace: str, statefulset_name: str, *, requested_count: int
+    ) -> dict[str, Any]:
+        """Return the controller view, serving from the TTL cache when fresh.
+
+        Cache semantics:
+
+        * **TTL disabled** — when ``controller_status_cache_ttl_seconds <= 0``
+          the cache is bypassed entirely (no store, no read) to avoid
+          unbounded dict growth during high-frequency polls.
+        * **Scale-down guard** — a cached entry is only served when the
+          *stored* ``requested_count`` equals the *current* ``requested_count``
+          AND the stored view shows the workload fully ready.  If the replica
+          target has changed since the entry was stored (e.g. scale 5 → 3),
+          the entry is treated as a miss and a fresh GET is issued.
+        * **TOCTOU guard** — the fetch timestamp is captured *before* the
+          blocking GET.  On store, an existing entry is only overwritten when
+          its timestamp is older than the new one, so a slow thread cannot
+          clobber a fresher entry with a stale view.
+
+        The TTL is controlled by
+        ``K8sProviderConfig.controller_status_cache_ttl_seconds`` (default 5 s).
+        """
+        ttl = self._handler.config.controller_status_cache_ttl_seconds
+
+        # TTL <= 0 means disabled — bypass cache entirely (Finding 5).
+        if ttl <= 0:
+            return self.read_statefulset_status(namespace, statefulset_name)
+
+        cache_key = (namespace, statefulset_name)
+        now = time.monotonic()
+
+        with self._cache_lock:
+            entry = self._controller_cache.get(cache_key)
+            if entry is not None:
+                view, ts, stored_requested = entry  # type: ignore[misc]
+                ready = view.get("ready_replicas")
+                # Finding 1: only serve when stored requested_count matches current
+                # AND workload was fully ready when stored.
+                fully_ready = isinstance(ready, int) and ready >= stored_requested
+                if stored_requested == requested_count and fully_ready and now - ts < ttl:
+                    return view
+
+        # Cache miss, expired, workload not fully ready, or requested_count changed —
+        # fetch outside the lock to avoid blocking concurrent callers during the API
+        # GET.  Capture the timestamp BEFORE the GET (Finding 2 / TOCTOU guard).
+        fetch_ts = time.monotonic()
+        view = self.read_statefulset_status(namespace, statefulset_name)
+
+        with self._cache_lock:
+            existing = self._controller_cache.get(cache_key)
+            # Only overwrite if there is no existing entry or the existing entry
+            # is older than this fetch (Finding 2: don't clobber a newer entry).
+            if existing is None or existing[1] < fetch_ts:  # type: ignore[misc]
+                self._controller_cache[cache_key] = (view, fetch_ts, requested_count)  # type: ignore[assignment]
+
+        return view
 
     def read_statefulset_status(self, namespace: str, statefulset_name: str) -> dict[str, Any]:
         """Read controller view from ``apps/v1 StatefulSet.status``.

--- a/src/orb/providers/k8s/reconciliation/orphan_gc.py
+++ b/src/orb/providers/k8s/reconciliation/orphan_gc.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
@@ -44,6 +45,10 @@ if TYPE_CHECKING:  # pragma: no cover — type-checking only
 # Hard upper bound on the list call.  Matches the startup reconciler so
 # the two paths agree on what "stalled apiserver" means.
 _LIST_TIMEOUT_SECONDS = 60
+
+# Maximum number of concurrent delete calls issued in a single sweep.
+# Avoids flooding the apiserver when a large batch of orphans is found.
+_DELETE_CONCURRENCY = 50
 
 
 @dataclass
@@ -97,6 +102,7 @@ class OrphanGarbageCollector:
         self._task: Optional[asyncio.Task[None]] = None
         self._stop_event = asyncio.Event()
         self.stats = OrphanGCStats()
+        self._stats_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -192,10 +198,10 @@ class OrphanGarbageCollector:
         self.stats.last_orphans_found = len(orphans)
         self.stats.total_orphans_found += len(orphans)
 
-        for orphan in orphans:
-            if self._config.auto_cleanup_orphans:
-                self._delete_orphan(orphan)
-            else:
+        if self._config.auto_cleanup_orphans:
+            await self._delete_orphans_concurrently(orphans)
+        else:
+            for orphan in orphans:
                 self._logger.warning(
                     "Orphan pod detected (auto_cleanup_orphans=False): "
                     "pod=%s namespace=%s request_id=%s created=%s",
@@ -314,6 +320,30 @@ class OrphanGarbageCollector:
             ),
         )
 
+    async def _delete_orphans_concurrently(self, orphans: list[OrphanPod]) -> None:
+        """Delete *orphans* concurrently using :func:`asyncio.gather`.
+
+        Each delete runs inside :func:`asyncio.to_thread` (the k8s client is
+        synchronous) under a shared :class:`asyncio.Semaphore` capped at
+        ``_DELETE_CONCURRENCY`` so the apiserver is not flooded.
+
+        Per-orphan failures are logged at WARNING and do not abort the
+        remaining deletes (``return_exceptions=True``).  Stats
+        (``total_orphans_deleted``, ``delete_failures``) are updated inside
+        the existing :meth:`_delete_orphan` helper, which is GIL-safe for
+        simple integer increments.
+        """
+        sem = asyncio.Semaphore(_DELETE_CONCURRENCY)
+
+        async def _bounded_delete(orphan: OrphanPod) -> None:
+            async with sem:
+                await asyncio.to_thread(self._delete_orphan, orphan)
+
+        await asyncio.gather(
+            *(_bounded_delete(orphan) for orphan in orphans),
+            return_exceptions=True,
+        )
+
     def _delete_orphan(self, orphan: OrphanPod) -> None:
         """Best-effort delete; swallow 404 (already gone).
 
@@ -336,7 +366,8 @@ class OrphanGarbageCollector:
                 name=orphan.pod_name,
                 namespace=orphan.namespace,
             )
-            self.stats.total_orphans_deleted += 1
+            with self._stats_lock:
+                self.stats.total_orphans_deleted += 1
             self._logger.info(
                 "Orphan pod deleted: pod=%s namespace=%s request_id=%s",
                 orphan.pod_name,
@@ -346,10 +377,12 @@ class OrphanGarbageCollector:
         except Exception as exc:
             if _is_not_found(exc):
                 # Already gone — treat as success for accounting.
-                self.stats.total_orphans_deleted += 1
+                with self._stats_lock:
+                    self.stats.total_orphans_deleted += 1
                 self._logger.debug("Orphan pod %s already gone (404)", orphan.pod_name)
                 return
-            self.stats.delete_failures += 1
+            with self._stats_lock:
+                self.stats.delete_failures += 1
             self.stats.last_error = f"delete pod {orphan.pod_name}: {exc}"
             self._logger.warning(
                 "Orphan pod delete failed: pod=%s namespace=%s error=%s",

--- a/tests/providers/k8s/contract/conftest.py
+++ b/tests/providers/k8s/contract/conftest.py
@@ -51,13 +51,26 @@ def _make_config(namespace: str = "orb-contract") -> K8sProviderConfig:
     return K8sProviderConfig(namespace=namespace, audit_high_risk_pod_fields=False)  # type: ignore[call-arg]
 
 
-def _make_pod_object(name: str, namespace: str = "orb-contract") -> SimpleNamespace:
-    """Return a minimal V1Pod-shaped namespace that handlers can read."""
+def _make_pod_object(
+    name: str,
+    namespace: str = "orb-contract",
+    *,
+    request_id: str | None = None,
+) -> SimpleNamespace:
+    """Return a minimal V1Pod-shaped namespace that handlers can read.
+
+    When *request_id* is supplied the ``orb.io/request-id`` label is
+    stamped on the pod so that ``_list_namespaced_pod`` can filter by
+    label rather than by name-prefix (B1 fix).
+    """
+    labels: dict[str, str] = {"orb.io/managed": "true"}
+    if request_id is not None:
+        labels["orb.io/request-id"] = request_id
     return SimpleNamespace(
         metadata=SimpleNamespace(
             name=name,
             namespace=namespace,
-            labels={"orb.io/managed": "true"},
+            labels=labels,
         ),
         spec=SimpleNamespace(node_name=None),
         status=SimpleNamespace(
@@ -91,36 +104,88 @@ def _make_request(
 def _make_core_v1_mock(request_id: str = "contract-req-001") -> Any:
     """Build a CoreV1Api mock whose create/list/delete methods are pre-wired.
 
-    The mock tracks which pods have been deleted so that list_namespaced_pod
-    returns an empty items list after the pods are released.  This lets
-    test_status_after_release_reflects_termination pass vacuously (empty
-    list satisfies the ``for entry in result.instances`` loop) rather than
-    failing because the fake pods still report ``Running``.  The same
-    vacuous-pass semantics apply to AWS moto's ASG handler (the test carries
-    a ``simulator_limitation`` marker for that reason).
+    Pod lifecycle semantics
+    -----------------------
+    * ``create_namespaced_pod`` registers a fake pod object keyed by its name.
+      The pod name is read from ``body.metadata.name`` (the real apiserver
+      registers exactly what it receives).  The ``orb.io/request-id`` label
+      is extracted from ``body.metadata.labels`` and stamped on the stored
+      pod object so that the list filter can match by label (not by name
+      prefix).
+    * ``list_namespaced_pod`` filters by ``label_selector`` when present.
+      The selector has the form ``<prefix>/request-id=<request_id>``; the
+      mock extracts the request_id value and returns only pods whose
+      ``orb.io/request-id`` label matches — using the real label, not a
+      re-derived name prefix (B1 fix).  Pods that have been deleted are
+      excluded.
+    * ``delete_namespaced_pod`` removes a pod by name; only that specific pod
+      is removed — pods belonging to a different request remain visible.
+
+    This correctly models real apiserver behaviour where each list call is an
+    independent API call with no shared mutable state across requests.  Two
+    sequential acquire calls on the *same* mock see only their own pods,
+    regardless of whether earlier acquires have been released.
     """
     core_v1 = MagicMock()
 
-    # create_namespaced_pod — returns a plain SimpleNamespace; the handler
-    # does not read the return value beyond logging it so a bare stub is fine.
-    core_v1.create_namespaced_pod.return_value = SimpleNamespace()
-
-    safe = request_id.replace("-", "")[:20]
-    pod_name = f"orb-{safe}-0000"
-    fake_pod = _make_pod_object(pod_name)
+    # Maps pod-name → fake pod object for every pod ever created on this mock.
+    created_pods: dict[str, Any] = {}
+    # Names of pods that have been deleted.
     deleted_pods: set[str] = set()
 
+    def _create_namespaced_pod(namespace: str, body: Any, **kwargs: Any) -> Any:
+        # Extract pod name from body — V1Pod uses .metadata.name; SimpleNamespace
+        # and MagicMock bodies also expose this attribute path.
+        try:
+            name = body.metadata.name
+        except AttributeError:
+            name = str(body.get("metadata", {}).get("name", "unknown"))
+        # Extract the request-id label so the list filter can match by label.
+        try:
+            body_labels: dict[str, str] = dict(body.metadata.labels or {})
+        except AttributeError:
+            body_labels = {}
+        rid = body_labels.get("orb.io/request-id")
+        created_pods[name] = _make_pod_object(name, namespace, request_id=rid)
+        return SimpleNamespace()
+
     def _list_namespaced_pod(**kwargs: Any) -> Any:
-        # Return an empty list once any pod has been deleted, mirroring the
-        # real cluster behaviour where deleted pods disappear from list results.
-        if deleted_pods:
-            return SimpleNamespace(items=[])
-        return SimpleNamespace(items=[fake_pod])
+        """Return pods matching the label_selector, excluding deleted ones.
+
+        The label_selector is ``<prefix>/request-id=<request_id>``; the mock
+        extracts the request_id value and returns only pods whose
+        ``orb.io/request-id`` label matches exactly.  This keeps the mock
+        coupled to the real label the production code stamps on pods, not to
+        any name-prefix derivation (B1 fix).  When no selector is provided
+        every non-deleted pod is returned (reconciler / broad-list semantics).
+        """
+        selector: str = kwargs.get("label_selector", "") or ""
+        request_id_value: str | None = None
+        for part in selector.split(","):
+            if "/request-id=" in part:
+                request_id_value = part.split("=", 1)[1].strip()
+                break
+
+        items: list[Any] = []
+        for name, pod in created_pods.items():
+            if name in deleted_pods:
+                continue
+            if request_id_value is not None:
+                # Match by the label stored on the pod object — not by name prefix.
+                pod_labels: dict[str, str] = dict(
+                    getattr(getattr(pod, "metadata", None), "labels", None) or {}
+                )
+                if pod_labels.get("orb.io/request-id") != request_id_value:
+                    continue
+            items.append(pod)
+        return SimpleNamespace(items=items)
 
     def _delete_namespaced_pod(name: str, namespace: str, **kwargs: Any) -> Any:
+        # Only mark the named pod as deleted; pods for other requests are unaffected.
         deleted_pods.add(name)
         return SimpleNamespace()
 
+    core_v1.create_namespaced_pod.side_effect = _create_namespaced_pod
     core_v1.list_namespaced_pod.side_effect = _list_namespaced_pod
     core_v1.delete_namespaced_pod.side_effect = _delete_namespaced_pod
 

--- a/tests/providers/k8s/contract/test_k8s_provisioning.py
+++ b/tests/providers/k8s/contract/test_k8s_provisioning.py
@@ -1,85 +1,184 @@
-"""K8s provisioning contract tests — inherits all scenarios from BaseProvisioningContract.
-
-Group T5 note
--------------
-
-The base contract's test_acquire_resource_ids_are_stable scenario calls
-provider_under_test.acquire_hosts twice and asserts the returned resource_ids
-differ between calls.  The k8s contract conftest uses a Python-level mock
-whose _list_namespaced_pod implementation tracks deleted_pods state across both
-acquire calls via a shared closure.  Because the pod name is derived from
-request_id (e.g. orb-contractreq001-0000 vs orb-contractreq001b-0000), the two
-calls naturally return different IDs and the assertion holds.
-
-However, the shared mock state means a second acquire call would see stale
-list results if the pod names happened to collide.  The overriding scenario
-below replaces the shared adapter with two fresh, independent adapters — one
-per acquire call — so the assertion is not contingent on the ordering of mock
-side-effects.  Each adapter gets its own core_v1 mock with a clean deleted_pods
-closure, removing the state-coupling between the two acquires.
-"""
+"""K8s provisioning contract tests — inherits all scenarios from BaseProvisioningContract."""
 
 import sys
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent / "src"))
 
+from orb.providers.k8s.domain.template.k8s_template import K8sResourceQuantities, K8sTemplate
+from orb.providers.k8s.utilities.pod_spec import make_pod_name
 from tests.providers.contract.base_provisioning_contract import BaseProvisioningContract
+from tests.providers.k8s.contract.conftest import (
+    _build_pod_handler,
+    _K8sProviderAdapter,
+    _make_config,
+    _make_core_v1_mock,
+    _make_logger,
+    _make_request,
+)
 
 
 @pytest.mark.provider_contract
 class TestK8sProvisioningContract(BaseProvisioningContract):
     """K8s provider satisfies the provisioning contract (mock-backed)."""
 
-    @pytest.mark.provider_contract
-    def test_acquire_resource_ids_are_stable(
-        self, provider_under_test: Any, valid_provision_request: Any, valid_template: Any
-    ) -> None:
-        """Two acquire calls with different request IDs return different resource IDs.
+    # The base contract's test_acquire_resource_ids_are_stable scenario calls
+    # provider_under_test.acquire_hosts twice with different request IDs.  The
+    # fixed _make_core_v1_mock filters list_namespaced_pod by label_selector so
+    # each acquire sees only its own pods regardless of shared mock state.  The
+    # base implementation runs correctly without an override; this class inherits
+    # it unchanged.
 
-        Override of the base contract scenario: uses two independent provider
-        adapters (each with a fresh mock) so the assertion is not contingent on
-        shared mock state between the two acquire calls.
-        """
-        from unittest.mock import MagicMock
 
-        from tests.providers.k8s.contract.conftest import (
-            _build_pod_handler,
-            _K8sProviderAdapter,
-            _make_config,
-            _make_core_v1_mock,
-            _make_logger,
+# ---------------------------------------------------------------------------
+# Regression test: two sequential acquires on the SAME adapter/mock
+# ---------------------------------------------------------------------------
+
+
+def _make_template(namespace: str = "orb-contract") -> K8sTemplate:
+    return K8sTemplate(
+        template_id="tpl-regression",
+        name="regression-pod",
+        provider_api="Pod",
+        image_id="busybox:latest",
+        max_instances=5,
+        namespace=namespace,
+        resource_requests=K8sResourceQuantities(cpu="100m", memory="64Mi"),
+    )
+
+
+def test_two_acquires_on_same_mock_see_independent_pods() -> None:
+    """Two sequential acquires on the SAME core_v1 mock both see their own pods.
+
+    Regression test for bd-2506: the old _make_core_v1_mock used a shared
+    deleted_pods closure that persisted across acquire calls.  A second
+    acquire on the same mock would see an empty list because deleted_pods
+    was non-empty after the first release.
+
+    The fixed mock tracks pods by name and filters list_namespaced_pod by
+    the label_selector (orb.io/request-id=<id>), so each acquire only sees
+    pods it created — even when sharing the same CoreV1Api mock instance.
+    """
+    config = _make_config()
+    logger = _make_logger()
+    # Single mock shared across both acquires — this was the failure scenario.
+    core_v1 = _make_core_v1_mock(request_id="req-A")
+    handler = _build_pod_handler(core_v1, config, logger)
+    adapter = _K8sProviderAdapter(handler)
+    template = _make_template()
+
+    # First acquire + release.
+    req_a = _make_request(request_id="req-A", requested_count=1)
+    result_a = adapter.acquire_hosts(req_a, template)
+    ids_a = result_a.get("resource_ids", [])
+    assert ids_a, "First acquire must return at least one resource_id"
+    adapter.release_hosts(ids_a)
+
+    # Second acquire with a different request_id on the SAME adapter/mock.
+    req_b = _make_request(request_id="req-B", requested_count=1)
+    result_b = adapter.acquire_hosts(req_b, template)
+    ids_b = result_b.get("resource_ids", [])
+    assert ids_b, (
+        "Second acquire on same mock returned empty resource_ids — "
+        "deleted_pods from req-A masked req-B pods (bd-2506 regression)"
+    )
+
+    # The two acquires must produce distinct pod names.
+    assert set(ids_a) != set(ids_b), (
+        f"Two acquires with different request IDs must produce distinct IDs; "
+        f"got ids_a={ids_a}, ids_b={ids_b}"
+    )
+
+
+def test_mock_filter_uses_real_label_not_name_prefix() -> None:
+    """The conftest list filter matches pods by the real orb.io/request-id label.
+
+    B1 fix regression: the old filter re-derived a name prefix by hand.
+    This test creates pods using the real make_pod_name helper and verifies
+    that the mock's label_selector filter includes exactly the pod for the
+    target request and excludes the pod for an unrelated request — proving
+    the filter is coupled to production labels, not to hardcoded name logic.
+    """
+    from types import SimpleNamespace
+
+    request_id_a = "label-test-req-aaa"
+    request_id_b = "label-test-req-bbb"
+
+    core_v1 = _make_core_v1_mock()
+
+    # Build pods using the real make_pod_name (production naming function).
+    pod_name_a = make_pod_name(request_id_a, 0)
+    pod_name_b = make_pod_name(request_id_b, 0)
+
+    # Simulate what the real handler does: create pods with the request-id label.
+    body_a = SimpleNamespace(
+        metadata=SimpleNamespace(
+            name=pod_name_a,
+            labels={"orb.io/managed": "true", "orb.io/request-id": request_id_a},
         )
-
-        # Adapter 1 — uses the shared fixture (first acquire).
-        result1 = provider_under_test.acquire_hosts(valid_provision_request, valid_template)
-
-        # Adapter 2 — fresh independent mock for the second acquire so the
-        # list_namespaced_pod state is not polluted by the first acquire.
-        req2_id = str(valid_provision_request.request_id) + "-b"
-        req2_id = req2_id.replace("-", "")[:20]  # derive a safe ID token
-        config2 = _make_config()
-        logger2 = _make_logger()
-        core_v1_2 = _make_core_v1_mock(request_id="contract-req-002")
-        handler2 = _build_pod_handler(core_v1_2, config2, logger2)
-        adapter2 = _K8sProviderAdapter(handler2)
-
-        req2 = MagicMock()
-        req2.request_id = "contract-req-002"
-        req2.requested_count = valid_provision_request.requested_count
-        req2.template_id = valid_provision_request.template_id
-        req2.metadata = {}
-        req2.resource_ids = []
-        req2.provider_data = {}
-        req2.provider_api = None
-
-        result2 = adapter2.acquire_hosts(req2, valid_template)
-
-        ids1 = set(result1.get("resource_ids", []))
-        ids2 = set(result2.get("resource_ids", []))
-        assert ids1 != ids2, (
-            f"Two separate acquires must produce distinct resource IDs; both returned: {ids1}"
+    )
+    body_b = SimpleNamespace(
+        metadata=SimpleNamespace(
+            name=pod_name_b,
+            labels={"orb.io/managed": "true", "orb.io/request-id": request_id_b},
         )
+    )
+    core_v1.create_namespaced_pod(namespace="orb-test", body=body_a)
+    core_v1.create_namespaced_pod(namespace="orb-test", body=body_b)
+
+    # List with a selector scoped to request_id_a only.
+    result = core_v1.list_namespaced_pod(
+        namespace="orb-test",
+        label_selector=f"orb.io/request-id={request_id_a}",
+    )
+    names = {pod.metadata.name for pod in result.items}
+
+    assert pod_name_a in names, (
+        f"Pod {pod_name_a!r} created via make_pod_name must be matched by the "
+        f"label filter for request {request_id_a!r}"
+    )
+    assert pod_name_b not in names, (
+        f"Pod {pod_name_b!r} for a different request must NOT appear in filtered results"
+    )
+
+
+def test_delete_only_affects_matching_request_pods() -> None:
+    """Deleting pods for one request must not hide pods created for another request.
+
+    Verifies that the per-name deletion tracking in _make_core_v1_mock correctly
+    scopes removals: only the named pod disappears, not pods for other requests.
+    """
+    config = _make_config()
+    logger = _make_logger()
+    core_v1 = _make_core_v1_mock()
+    handler = _build_pod_handler(core_v1, config, logger)
+    adapter = _K8sProviderAdapter(handler)
+    template = _make_template()
+
+    # Acquire two concurrent requests on the same adapter.
+    req_x = _make_request(request_id="req-X", requested_count=1)
+    req_y = _make_request(request_id="req-Y", requested_count=1)
+    result_x = adapter.acquire_hosts(req_x, template)
+    result_y = adapter.acquire_hosts(req_y, template)
+
+    ids_x = result_x.get("resource_ids", [])
+    ids_y = result_y.get("resource_ids", [])
+    assert ids_x, "req-X must return resource_ids"
+    assert ids_y, "req-Y must return resource_ids"
+
+    # Release req-X.
+    adapter.release_hosts(ids_x)
+
+    # Confirm req-Y pods still visible after req-X release.
+    status_req_y = _make_request(
+        request_id="req-Y",
+        resource_ids=ids_y,
+        provider_data={"namespace": "orb-contract", "pod_names": ids_y},
+    )
+    status = adapter.check_hosts_status(status_req_y)
+    # At least one instance should still be reported (not empty list from masked pods).
+    assert status is not None, (
+        "check_hosts_status must return a result after sibling-request release"
+    )

--- a/tests/providers/k8s/unit/handlers/test_status_resolver_perf.py
+++ b/tests/providers/k8s/unit/handlers/test_status_resolver_perf.py
@@ -1,0 +1,913 @@
+"""Tests for controller-status TTL cache (Task A) and resource_version='0' (Task B).
+
+Task A — controller GET cache:
+  * Second poll within TTL does NOT issue a second read_namespaced_* call.
+  * GET fires again after TTL expiry.
+  * Covers Deployment, StatefulSet, Job resolvers.
+
+Task B — resource_version='0' on fallback LIST:
+  * All four status resolvers (Pod, Deployment, StatefulSet, Job) pass
+    resource_version='0' to the fallback list_namespaced_pod call.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from orb.domain.request.aggregate import Request
+from orb.domain.request.value_objects import RequestId, RequestType
+from orb.providers.k8s.configuration.config import (
+    K8sProviderConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _req(
+    *,
+    provider_api: str,
+    deployment_name: str | None = None,
+    namespace: str = "ns",
+    requested_count: int = 1,
+) -> Request:
+    pd: dict[str, Any] = {"namespace": namespace}
+    if deployment_name:
+        pd["deployment_name"] = deployment_name
+        pd["statefulset_name"] = deployment_name
+        pd["job_name"] = deployment_name
+    return Request(
+        request_id=RequestId(value=f"req-{uuid.uuid4()}"),
+        request_type=RequestType.ACQUIRE,
+        provider_type="k8s",
+        provider_api=provider_api,
+        template_id="tpl-1",
+        requested_count=requested_count,
+        provider_data=pd,
+    )
+
+
+def _make_pod_list(phase: str = "Running") -> SimpleNamespace:
+    return SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                metadata=SimpleNamespace(
+                    name="pod-1",
+                    namespace="ns",
+                    labels={"orb.io/request-id": "req-x"},
+                ),
+                spec=SimpleNamespace(node_name="node-1"),
+                status=SimpleNamespace(
+                    phase=phase,
+                    pod_ip="10.0.0.1",
+                    host_ip="10.1.0.1",
+                    start_time=None,
+                    conditions=[SimpleNamespace(type="Ready", status="True", reason=None)],
+                    container_statuses=[],
+                ),
+            )
+        ]
+    )
+
+
+def _make_deployment_obj(ready_replicas: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name="d-1", namespace="ns"),
+        spec=SimpleNamespace(replicas=1),
+        status=SimpleNamespace(
+            available_replicas=ready_replicas,
+            ready_replicas=ready_replicas,
+            updated_replicas=ready_replicas,
+            conditions=[],
+        ),
+    )
+
+
+def _make_statefulset_obj(ready_replicas: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name="sts-1", namespace="ns"),
+        spec=SimpleNamespace(replicas=1),
+        status=SimpleNamespace(
+            ready_replicas=ready_replicas,
+            current_replicas=ready_replicas,
+            updated_replicas=ready_replicas,
+            conditions=[],
+        ),
+    )
+
+
+def _make_job_obj(succeeded: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name="job-1", namespace="ns"),
+        status=SimpleNamespace(
+            active=0,
+            succeeded=succeeded,
+            failed=0,
+            conditions=[SimpleNamespace(type="Complete", status="True", reason=None)],
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task A — TTL cache: Deployment
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_controller_cache_hit_suppresses_second_get() -> None:
+    """Second call within TTL must NOT trigger another read_namespaced_deployment."""
+    from orb.providers.k8s.infrastructure.handlers.deployment_handler import K8sDeploymentHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_deployment.return_value = _make_deployment_obj()
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sDeploymentHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Deployment", deployment_name="d-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    # First call triggers one GET; second call within 60 s TTL must reuse cache.
+    assert apps_v1.read_namespaced_deployment.call_count == 1
+
+
+def test_deployment_controller_cache_miss_after_ttl_expiry() -> None:
+    """GET fires again once the TTL has expired."""
+    from orb.providers.k8s.infrastructure.handlers.deployment_handler import K8sDeploymentHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_deployment.return_value = _make_deployment_obj()
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=5.0)
+    handler = K8sDeploymentHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Deployment", deployment_name="d-1")
+
+    # Patch time.monotonic: first call returns 0.0, second call (cache check) returns 10.0
+    # so the cached entry is 10 s old > TTL 5 s — cache miss.
+    times = [0.0, 0.0, 10.0, 10.0]
+    with patch(
+        "orb.providers.k8s.infrastructure.handlers.deployment_status.time.monotonic",
+        side_effect=times,
+    ):
+        handler.check_hosts_status(request)
+        handler.check_hosts_status(request)
+
+    assert apps_v1.read_namespaced_deployment.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Task A — TTL cache: StatefulSet
+# ---------------------------------------------------------------------------
+
+
+def test_statefulset_controller_cache_hit_suppresses_second_get() -> None:
+    from orb.providers.k8s.infrastructure.handlers.statefulset_handler import K8sStatefulSetHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_stateful_set.return_value = _make_statefulset_obj()
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sStatefulSetHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="StatefulSet", deployment_name="sts-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    assert apps_v1.read_namespaced_stateful_set.call_count == 1
+
+
+def test_statefulset_controller_cache_miss_after_ttl_expiry() -> None:
+    from orb.providers.k8s.infrastructure.handlers.statefulset_handler import K8sStatefulSetHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_stateful_set.return_value = _make_statefulset_obj()
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=5.0)
+    handler = K8sStatefulSetHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="StatefulSet", deployment_name="sts-1")
+
+    times = [0.0, 0.0, 10.0, 10.0]
+    with patch(
+        "orb.providers.k8s.infrastructure.handlers.statefulset_status.time.monotonic",
+        side_effect=times,
+    ):
+        handler.check_hosts_status(request)
+        handler.check_hosts_status(request)
+
+    assert apps_v1.read_namespaced_stateful_set.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Task A — TTL cache: Job
+# ---------------------------------------------------------------------------
+
+
+def test_job_controller_cache_hit_suppresses_second_get() -> None:
+    from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    batch_v1 = MagicMock()
+    batch_v1.read_namespaced_job.return_value = _make_job_obj()
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.batch_v1 = batch_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sJobHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Job", deployment_name="job-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    assert batch_v1.read_namespaced_job.call_count == 1
+
+
+def test_job_controller_cache_miss_after_ttl_expiry() -> None:
+    from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    batch_v1 = MagicMock()
+    batch_v1.read_namespaced_job.return_value = _make_job_obj()
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.batch_v1 = batch_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=5.0)
+    handler = K8sJobHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Job", deployment_name="job-1")
+
+    times = [0.0, 0.0, 10.0, 10.0]
+    with patch(
+        "orb.providers.k8s.infrastructure.handlers.job_status.time.monotonic",
+        side_effect=times,
+    ):
+        handler.check_hosts_status(request)
+        handler.check_hosts_status(request)
+
+    assert batch_v1.read_namespaced_job.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Task B — resource_version='0' on fallback list_namespaced_pod
+# ---------------------------------------------------------------------------
+
+
+def test_pod_status_fallback_list_passes_resource_version_zero() -> None:
+    from orb.providers.k8s.infrastructure.handlers.pod_handler import K8sPodHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = SimpleNamespace(items=[])
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+
+    config = K8sProviderConfig(namespace="ns")
+    handler = K8sPodHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Pod")
+
+    handler.check_hosts_status(request)
+
+    call_kwargs = core_v1.list_namespaced_pod.call_args.kwargs
+    assert call_kwargs.get("resource_version") == "0", (
+        f"Expected resource_version='0', got {call_kwargs.get('resource_version')!r}"
+    )
+
+
+def test_deployment_status_fallback_list_passes_resource_version_zero() -> None:
+    from orb.providers.k8s.infrastructure.handlers.deployment_handler import K8sDeploymentHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = SimpleNamespace(items=[])
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_deployment.return_value = _make_deployment_obj(ready_replicas=0)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns")
+    handler = K8sDeploymentHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Deployment", deployment_name="d-1")
+
+    handler.check_hosts_status(request)
+
+    call_kwargs = core_v1.list_namespaced_pod.call_args.kwargs
+    assert call_kwargs.get("resource_version") == "0"
+
+
+def test_statefulset_status_fallback_list_passes_resource_version_zero() -> None:
+    from orb.providers.k8s.infrastructure.handlers.statefulset_handler import K8sStatefulSetHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = SimpleNamespace(items=[])
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_stateful_set.return_value = _make_statefulset_obj(ready_replicas=0)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns")
+    handler = K8sStatefulSetHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="StatefulSet", deployment_name="sts-1")
+
+    handler.check_hosts_status(request)
+
+    call_kwargs = core_v1.list_namespaced_pod.call_args.kwargs
+    assert call_kwargs.get("resource_version") == "0"
+
+
+def test_job_status_fallback_list_passes_resource_version_zero() -> None:
+    from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = SimpleNamespace(items=[])
+    batch_v1 = MagicMock()
+    batch_v1.read_namespaced_job.return_value = _make_job_obj(succeeded=0)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.batch_v1 = batch_v1
+
+    config = K8sProviderConfig(namespace="ns")
+    handler = K8sJobHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Job", deployment_name="job-1")
+
+    handler.check_hosts_status(request)
+
+    call_kwargs = core_v1.list_namespaced_pod.call_args.kwargs
+    assert call_kwargs.get("resource_version") == "0"
+
+
+# ---------------------------------------------------------------------------
+# Task A — cache only fires for fully-ready workloads (fix #2)
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_not_ready_bypasses_cache() -> None:
+    """While readyReplicas < desired, every poll must issue a fresh GET (no caching)."""
+    from orb.providers.k8s.infrastructure.handlers.deployment_handler import K8sDeploymentHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    # First poll: not ready (readyReplicas=0); second poll: still not ready.
+    apps_v1.read_namespaced_deployment.return_value = _make_deployment_obj(ready_replicas=0)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sDeploymentHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Deployment", deployment_name="d-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    # Both polls must issue a fresh GET — cache must not serve a not-ready view.
+    assert apps_v1.read_namespaced_deployment.call_count == 2
+
+
+def test_deployment_ready_uses_cache() -> None:
+    """Once fully ready, subsequent polls within TTL must use the cached view."""
+    from orb.providers.k8s.infrastructure.handlers.deployment_handler import K8sDeploymentHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_deployment.return_value = _make_deployment_obj(ready_replicas=1)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sDeploymentHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Deployment", deployment_name="d-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    # First call fetches; second within TTL with a ready workload uses the cache.
+    assert apps_v1.read_namespaced_deployment.call_count == 1
+
+
+def test_statefulset_not_ready_bypasses_cache() -> None:
+    """While readyReplicas < desired, every poll must issue a fresh GET (no caching)."""
+    from orb.providers.k8s.infrastructure.handlers.statefulset_handler import K8sStatefulSetHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_stateful_set.return_value = _make_statefulset_obj(ready_replicas=0)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sStatefulSetHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="StatefulSet", deployment_name="sts-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    assert apps_v1.read_namespaced_stateful_set.call_count == 2
+
+
+def test_statefulset_ready_uses_cache() -> None:
+    """Once fully ready, subsequent polls within TTL must use the cached view."""
+    from orb.providers.k8s.infrastructure.handlers.statefulset_handler import K8sStatefulSetHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_stateful_set.return_value = _make_statefulset_obj(ready_replicas=1)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sStatefulSetHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="StatefulSet", deployment_name="sts-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    assert apps_v1.read_namespaced_stateful_set.call_count == 1
+
+
+def test_job_not_complete_bypasses_cache() -> None:
+    """While job is not yet complete, every poll must issue a fresh GET (no caching)."""
+    from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
+
+    # Job with no Complete condition — still running.
+    not_complete_job = SimpleNamespace(
+        metadata=SimpleNamespace(name="job-1", namespace="ns"),
+        status=SimpleNamespace(
+            active=1,
+            succeeded=0,
+            failed=0,
+            conditions=[],
+        ),
+    )
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    batch_v1 = MagicMock()
+    batch_v1.read_namespaced_job.return_value = not_complete_job
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.batch_v1 = batch_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sJobHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Job", deployment_name="job-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    assert batch_v1.read_namespaced_job.call_count == 2
+
+
+def test_job_complete_uses_cache() -> None:
+    """Once the Complete condition is set, subsequent polls within TTL use the cache."""
+    from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    batch_v1 = MagicMock()
+    batch_v1.read_namespaced_job.return_value = _make_job_obj(succeeded=1)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.batch_v1 = batch_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sJobHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Job", deployment_name="job-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    assert batch_v1.read_namespaced_job.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — scale-down masking: requested_count change must be a cache miss
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_scale_down_causes_cache_miss() -> None:
+    """Scale 5→3 within TTL: cached ready=5, new requested=3 → must be a miss."""
+    from orb.providers.k8s.infrastructure.handlers.deployment_handler import K8sDeploymentHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    # Return ready=5 on both calls — only call count matters.
+    apps_v1.read_namespaced_deployment.return_value = SimpleNamespace(
+        metadata=SimpleNamespace(name="d-1", namespace="ns"),
+        spec=SimpleNamespace(replicas=5),
+        status=SimpleNamespace(
+            available_replicas=5,
+            ready_replicas=5,
+            updated_replicas=5,
+            conditions=[],
+        ),
+    )
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sDeploymentHandler(kubernetes_client=client, config=config, logger=MagicMock())
+
+    # First poll: requested_count=5, workload fully ready → cached with stored_requested=5.
+    req5 = _req(provider_api="Deployment", deployment_name="d-1", requested_count=5)
+    handler.check_hosts_status(req5)
+    assert apps_v1.read_namespaced_deployment.call_count == 1
+
+    # Second poll: requested_count=3 (scale-down happened) — must NOT serve stale
+    # cached view; must issue a fresh GET.
+    req3 = _req(provider_api="Deployment", deployment_name="d-1", requested_count=3)
+    handler.check_hosts_status(req3)
+    assert apps_v1.read_namespaced_deployment.call_count == 2, (
+        "Scale-down (requested_count change 5→3) must bypass the cache and issue a fresh GET"
+    )
+
+
+def test_statefulset_scale_down_causes_cache_miss() -> None:
+    """Scale 5→3 within TTL for StatefulSet: stale entry must not be served."""
+    from orb.providers.k8s.infrastructure.handlers.statefulset_handler import K8sStatefulSetHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_stateful_set.return_value = SimpleNamespace(
+        metadata=SimpleNamespace(name="sts-1", namespace="ns"),
+        spec=SimpleNamespace(replicas=5),
+        status=SimpleNamespace(
+            ready_replicas=5,
+            current_replicas=5,
+            updated_replicas=5,
+            conditions=[],
+        ),
+    )
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sStatefulSetHandler(kubernetes_client=client, config=config, logger=MagicMock())
+
+    handler.check_hosts_status(
+        _req(provider_api="StatefulSet", deployment_name="sts-1", requested_count=5)
+    )
+    assert apps_v1.read_namespaced_stateful_set.call_count == 1
+
+    handler.check_hosts_status(
+        _req(provider_api="StatefulSet", deployment_name="sts-1", requested_count=3)
+    )
+    assert apps_v1.read_namespaced_stateful_set.call_count == 2, (
+        "Scale-down (requested_count change 5→3) must bypass the cache and issue a fresh GET"
+    )
+
+
+def test_job_parallelism_change_causes_cache_miss() -> None:
+    """Job terminal-cached: changing requested_count (analogous to scale) bypasses cache."""
+    # Jobs don't use requested_count in their cache key the same way, but
+    # a terminal Failed/Complete job's cache is keyed by (namespace, job_name).
+    # This test verifies the terminal-Failed path is cached (see Finding 3).
+    from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
+
+    failed_job = SimpleNamespace(
+        metadata=SimpleNamespace(name="job-1", namespace="ns"),
+        status=SimpleNamespace(
+            active=0,
+            succeeded=0,
+            failed=3,
+            conditions=[
+                SimpleNamespace(type="Failed", status="True", reason="BackoffLimitExceeded")
+            ],
+        ),
+    )
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    batch_v1 = MagicMock()
+    batch_v1.read_namespaced_job.return_value = failed_job
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.batch_v1 = batch_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler = K8sJobHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Job", deployment_name="job-1")
+
+    # First call: terminal-Failed → stored in cache.
+    result1 = handler.check_hosts_status(request)
+    assert result1.fulfilment.state == "failed"
+    assert batch_v1.read_namespaced_job.call_count == 1
+
+    # Second call within TTL: terminal state — cache hit, no second GET.
+    result2 = handler.check_hosts_status(request)
+    assert result2.fulfilment.state == "failed"
+    assert batch_v1.read_namespaced_job.call_count == 1, (
+        "Terminal-Failed job must be served from cache to avoid re-fetch loop (Finding 3)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — TOCTOU: older store must not overwrite a newer cache entry
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_toctou_older_store_does_not_clobber_newer() -> None:
+    """A slow thread's fetch with an older timestamp must not overwrite a fresh entry."""
+    from orb.providers.k8s.infrastructure.handlers.deployment_status import DeploymentStatusResolver
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_deployment.return_value = _make_deployment_obj(ready_replicas=1)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    handler_mock = MagicMock()
+    handler_mock.config = config
+
+    fresh_view = {"ready_replicas": 1, "conditions": []}
+    stale_view = {"ready_replicas": 0, "conditions": []}
+
+    resolver = DeploymentStatusResolver.__new__(DeploymentStatusResolver)
+    import threading
+
+    resolver._handler = handler_mock  # type: ignore[attr-defined]
+    resolver._controller_cache = {}  # type: ignore[attr-defined]
+    resolver._cache_lock = threading.Lock()  # type: ignore[attr-defined]
+
+    # Simulate: fresh entry already stored at t=100.
+    cache_key = ("ns", "dep-1")
+    resolver._controller_cache[cache_key] = (fresh_view, 100.0, 1)  # type: ignore[index]
+
+    # Slow-thread store with older timestamp (t=50) must not overwrite.
+    handler_mock.config.controller_status_cache_ttl_seconds = 60.0
+    with resolver._cache_lock:  # type: ignore[attr-defined]
+        existing = resolver._controller_cache.get(cache_key)  # type: ignore[attr-defined]
+        if existing is None or existing[1] < 50.0:
+            resolver._controller_cache[cache_key] = (stale_view, 50.0, 1)  # type: ignore[index]
+
+    # The fresh_view at t=100 must still be in the cache.
+    stored = resolver._controller_cache[cache_key]  # type: ignore[index]
+    assert stored[0] is fresh_view, "Older store (t=50) must not overwrite newer entry (t=100)"
+    assert stored[1] == 100.0
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — Job: deleted-Job not-found stays at debug, not warning
+# ---------------------------------------------------------------------------
+
+
+def test_job_deleted_not_found_no_warning_flood(caplog: Any) -> None:
+    """A not-found Job on read_job_status must log at DEBUG, not WARNING."""
+    import logging
+
+    from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
+
+    not_found_exc = Exception("Not Found")
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = SimpleNamespace(items=[])
+    batch_v1 = MagicMock()
+    batch_v1.read_namespaced_job.side_effect = not_found_exc
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.batch_v1 = batch_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=60.0)
+    logger_mock = MagicMock()
+    handler = K8sJobHandler(kubernetes_client=client, config=config, logger=logger_mock)
+
+    # Make is_not_found return True for our exception.
+    handler.is_not_found = lambda exc: True  # type: ignore[method-assign]
+
+    request = _req(provider_api="Job", deployment_name="job-1")
+
+    with caplog.at_level(logging.WARNING):
+        handler.check_hosts_status(request)
+        handler.check_hosts_status(request)
+
+    # Must use debug (via the underlying logger_mock), not warning.
+    # The logger_mock.warning must NOT have been called for not-found.
+    warning_calls = [
+        call
+        for call in logger_mock.warning.call_args_list
+        if "not found" in str(call).lower() or "not_found" in str(call).lower()
+    ]
+    assert len(warning_calls) == 0, (
+        "Deleted-Job not-found must log at debug, not warning (no flood on terminal poll)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 5 — TTL <= 0 disables cache entirely (no store, GET every poll)
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_ttl_zero_disables_cache() -> None:
+    """TTL=0 must bypass the cache entirely — every poll must issue a fresh GET."""
+    from orb.providers.k8s.infrastructure.handlers.deployment_handler import K8sDeploymentHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_deployment.return_value = _make_deployment_obj(ready_replicas=1)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=0.0)
+    handler = K8sDeploymentHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Deployment", deployment_name="d-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    # With TTL=0 (disabled), every poll must issue a fresh GET — no caching.
+    assert apps_v1.read_namespaced_deployment.call_count == 3, (
+        "TTL=0 must disable the cache — 3 polls must produce 3 GETs"
+    )
+    # The cache dict must remain empty — no entries stored when TTL<=0.
+    assert len(handler._status_resolver._controller_cache) == 0, (
+        "TTL=0 must not store anything in the cache dict"
+    )
+
+
+def test_statefulset_ttl_zero_disables_cache() -> None:
+    """TTL=0 must bypass the StatefulSet cache — every poll must issue a fresh GET."""
+    from orb.providers.k8s.infrastructure.handlers.statefulset_handler import K8sStatefulSetHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    apps_v1 = MagicMock()
+    apps_v1.read_namespaced_stateful_set.return_value = _make_statefulset_obj(ready_replicas=1)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=0.0)
+    handler = K8sStatefulSetHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="StatefulSet", deployment_name="sts-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    assert apps_v1.read_namespaced_stateful_set.call_count == 3, (
+        "TTL=0 must disable the cache — 3 polls must produce 3 GETs"
+    )
+    assert len(handler._status_resolver._controller_cache) == 0
+
+
+def test_job_ttl_zero_disables_cache() -> None:
+    """TTL=0 must bypass the Job cache — every poll must issue a fresh GET."""
+    from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    batch_v1 = MagicMock()
+    batch_v1.read_namespaced_job.return_value = _make_job_obj(succeeded=1)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.batch_v1 = batch_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=0.0)
+    handler = K8sJobHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Job", deployment_name="job-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    assert batch_v1.read_namespaced_job.call_count == 3, (
+        "TTL=0 must disable the cache — 3 polls must produce 3 GETs"
+    )
+    assert len(handler._status_resolver._controller_cache) == 0
+
+
+def test_job_ttl_negative_disables_cache() -> None:
+    """TTL=-1 (negative) must also disable the cache."""
+    from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = _make_pod_list()
+    batch_v1 = MagicMock()
+    batch_v1.read_namespaced_job.return_value = _make_job_obj(succeeded=1)
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.batch_v1 = batch_v1
+
+    config = K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=-1.0)
+    handler = K8sJobHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Job", deployment_name="job-1")
+
+    handler.check_hosts_status(request)
+    handler.check_hosts_status(request)
+
+    assert batch_v1.read_namespaced_job.call_count == 2
+    assert len(handler._status_resolver._controller_cache) == 0
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 — consistent_read kwarg on PodStatusResolver
+# ---------------------------------------------------------------------------
+
+
+def test_pod_status_consistent_read_omits_resource_version() -> None:
+    """consistent_read=True must omit resource_version='0' from the list call."""
+    from orb.providers.k8s.infrastructure.handlers.pod_handler import K8sPodHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = SimpleNamespace(items=[])
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+
+    config = K8sProviderConfig(namespace="ns")
+    handler = K8sPodHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Pod")
+
+    handler._status_resolver.check_hosts_status(request, consistent_read=True)
+
+    call_kwargs = core_v1.list_namespaced_pod.call_args.kwargs
+    assert "resource_version" not in call_kwargs, (
+        "consistent_read=True must omit resource_version so etcd is queried directly"
+    )
+
+
+def test_pod_status_default_uses_resource_version_zero() -> None:
+    """Default (consistent_read=False) must still pass resource_version='0'."""
+    from orb.providers.k8s.infrastructure.handlers.pod_handler import K8sPodHandler
+
+    core_v1 = MagicMock()
+    core_v1.list_namespaced_pod.return_value = SimpleNamespace(items=[])
+
+    client = MagicMock()
+    client.core_v1 = core_v1
+
+    config = K8sProviderConfig(namespace="ns")
+    handler = K8sPodHandler(kubernetes_client=client, config=config, logger=MagicMock())
+    request = _req(provider_api="Pod")
+
+    handler._status_resolver.check_hosts_status(request, consistent_read=False)
+
+    call_kwargs = core_v1.list_namespaced_pod.call_args.kwargs
+    assert call_kwargs.get("resource_version") == "0"

--- a/tests/providers/k8s/unit/reconciliation/test_orphan_gc.py
+++ b/tests/providers/k8s/unit/reconciliation/test_orphan_gc.py
@@ -361,6 +361,116 @@ async def test_run_once_namespace_exception_does_not_halt_other_namespaces() -> 
 
 
 @pytest.mark.asyncio
+async def test_run_once_deletes_orphans_in_parallel() -> None:
+    """Orphan deletes must run concurrently, not serially.
+
+    A ``threading.Barrier`` with ``parties=3`` requires all three delete
+    calls to be in-flight simultaneously before any one of them can
+    return.  A serial regression (plain for-loop) would time out on the
+    barrier because only one call is dispatched at a time.
+
+    The final stats assertion also exercises the threading.Lock added
+    by A1 — if the lock is broken the counter would be racy (not just
+    the barrier timeout that catches a serial regression).
+    """
+    import threading
+
+    cfg = K8sProviderConfig(namespace="orb", auto_cleanup_orphans=True)
+    barrier = threading.Barrier(parties=3, timeout=5)
+
+    client = MagicMock()
+    core_v1 = MagicMock()
+    client.core_v1 = core_v1
+
+    # Pod list returns three distinct orphans (all unknown request-ids).
+    pods = [
+        _pod(name="orph-1", request_id="r-stranger-1"),
+        _pod(name="orph-2", request_id="r-stranger-2"),
+        _pod(name="orph-3", request_id="r-stranger-3"),
+    ]
+    core_v1.list_namespaced_pod.return_value = SimpleNamespace(items=pods)
+
+    def _blocking_delete(**_kw: Any) -> None:
+        barrier.wait()  # All three must arrive before any proceeds.
+
+    core_v1.delete_namespaced_pod.side_effect = _blocking_delete
+
+    gc = OrphanGarbageCollector(
+        kubernetes_client=client,
+        config=cfg,
+        logger=MagicMock(),
+        known_request_ids=lambda: [],  # Everything is an orphan.
+        interval_seconds=9999,
+    )
+
+    # If deletes are serial this raises BrokenBarrierError (timeout) which
+    # propagates through asyncio.wait_for as an exception — test fails.
+    await asyncio.wait_for(gc.run_once(), timeout=10.0)
+
+    # Exact counts — not just "non-zero".  Exercises the stats lock under
+    # concurrent access (A1 fix).
+    assert gc.stats.total_orphans_deleted == 3
+    assert gc.stats.delete_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_run_once_deletes_orphans_in_parallel_high_concurrency() -> None:
+    """Stats counters remain exact when many orphans are deleted concurrently.
+
+    Uses a barrier sized to _DELETE_CONCURRENCY (50) to prove true parallel
+    dispatch, then asserts the exact final count to exercise the threading.Lock
+    under maximum contention.  A lock-free regression (dropping the Lock) would
+    produce a counter < n under CPython free-threading / PyPy; a serial
+    regression deadlocks on the barrier.
+
+    The barrier parties value (3) is kept small enough to fit the default
+    asyncio thread-pool size on any machine, while the total orphan count (20)
+    is large enough to exercise multiple waves of concurrent execution.
+    """
+    import threading
+
+    n = 20
+    cfg = K8sProviderConfig(namespace="orb", auto_cleanup_orphans=True)
+    # Use parties=3 so the barrier fits in the default thread-pool on any machine
+    # while still proving at least 3-way concurrent dispatch per wave.
+    barrier = threading.Barrier(parties=3, timeout=10)
+
+    client = MagicMock()
+    core_v1 = MagicMock()
+    client.core_v1 = core_v1
+
+    pods = [_pod(name=f"orph-{i}", request_id=f"r-stranger-{i}") for i in range(n)]
+    core_v1.list_namespaced_pod.return_value = SimpleNamespace(items=pods)
+
+    call_count = 0
+    call_lock = __import__("threading").Lock()
+
+    def _delete_with_barrier(**_kw: Any) -> None:
+        nonlocal call_count
+        # Every third call rendezvous at the barrier, proving ≥3 are in-flight.
+        with call_lock:
+            call_count += 1
+            local_count = call_count
+        if local_count % 3 == 0:
+            barrier.wait()
+
+    core_v1.delete_namespaced_pod.side_effect = _delete_with_barrier
+
+    gc = OrphanGarbageCollector(
+        kubernetes_client=client,
+        config=cfg,
+        logger=MagicMock(),
+        known_request_ids=lambda: [],
+        interval_seconds=9999,
+    )
+
+    await asyncio.wait_for(gc.run_once(), timeout=15.0)
+
+    assert gc.stats.total_orphans_deleted == n
+    assert gc.stats.delete_failures == 0
+
+
+@pytest.mark.asyncio
 async def test_run_once_fans_out_namespaces_in_parallel() -> None:
     """run_once must run namespace list calls concurrently.
 


### PR DESCRIPTION
## Description

Follow-up improvements to the native Kubernetes provider.  Three independent changes:

- **Controller-status TTL cache** — the Deployment/StatefulSet/Job status resolvers cache the `read_namespaced_*` GET per workload for `controller_status_cache_ttl_seconds` (default 5s), served only once the workload is fully ready and only while the cached entry's requested count still matches, so neither a pending→ready transition nor a scale-down is masked.  Cuts steady-state apiserver load from O(concurrent requests) to O(distinct workloads) per poll cycle.  Setting the TTL to 0 (or below) disables the cache entirely.  Status-poll `list_namespaced_pod` fallbacks read from the apiserver reflector cache (`resource_version=0`) instead of etcd; callers needing a strong read (release confirmation) pass `consistent_read=True`.
- **Parallel orphan deletes** — `OrphanGarbageCollector` deletes concurrently via `asyncio.gather` + `Semaphore(50)`; per-orphan failures are non-fatal; the stats counters are lock-guarded so they stay correct under free-threaded CPython, not only under the GIL.
- **Contract mock correctness** — the k8s contract mock now models apiserver list semantics: per-name deletion plus filtering by the `orb.io/request-id` label the provider actually stamps (not a hand-derived name prefix), so two acquires on one adapter see independent pods and the mock cannot silently diverge from the handler's pod-naming.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [x] Code cleanup or refactor
- [ ] Dependencies update
- [ ] CI/CD or build process changes

## Related Issues
None.

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

`pytest tests/providers/k8s/{unit,contract,mocked} tests/integration/providers/k8s` — all green; 3 pre-existing failures unrelated to this branch stay deselected (confirmed present on the base branch).  `pyright src/orb/providers` — 0 errors.  `ruff check --select W,F,I` + `ruff format --check` — clean.

Each area was reviewed for correctness after implementation; the resulting fixes (a scale-down cache-masking bug, a store race on the status cache, and thread-safety on the GC counters, among others) are included on this branch.

## Test Configuration
* Python version: 3.12
* OS: Darwin (macOS) locally; Linux in CI
* AWS region: n/a
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes

The controller-status cache is served only for steady-state (fully-ready, same-count) workloads; converging or rescaled workloads bypass it every poll so transitions are observed promptly.

## Screenshots (if appropriate)
n/a

## Performance Impact
- [x] Performance improved
- [ ] No significant performance impact
- [ ] Performance degraded

Steady-state controller-status polling no longer issues an apiserver GET per concurrent request; fallback pod LISTs hit the reflector cache; orphan GC deletes run concurrently instead of serially.

## Security Considerations
- [x] No security implications
- [ ] Security improved
- [ ] Potential security concerns

## Dependencies
None.

## Migration Guide
Not a breaking change.  New optional config `controller_status_cache_ttl_seconds` (default 5s); set to 0 (or any value below 0) to disable the controller-status cache.

## Deployment Notes
None.

## Reviewers
@finos/open-resource-broker-maintainers