### PR TITLE
fix(machines): route provider identifier to start/stop so operations don't all-fail

### DIFF
--- a/src/orb/application/services/orchestration/start_machines.py
+++ b/src/orb/application/services/orchestration/start_machines.py
@@ -9,6 +9,7 @@ from orb.application.ports.query_bus_port import QueryBusPort
 from orb.application.provider.commands import ExecuteProviderOperationCommand
 from orb.application.services.orchestration.base import OrchestratorBase
 from orb.application.services.orchestration.dtos import StartMachinesInput, StartMachinesOutput
+from orb.application.services.provider_registry_service import ProviderRegistryService
 from orb.domain.base.operations import (
     Operation as ProviderOperation,
     OperationType as ProviderOperationType,
@@ -20,11 +21,16 @@ class StartMachinesOrchestrator(OrchestratorBase[StartMachinesInput, StartMachin
     """Orchestrator for starting machines via the provider layer."""
 
     def __init__(
-        self, command_bus: CommandBusPort, query_bus: QueryBusPort, logger: LoggingPort
+        self,
+        command_bus: CommandBusPort,
+        query_bus: QueryBusPort,
+        logger: LoggingPort,
+        provider_registry_service: ProviderRegistryService,
     ) -> None:
         self._command_bus = command_bus
         self._query_bus = query_bus
         self._logger = logger
+        self._provider_registry_service = provider_registry_service
 
     async def execute(self, input: StartMachinesInput) -> StartMachinesOutput:  # type: ignore[return]
         self._logger.info(
@@ -57,11 +63,35 @@ class StartMachinesOrchestrator(OrchestratorBase[StartMachinesInput, StartMachin
                 message="No machines to start",
             )
 
+        # Resolve the effective provider identifier so the command handler can
+        # route the operation to the correct provider strategy.  Preference
+        # order: explicit name > explicit type > active provider from registry.
+        if input.provider_name:
+            strategy_override = input.provider_name
+        elif input.provider_type:
+            strategy_override = input.provider_type
+        else:
+            try:
+                selection = self._provider_registry_service.select_active_provider()
+                strategy_override = selection.provider_name
+            except Exception as exc:
+                self._logger.error(
+                    "StartMachinesOrchestrator: cannot resolve active provider: %s", exc
+                )
+                return StartMachinesOutput(
+                    started_machines=[],
+                    failed_machines=list(machine_ids),
+                    success=False,
+                    message=f"Cannot resolve active provider: {exc}",
+                )
+
         provider_op = ProviderOperation(
             operation_type=ProviderOperationType.START_INSTANCES,
             parameters={"instance_ids": machine_ids},
         )
-        command = ExecuteProviderOperationCommand(operation=provider_op)
+        command = ExecuteProviderOperationCommand(
+            operation=provider_op, strategy_override=strategy_override
+        )
         await self._command_bus.execute(command)
 
         if command.result and command.result.get("success"):

--- a/src/orb/application/services/orchestration/stop_machines.py
+++ b/src/orb/application/services/orchestration/stop_machines.py
@@ -9,6 +9,7 @@ from orb.application.ports.query_bus_port import QueryBusPort
 from orb.application.provider.commands import ExecuteProviderOperationCommand
 from orb.application.services.orchestration.base import OrchestratorBase
 from orb.application.services.orchestration.dtos import StopMachinesInput, StopMachinesOutput
+from orb.application.services.provider_registry_service import ProviderRegistryService
 from orb.domain.base.operations import (
     Operation as ProviderOperation,
     OperationType as ProviderOperationType,
@@ -20,11 +21,16 @@ class StopMachinesOrchestrator(OrchestratorBase[StopMachinesInput, StopMachinesO
     """Orchestrator for stopping machines via the provider layer."""
 
     def __init__(
-        self, command_bus: CommandBusPort, query_bus: QueryBusPort, logger: LoggingPort
+        self,
+        command_bus: CommandBusPort,
+        query_bus: QueryBusPort,
+        logger: LoggingPort,
+        provider_registry_service: ProviderRegistryService,
     ) -> None:
         self._command_bus = command_bus
         self._query_bus = query_bus
         self._logger = logger
+        self._provider_registry_service = provider_registry_service
 
     async def execute(self, input: StopMachinesInput) -> StopMachinesOutput:  # type: ignore[return]
         self._logger.info(
@@ -58,11 +64,35 @@ class StopMachinesOrchestrator(OrchestratorBase[StopMachinesInput, StopMachinesO
                 message="No machines to stop",
             )
 
+        # Resolve the effective provider identifier so the command handler can
+        # route the operation to the correct provider strategy.  Preference
+        # order: explicit name > explicit type > active provider from registry.
+        if input.provider_name:
+            strategy_override = input.provider_name
+        elif input.provider_type:
+            strategy_override = input.provider_type
+        else:
+            try:
+                selection = self._provider_registry_service.select_active_provider()
+                strategy_override = selection.provider_name
+            except Exception as exc:
+                self._logger.error(
+                    "StopMachinesOrchestrator: cannot resolve active provider: %s", exc
+                )
+                return StopMachinesOutput(
+                    stopped_machines=[],
+                    failed_machines=list(machine_ids),
+                    success=False,
+                    message=f"Cannot resolve active provider: {exc}",
+                )
+
         operation = ProviderOperation(
             operation_type=ProviderOperationType.STOP_INSTANCES,
             parameters={"instance_ids": machine_ids},
         )
-        command = ExecuteProviderOperationCommand(operation=operation)
+        command = ExecuteProviderOperationCommand(
+            operation=operation, strategy_override=strategy_override
+        )
         await self._command_bus.execute(command)
 
         if command.result and command.result.get("success"):

--- a/src/orb/bootstrap/orchestrator_registry.py
+++ b/src/orb/bootstrap/orchestrator_registry.py
@@ -210,21 +210,27 @@ def register_orchestrators(container: DIContainer) -> None:
             ),
         )
     if not container.is_registered(StopMachinesOrchestrator):
+        from orb.application.services.provider_registry_service import ProviderRegistryService
+
         container.register_singleton(
             StopMachinesOrchestrator,
             lambda c: StopMachinesOrchestrator(
                 command_bus=c.get(CommandBus),
                 query_bus=c.get(QueryBus),
                 logger=c.get(LoggingPort),
+                provider_registry_service=c.get(ProviderRegistryService),
             ),
         )
     if not container.is_registered(StartMachinesOrchestrator):
+        from orb.application.services.provider_registry_service import ProviderRegistryService
+
         container.register_singleton(
             StartMachinesOrchestrator,
             lambda c: StartMachinesOrchestrator(
                 command_bus=c.get(CommandBus),
                 query_bus=c.get(QueryBus),
                 logger=c.get(LoggingPort),
+                provider_registry_service=c.get(ProviderRegistryService),
             ),
         )
     if not container.is_registered(GetProviderHealthOrchestrator):

--- a/tests/unit/application/services/orchestration/test_start_machines_orchestrator.py
+++ b/tests/unit/application/services/orchestration/test_start_machines_orchestrator.py
@@ -50,11 +50,27 @@ def mock_logger():
 
 
 @pytest.fixture
-def orchestrator(mock_command_bus, mock_query_bus, mock_logger):
+def mock_provider_registry_service():
+    from orb.application.services.provider_registry_service import ProviderRegistryService
+    from orb.domain.base.results import ProviderSelectionResult
+
+    svc = MagicMock(spec=ProviderRegistryService)
+    svc.select_active_provider.return_value = ProviderSelectionResult(
+        provider_type="aws",
+        provider_name="aws-default",
+        selection_reason="test_fixture",
+        confidence=1.0,
+    )
+    return svc
+
+
+@pytest.fixture
+def orchestrator(mock_command_bus, mock_query_bus, mock_logger, mock_provider_registry_service):
     return StartMachinesOrchestrator(
         command_bus=mock_command_bus,
         query_bus=mock_query_bus,
         logger=mock_logger,
+        provider_registry_service=mock_provider_registry_service,
     )
 
 

--- a/tests/unit/application/services/orchestration/test_stop_machines_orchestrator.py
+++ b/tests/unit/application/services/orchestration/test_stop_machines_orchestrator.py
@@ -52,11 +52,27 @@ def mock_logger():
 
 
 @pytest.fixture
-def orchestrator(mock_command_bus, mock_query_bus, mock_logger):
+def mock_provider_registry_service():
+    from orb.application.services.provider_registry_service import ProviderRegistryService
+    from orb.domain.base.results import ProviderSelectionResult
+
+    svc = MagicMock(spec=ProviderRegistryService)
+    svc.select_active_provider.return_value = ProviderSelectionResult(
+        provider_type="aws",
+        provider_name="aws-default",
+        selection_reason="test_fixture",
+        confidence=1.0,
+    )
+    return svc
+
+
+@pytest.fixture
+def orchestrator(mock_command_bus, mock_query_bus, mock_logger, mock_provider_registry_service):
     return StopMachinesOrchestrator(
         command_bus=mock_command_bus,
         query_bus=mock_query_bus,
         logger=mock_logger,
+        provider_registry_service=mock_provider_registry_service,
     )
 
 

--- a/tests/unit/test_machines_start_stop_real_path.py
+++ b/tests/unit/test_machines_start_stop_real_path.py
@@ -1,0 +1,397 @@
+"""Real-path tests for StartMachinesOrchestrator and StopMachinesOrchestrator.
+
+These tests exercise the real orchestrator -> real CommandBus ->
+real ExecuteProviderOperationHandler path, mocking only the leaf
+provider I/O (ProviderRegistryService) to avoid AWS calls.
+
+This verifies that:
+  - strategy_override IS set on the ExecuteProviderOperationCommand
+  - a successful provider operation reports machines STARTED / STOPPED (not failed)
+  - the no-provider-flag default case resolves the active provider via the
+    registry service and succeeds
+  - the explicit provider_name and provider_type cases short-circuit registry lookup
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orb.application.commands.machine_handlers import UpdateMachineStatusHandler
+from orb.application.commands.provider_handlers import ExecuteProviderOperationHandler
+from orb.application.provider.commands import ExecuteProviderOperationCommand
+from orb.application.services.orchestration.dtos import (
+    StartMachinesInput,
+    StopMachinesInput,
+)
+from orb.application.services.orchestration.start_machines import StartMachinesOrchestrator
+from orb.application.services.orchestration.stop_machines import StopMachinesOrchestrator
+from orb.application.services.provider_registry_service import ProviderRegistryService
+from orb.domain.base.results import ProviderSelectionResult
+from orb.infrastructure.di.buses import CommandBus
+from orb.infrastructure.di.container import DIContainer
+
+# ---------------------------------------------------------------------------
+# Shared test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider_result(name: str, ptype: str = "aws") -> ProviderSelectionResult:
+    return ProviderSelectionResult(
+        provider_type=ptype,
+        provider_name=name,
+        selection_reason="test",
+        confidence=1.0,
+    )
+
+
+def _make_mock_operation_result(machine_ids: list[str], success: bool = True) -> MagicMock:
+    """Build the ProviderOperationResult mock returned by execute_operation."""
+    result = MagicMock()
+    result.success = success
+    result.data = {"results": {mid: success for mid in machine_ids}}
+    result.error_message = None if success else "provider error"
+    return result
+
+
+def _build_command_bus(
+    provider_registry_service: ProviderRegistryService,
+) -> CommandBus:
+    """
+    Construct a CommandBus wired to a minimal DIContainer that knows about:
+      - ExecuteProviderOperationHandler  (uses provider_registry_service)
+      - UpdateMachineStatusHandler       (replaced with a no-op mock)
+    """
+    container = DIContainer()
+
+    # Register ExecuteProviderOperationHandler with real implementation
+    # but leaf-mocked ProviderRegistryService
+    from orb.domain.base.ports import (
+        ContainerPort,
+        ErrorHandlingPort,
+        EventPublisherPort,
+        LoggingPort,
+    )
+
+    mock_logger = MagicMock(spec=LoggingPort)
+    mock_logger.info = MagicMock()
+    mock_logger.debug = MagicMock()
+    mock_logger.error = MagicMock()
+    mock_logger.warning = MagicMock()
+
+    mock_event_publisher = MagicMock(spec=EventPublisherPort)
+    mock_error_handler = MagicMock(spec=ErrorHandlingPort)
+    mock_container_port = MagicMock(spec=ContainerPort)
+
+    exec_handler = ExecuteProviderOperationHandler(
+        container=mock_container_port,
+        logger=mock_logger,
+        event_publisher=mock_event_publisher,
+        error_handler=mock_error_handler,
+        provider_registry_service=provider_registry_service,
+    )
+    container.register_instance(ExecuteProviderOperationHandler, exec_handler)
+
+    # No-op UpdateMachineStatusHandler so we don't need a real repository
+    class _NoOpUpdateMachineStatusHandler:
+        async def handle(self, command):  # noqa: ANN001
+            pass  # UpdateMachineStatusCommand has no result field; just return None
+
+    container.register_instance(UpdateMachineStatusHandler, _NoOpUpdateMachineStatusHandler())
+
+    bus = CommandBus(container=container, logger=mock_logger)
+    return bus
+
+
+def _make_logger():
+    from orb.domain.base.ports.logging_port import LoggingPort
+
+    mock = MagicMock(spec=LoggingPort)
+    mock.info = MagicMock()
+    mock.debug = MagicMock()
+    mock.error = MagicMock()
+    mock.warning = MagicMock()
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# StartMachinesOrchestrator — real path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_machines_real_path_success_with_active_provider():
+    """
+    Real orchestrator -> real CommandBus -> real ExecuteProviderOperationHandler.
+    No provider_name / provider_type provided (default CLI case).
+    Active provider is resolved from ProviderRegistryService.
+    Assert: strategy_override IS set, machines reported as started not failed.
+    """
+    machine_ids = ["i-aaa", "i-bbb"]
+    active_provider_name = "aws-prod"
+
+    mock_registry_service = MagicMock(spec=ProviderRegistryService)
+    mock_registry_service.select_active_provider.return_value = _make_provider_result(
+        active_provider_name
+    )
+    mock_registry_service.execute_operation = AsyncMock(
+        return_value=_make_mock_operation_result(machine_ids, success=True)
+    )
+
+    command_bus = _build_command_bus(mock_registry_service)
+
+    # Track the command received by the handler
+    received_commands: list[ExecuteProviderOperationCommand] = []
+    original_execute = ExecuteProviderOperationHandler.execute_command
+
+    async def _spy_execute(self_h, command):
+        received_commands.append(command)
+        return await original_execute(self_h, command)
+
+    with patch.object(ExecuteProviderOperationHandler, "execute_command", _spy_execute):
+        orchestrator = StartMachinesOrchestrator(
+            command_bus=command_bus,
+            query_bus=MagicMock(),
+            logger=_make_logger(),
+            provider_registry_service=mock_registry_service,
+        )
+        result = await orchestrator.execute(StartMachinesInput(machine_ids=machine_ids))
+
+    # The provider registry service must have been asked for the active provider
+    mock_registry_service.select_active_provider.assert_called_once()
+
+    # The command routed to the handler must carry the resolved provider name
+    assert len(received_commands) == 1
+    assert received_commands[0].strategy_override == active_provider_name
+
+    # Machines must be reported started, not failed
+    assert result.success is True
+    assert set(result.started_machines) == set(machine_ids)
+    assert result.failed_machines == []
+
+
+@pytest.mark.asyncio
+async def test_start_machines_real_path_explicit_provider_name_skips_registry():
+    """
+    When provider_name is supplied, select_active_provider must NOT be called.
+    strategy_override must equal the supplied provider_name.
+    """
+    machine_ids = ["i-ccc"]
+    explicit_name = "aws-staging"
+
+    mock_registry_service = MagicMock(spec=ProviderRegistryService)
+    mock_registry_service.execute_operation = AsyncMock(
+        return_value=_make_mock_operation_result(machine_ids, success=True)
+    )
+
+    command_bus = _build_command_bus(mock_registry_service)
+
+    received_commands: list[ExecuteProviderOperationCommand] = []
+    original_execute = ExecuteProviderOperationHandler.execute_command
+
+    async def _spy(self_h, command):
+        received_commands.append(command)
+        return await original_execute(self_h, command)
+
+    with patch.object(ExecuteProviderOperationHandler, "execute_command", _spy):
+        orchestrator = StartMachinesOrchestrator(
+            command_bus=command_bus,
+            query_bus=MagicMock(),
+            logger=_make_logger(),
+            provider_registry_service=mock_registry_service,
+        )
+        result = await orchestrator.execute(
+            StartMachinesInput(machine_ids=machine_ids, provider_name=explicit_name)
+        )
+
+    mock_registry_service.select_active_provider.assert_not_called()
+    assert received_commands[0].strategy_override == explicit_name
+    assert result.started_machines == machine_ids
+    assert result.failed_machines == []
+
+
+@pytest.mark.asyncio
+async def test_start_machines_real_path_explicit_provider_type_skips_registry():
+    """
+    When provider_type (but no name) is supplied, the type is used directly
+    and select_active_provider must NOT be called.
+    """
+    machine_ids = ["i-ddd"]
+    explicit_type = "k8s"
+
+    mock_registry_service = MagicMock(spec=ProviderRegistryService)
+    mock_registry_service.execute_operation = AsyncMock(
+        return_value=_make_mock_operation_result(machine_ids, success=True)
+    )
+
+    command_bus = _build_command_bus(mock_registry_service)
+
+    received_commands: list[ExecuteProviderOperationCommand] = []
+    original_execute = ExecuteProviderOperationHandler.execute_command
+
+    async def _spy(self_h, command):
+        received_commands.append(command)
+        return await original_execute(self_h, command)
+
+    with patch.object(ExecuteProviderOperationHandler, "execute_command", _spy):
+        orchestrator = StartMachinesOrchestrator(
+            command_bus=command_bus,
+            query_bus=MagicMock(),
+            logger=_make_logger(),
+            provider_registry_service=mock_registry_service,
+        )
+        result = await orchestrator.execute(
+            StartMachinesInput(machine_ids=machine_ids, provider_type=explicit_type)
+        )
+
+    mock_registry_service.select_active_provider.assert_not_called()
+    assert received_commands[0].strategy_override == explicit_type
+    assert result.started_machines == machine_ids
+    assert result.failed_machines == []
+
+
+@pytest.mark.asyncio
+async def test_start_machines_real_path_no_active_provider_returns_failure():
+    """
+    If the registry cannot resolve an active provider, the orchestrator must
+    return a clear failure Output rather than silently marking all machines failed.
+    """
+    machine_ids = ["i-eee"]
+
+    mock_registry_service = MagicMock(spec=ProviderRegistryService)
+    mock_registry_service.select_active_provider.side_effect = ValueError(
+        "No active providers found"
+    )
+
+    command_bus = _build_command_bus(mock_registry_service)
+
+    orchestrator = StartMachinesOrchestrator(
+        command_bus=command_bus,
+        query_bus=MagicMock(),
+        logger=_make_logger(),
+        provider_registry_service=mock_registry_service,
+    )
+    result = await orchestrator.execute(StartMachinesInput(machine_ids=machine_ids))
+
+    assert result.success is False
+    assert "active provider" in result.message.lower()
+    assert result.failed_machines == machine_ids
+    assert result.started_machines == []
+
+
+# ---------------------------------------------------------------------------
+# StopMachinesOrchestrator — real path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_machines_real_path_success_with_active_provider():
+    """
+    Real orchestrator -> real CommandBus -> real ExecuteProviderOperationHandler.
+    No provider_name / provider_type provided.
+    Active provider resolved; machines reported stopped, not failed.
+    """
+    machine_ids = ["i-fff", "i-ggg"]
+    active_provider_name = "aws-prod"
+
+    mock_registry_service = MagicMock(spec=ProviderRegistryService)
+    mock_registry_service.select_active_provider.return_value = _make_provider_result(
+        active_provider_name
+    )
+    mock_registry_service.execute_operation = AsyncMock(
+        return_value=_make_mock_operation_result(machine_ids, success=True)
+    )
+
+    command_bus = _build_command_bus(mock_registry_service)
+
+    received_commands: list[ExecuteProviderOperationCommand] = []
+    original_execute = ExecuteProviderOperationHandler.execute_command
+
+    async def _spy(self_h, command):
+        received_commands.append(command)
+        return await original_execute(self_h, command)
+
+    with patch.object(ExecuteProviderOperationHandler, "execute_command", _spy):
+        orchestrator = StopMachinesOrchestrator(
+            command_bus=command_bus,
+            query_bus=MagicMock(),
+            logger=_make_logger(),
+            provider_registry_service=mock_registry_service,
+        )
+        result = await orchestrator.execute(StopMachinesInput(machine_ids=machine_ids))
+
+    mock_registry_service.select_active_provider.assert_called_once()
+    assert len(received_commands) == 1
+    assert received_commands[0].strategy_override == active_provider_name
+
+    assert result.success is True
+    assert set(result.stopped_machines) == set(machine_ids)
+    assert result.failed_machines == []
+
+
+@pytest.mark.asyncio
+async def test_stop_machines_real_path_explicit_provider_name_skips_registry():
+    """
+    When provider_name is supplied, stop uses it directly without registry lookup.
+    """
+    machine_ids = ["i-hhh"]
+    explicit_name = "aws-dr"
+
+    mock_registry_service = MagicMock(spec=ProviderRegistryService)
+    mock_registry_service.execute_operation = AsyncMock(
+        return_value=_make_mock_operation_result(machine_ids, success=True)
+    )
+
+    command_bus = _build_command_bus(mock_registry_service)
+
+    received_commands: list[ExecuteProviderOperationCommand] = []
+    original_execute = ExecuteProviderOperationHandler.execute_command
+
+    async def _spy(self_h, command):
+        received_commands.append(command)
+        return await original_execute(self_h, command)
+
+    with patch.object(ExecuteProviderOperationHandler, "execute_command", _spy):
+        orchestrator = StopMachinesOrchestrator(
+            command_bus=command_bus,
+            query_bus=MagicMock(),
+            logger=_make_logger(),
+            provider_registry_service=mock_registry_service,
+        )
+        result = await orchestrator.execute(
+            StopMachinesInput(machine_ids=machine_ids, provider_name=explicit_name)
+        )
+
+    mock_registry_service.select_active_provider.assert_not_called()
+    assert received_commands[0].strategy_override == explicit_name
+    assert result.stopped_machines == machine_ids
+    assert result.failed_machines == []
+
+
+@pytest.mark.asyncio
+async def test_stop_machines_real_path_no_active_provider_returns_failure():
+    """
+    If registry cannot resolve an active provider, stop returns a clear failure.
+    """
+    machine_ids = ["i-iii"]
+
+    mock_registry_service = MagicMock(spec=ProviderRegistryService)
+    mock_registry_service.select_active_provider.side_effect = ValueError(
+        "No active providers found"
+    )
+
+    command_bus = _build_command_bus(mock_registry_service)
+
+    orchestrator = StopMachinesOrchestrator(
+        command_bus=command_bus,
+        query_bus=MagicMock(),
+        logger=_make_logger(),
+        provider_registry_service=mock_registry_service,
+    )
+    result = await orchestrator.execute(StopMachinesInput(machine_ids=machine_ids))
+
+    assert result.success is False
+    assert "active provider" in result.message.lower()
+    assert result.failed_machines == machine_ids
+    assert result.stopped_machines == []


### PR DESCRIPTION
## Description
Fixes a runtime bug where `machines start` and `machines stop` reported **every** machine as failed even when the underlying provider operation succeeded. Both the CLI (`machines start`/`stop`) and the MCP `start_machines`/`stop_machines` tools hit this path.

**Root cause:** `StartMachinesOrchestrator` / `StopMachinesOrchestrator` built `ExecuteProviderOperationCommand` without a `strategy_override`. The command handler then fell back to the hardcoded provider *type* string `"aws"`, but real provider instances are registered under their configured *name* (e.g. `aws-default`), so strategy lookup missed and raised `ValueError("No strategy found for provider: aws")`. That exception was swallowed into `command.result` (success=False), and the orchestrator's else-branch marked every machine failed.

**Fix:** the orchestrators now resolve the effective provider identifier — `input.provider_name` > `input.provider_type` > `ProviderRegistryService.select_active_provider().provider_name` (the same active-provider mechanism the scheduler and configuration manager already use) — and pass it as `strategy_override`. If the active provider genuinely cannot be resolved, the orchestrator returns a clear failure message instead of silently all-failing.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
Fixes #

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed

Added `tests/unit/test_machines_start_stop_real_path.py` exercising the **real** orchestrator -> command bus -> handler path (the pre-existing tests fully mocked the command bus, which is exactly why this bug shipped undetected). Start/stop suites: 10/10. Pre-existing orchestrator suites updated for the new constructor arg: 20/20. Full `tests/unit` + `tests/integration`: 8027 passed, 27 skipped, 1 pre-existing unrelated env failure. `pyright`: 0 errors. `ruff`: clean.

## Test Configuration
* Python version: 3.12
* OS: macOS
* AWS region: n/a
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
`StartMachinesOrchestrator` / `StopMachinesOrchestrator` gained a `provider_registry_service` constructor argument; DI registrations in `bootstrap/orchestrator_registry.py` updated accordingly.

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications

## Reviewers
@finos/open-resource-broker-maintainers
