### PR TITLE
fix(security): close auth, credential, and error-handling exposure gaps

### DIFF
--- a/dev-tools/setup/install_dev_tools.py
+++ b/dev-tools/setup/install_dev_tools.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Development Tools Installation Script
 
@@ -32,11 +31,12 @@ Options:
 
 import argparse
 import logging
+import os
 import platform
 import subprocess
 import sys
+import tempfile
 
-# Setup logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -126,7 +126,10 @@ class DevToolsInstaller:
                 "check_cmd": ["bun", "--version"],
                 "install": {
                     "darwin": self._install_bun_generic,
-                    "windows": ["powershell", "-c", "irm bun.sh/install.ps1 | iex"],
+                    # Windows: download-then-execute avoids inline iex eval of network content.
+                    # Residual risk: no checksum on the installer (RCE-by-design of
+                    # download-to-exec installs). Use choco or winget if available instead.
+                    "windows": self._install_bun_windows,
                     "ubuntu": self._install_bun_generic,
                     "debian": self._install_bun_generic,
                     "rhel": self._install_bun_generic,
@@ -263,7 +266,14 @@ class DevToolsInstaller:
         return "generic"
 
     def _ensure_chocolatey(self):
-        """Ensure Chocolatey is installed on Windows."""
+        """Ensure Chocolatey is installed on Windows.
+
+        The official Chocolatey installer is downloaded to a temp file and executed,
+        avoiding inline iex eval of network content.
+        Residual risk: no checksum is verified on the installer script
+        (RCE-by-design of download-to-exec installs without signature verification).
+        See https://chocolatey.org/install for manual verification steps.
+        """
         if self.distro != "windows":
             return True
 
@@ -281,17 +291,27 @@ class DevToolsInstaller:
             logger.info("[DRY RUN] Would install Chocolatey")
             return True
 
-        # Install Chocolatey using PowerShell
-        powershell_cmd = [
+        # Download installer to a temp file, then execute it — avoids inline iex eval.
+        powershell_download_cmd = [
             "powershell",
             "-Command",
             "Set-ExecutionPolicy Bypass -Scope Process -Force; "
-            "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; "
-            "iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))",
+            "[System.Net.ServicePointManager]::SecurityProtocol = "
+            "[System.Net.ServicePointManager]::SecurityProtocol -bor 3072; "
+            "Invoke-WebRequest -Uri 'https://community.chocolatey.org/install.ps1' "
+            "-OutFile $env:TEMP\\choco_install.ps1",
+        ]
+        powershell_exec_cmd = [
+            "powershell",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            "%TEMP%\\choco_install.ps1",
         ]
 
         try:
-            subprocess.run(powershell_cmd, check=True, capture_output=True, text=True)
+            subprocess.run(powershell_download_cmd, check=True, capture_output=True, text=True)
+            subprocess.run(powershell_exec_cmd, check=True, capture_output=True, text=True)
             logger.info("Chocolatey installed successfully")
             return True
         except subprocess.CalledProcessError as e:
@@ -299,12 +319,13 @@ class DevToolsInstaller:
             logger.error("Please install Chocolatey manually: https://chocolatey.org/install")
             return False
 
-    def _run_command(self, cmd, description="", shell=False):
-        """Run a command with dry-run support."""
-        if isinstance(cmd, list):
-            cmd_str = " ".join(cmd)
-        else:
-            cmd_str = cmd
+    def _run_command(self, cmd: list, description: str = "") -> bool:
+        """Run a command with dry-run support.
+
+        Args must always be a list so that no shell interpolation occurs.
+        Never pass user-supplied or URL-derived data through shell=True.
+        """
+        cmd_str = " ".join(cmd)
 
         if self.dry_run:
             logger.info(f"[DRY RUN] Would run: {cmd_str}")
@@ -312,7 +333,7 @@ class DevToolsInstaller:
 
         logger.info(f"Running: {cmd_str}")
         try:
-            subprocess.run(cmd, check=True, capture_output=True, text=True, shell=shell)
+            subprocess.run(cmd, check=True, capture_output=True, text=True)
             return True
         except subprocess.CalledProcessError as e:
             logger.error(f"Failed to run {cmd_str}: {e}")
@@ -320,7 +341,7 @@ class DevToolsInstaller:
                 logger.error(f"Error output: {e.stderr}")
             return False
         except FileNotFoundError:
-            logger.error(f"Command not found: {cmd[0] if isinstance(cmd, list) else cmd}")
+            logger.error(f"Command not found: {cmd[0]}")
             return False
 
     def _install_yq_generic(self):
@@ -349,45 +370,198 @@ class DevToolsInstaller:
         ) and self._run_command(["sudo", "chmod", "+x", "/usr/local/bin/hadolint"])
 
     def _install_trivy_generic(self):
-        """Install trivy using their install script."""
-        return self._run_command(
-            [
-                "curl",
-                "-sfL",
-                "https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh",
-                "|",
-                "sh",
-                "-s",
-                "--",
-                "-b",
-                "/usr/local/bin",
-            ]
-        )
+        """Install trivy using their install script (curl-to-tempfile, no shell=True).
+
+        Trust model: script is downloaded from aquasecurity/trivy main branch over HTTPS.
+        No checksum or signature verification is performed here — upstream does not publish
+        a standalone SHA for this helper script.  Residual risk: a compromised CDN or
+        GitHub branch could serve a malicious script (RCE-by-design of curl-to-sh installs).
+        Pin to a specific release tag when a more stable URL becomes available.
+        """
+        if self.dry_run:
+            logger.info(
+                "[DRY RUN] Would download trivy install script and run: sh <script> -s -- -b /usr/local/bin"
+            )
+            return True
+        fd, tmp_path = tempfile.mkstemp(suffix=".sh")
+        try:
+            os.close(fd)
+            ok = self._run_command(
+                [
+                    "curl",
+                    "-sfL",
+                    "-o",
+                    tmp_path,
+                    "https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh",
+                ]
+            ) and self._run_command(["sh", tmp_path, "-s", "--", "-b", "/usr/local/bin"])
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError as exc:
+                logger.debug("Failed to remove temporary installer file %s: %s", tmp_path, exc)
+        return ok
 
     def _install_syft_generic(self):
-        """Install syft using their install script."""
-        return self._run_command(
-            "curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin",
-            shell=True,
-        )
+        """Install syft using their install script (curl-to-tempfile, no shell=True).
+
+        Trust model: script is downloaded from anchore/syft main branch over HTTPS.
+        No checksum or signature verification is performed here.
+        Residual risk: compromised CDN or GitHub branch could serve a malicious script
+        (RCE-by-design of curl-to-sh installs).  Pin to a versioned URL once a stable
+        checksum-verified alternative is available.
+        """
+        if self.dry_run:
+            logger.info(
+                "[DRY RUN] Would download syft install script and run: sh <script> -s -- -b /usr/local/bin"
+            )
+            return True
+        fd, tmp_path = tempfile.mkstemp(suffix=".sh")
+        try:
+            os.close(fd)
+            ok = self._run_command(
+                [
+                    "curl",
+                    "-sSfL",
+                    "-o",
+                    tmp_path,
+                    "https://raw.githubusercontent.com/anchore/syft/main/install.sh",
+                ]
+            ) and self._run_command(["sh", tmp_path, "-s", "--", "-b", "/usr/local/bin"])
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError as exc:
+                logger.debug("Failed to remove temporary installer file %s: %s", tmp_path, exc)
+        return ok
 
     def _install_uv_generic(self):
-        """Install uv using their install script."""
-        return self._run_command(["curl", "-LsSf", "https://astral.sh/uv/install.sh", "|", "sh"])
+        """Install uv using their install script (curl-to-tempfile, no shell=True).
+
+        Trust model: script is downloaded from astral.sh over HTTPS.
+        Astral does not publish a standalone checksum for this installer URL.
+        Residual risk: compromised distribution endpoint could serve a malicious script
+        (RCE-by-design of curl-to-sh installs).
+        """
+        if self.dry_run:
+            logger.info("[DRY RUN] Would download uv install script and run: sh <script>")
+            return True
+        fd, tmp_path = tempfile.mkstemp(suffix=".sh")
+        try:
+            os.close(fd)
+            ok = self._run_command(
+                ["curl", "-LsSf", "-o", tmp_path, "https://astral.sh/uv/install.sh"]
+            ) and self._run_command(["sh", tmp_path])
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError as exc:
+                logger.debug("Failed to remove temporary installer file %s: %s", tmp_path, exc)
+        return ok
 
     def _install_bun_generic(self):
-        """Install bun via the official install script (~/.bun/bin/bun)."""
-        return self._run_command("curl -fsSL https://bun.sh/install | bash", shell=True)
+        """Install bun via the official install script (curl-to-tempfile, no shell=True).
+
+        Trust model: script is downloaded from bun.sh over HTTPS.
+        Bun does not publish a standalone checksum for this installer URL.
+        Residual risk: compromised distribution endpoint could serve a malicious script
+        (RCE-by-design of curl-to-sh installs).
+        """
+        if self.dry_run:
+            logger.info("[DRY RUN] Would download bun install script and run: bash <script>")
+            return True
+        fd, tmp_path = tempfile.mkstemp(suffix=".sh")
+        try:
+            os.close(fd)
+            ok = self._run_command(
+                ["curl", "-fsSL", "-o", tmp_path, "https://bun.sh/install"]
+            ) and self._run_command(["bash", tmp_path])
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError as exc:
+                logger.debug("Failed to remove temporary installer file %s: %s", tmp_path, exc)
+        return ok
+
+    def _install_bun_windows(self):
+        """Install bun on Windows via download-then-execute (avoids inline iex eval).
+
+        Trust model: installer is downloaded from bun.sh over HTTPS then executed as a
+        file — this avoids the `irm ... | iex` pattern where network content is evaluated
+        inline without any intermediate opportunity to inspect or verify.
+        Residual risk: no checksum or signature is verified before execution
+        (RCE-by-design of download-to-exec installs).  Use `choco install bun` or
+        `winget install bun` instead if a package manager is available, as those provide
+        additional verification layers.
+        """
+        if self.dry_run:
+            logger.info(
+                "[DRY RUN] Would download bun installer and run: powershell -File <installer>"
+            )
+            return True
+
+        download_cmd = [
+            "powershell",
+            "-Command",
+            "Invoke-WebRequest -Uri 'https://bun.sh/install.ps1' -OutFile $env:TEMP\\bun_install.ps1",
+        ]
+        exec_cmd = [
+            "powershell",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            "%TEMP%\\bun_install.ps1",
+        ]
+
+        try:
+            subprocess.run(download_cmd, check=True, capture_output=True, text=True)
+            subprocess.run(exec_cmd, check=True, capture_output=True, text=True)
+            logger.info("bun installed successfully on Windows")
+            return True
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to install bun on Windows: {e}")
+            logger.error("Please install bun manually: https://bun.sh/docs/installation")
+            return False
 
     def _install_actionlint_generic(self):
-        """Install actionlint using official download script."""
-        return self._run_command(
-            "bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)",
-            shell=True,
-        )
+        """Install actionlint using official download script (curl-to-tempfile, no shell=True).
+
+        Trust model: script is downloaded from rhysd/actionlint main branch over HTTPS.
+        No checksum or signature verification is performed here.
+        Residual risk: compromised CDN or GitHub branch could serve a malicious script
+        (RCE-by-design of curl-to-sh installs).  Pin to a versioned release URL once
+        a checksum-verified alternative is available.
+        """
+        if self.dry_run:
+            logger.info("[DRY RUN] Would download actionlint install script and run: bash <script>")
+            return True
+        fd, tmp_path = tempfile.mkstemp(suffix=".bash")
+        try:
+            os.close(fd)
+            ok = self._run_command(
+                [
+                    "curl",
+                    "-o",
+                    tmp_path,
+                    "https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash",
+                ]
+            ) and self._run_command(["bash", tmp_path])
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError as exc:
+                logger.debug("Failed to remove temporary installer file %s: %s", tmp_path, exc)
+        return ok
 
     def _install_shellcheck_generic(self):
-        """Install shellcheck using binary download."""
+        """Install shellcheck using binary download (curl-to-tempfile, no shell=True).
+
+        Trust model: binary tarball is downloaded from koalaman/shellcheck GitHub releases
+        over HTTPS.  GitHub Releases does not publish a standalone checksum file for the
+        latest redirect; pin to a specific version tag and verify SHA-256 when reproducibility
+        is required.  Residual risk: a compromised release artifact could be executed
+        (RCE-by-design of curl-to-binary installs without verification).
+        """
         arch = platform.machine().lower()
         if arch == "x86_64":
             arch = "x86_64"
@@ -395,24 +569,44 @@ class DevToolsInstaller:
             arch = "aarch64"
 
         url = f"https://github.com/koalaman/shellcheck/releases/latest/download/shellcheck-latest.linux.{arch}.tar.xz"
-        return self._run_command(
-            [
-                "curl",
-                "-L",
-                url,
-                "|",
-                "sudo",
-                "tar",
-                "-xJ",
-                "-C",
-                "/usr/local/bin",
-                "--strip-components=1",
-                "shellcheck-latest/shellcheck",
-            ]
-        )
+        if self.dry_run:
+            logger.info(
+                f"[DRY RUN] Would download shellcheck from {url} and extract to /usr/local/bin"
+            )
+            return True
+        fd, tmp_path = tempfile.mkstemp(suffix=".tar.xz")
+        try:
+            os.close(fd)
+            ok = self._run_command(["curl", "-L", "-o", tmp_path, url]) and self._run_command(
+                [
+                    "sudo",
+                    "tar",
+                    "-xJ",
+                    "-C",
+                    "/usr/local/bin",
+                    "--strip-components=1",
+                    "-f",
+                    tmp_path,
+                    "shellcheck-latest/shellcheck",
+                ]
+            )
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError as exc:
+                logger.debug("Failed to remove temporary installer file %s: %s", tmp_path, exc)
+        return ok
 
     def _install_trufflehog_generic(self):
-        """Install trufflehog using curl."""
+        """Install trufflehog using curl (curl-to-tempfile, no shell=True).
+
+        Trust model: binary tarball is downloaded from trufflesecurity/trufflehog GitHub
+        releases over HTTPS.  Each release includes checksums_SHA256.txt — verifying that
+        file before extraction would eliminate the residual integrity risk; not implemented
+        here because it requires a second curl call and sha256sum.  Pin to a specific
+        version tag and verify SHA-256 when reproducibility is required.
+        Residual risk: a compromised release artifact could be executed.
+        """
         arch = platform.machine().lower()
         if arch == "x86_64":
             arch = "amd64"
@@ -420,33 +614,53 @@ class DevToolsInstaller:
             arch = "arm64"
 
         url = f"https://github.com/trufflesecurity/trufflehog/releases/latest/download/trufflehog_linux_{arch}.tar.gz"
-        return self._run_command(
-            [
-                "curl",
-                "-L",
-                url,
-                "|",
-                "sudo",
-                "tar",
-                "-xz",
-                "-C",
-                "/usr/local/bin",
-                "trufflehog",
-            ]
-        )
+        if self.dry_run:
+            logger.info(
+                f"[DRY RUN] Would download trufflehog from {url} and extract to /usr/local/bin"
+            )
+            return True
+        fd, tmp_path = tempfile.mkstemp(suffix=".tar.gz")
+        try:
+            os.close(fd)
+            ok = self._run_command(["curl", "-L", "-o", tmp_path, url]) and self._run_command(
+                ["sudo", "tar", "-xz", "-C", "/usr/local/bin", "-f", tmp_path, "trufflehog"]
+            )
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError as exc:
+                logger.debug("Failed to remove temporary installer file %s: %s", tmp_path, exc)
+        return ok
 
     def _install_act_generic(self):
-        """Install act using GitHub releases."""
-        return self._run_command(
-            [
-                "curl",
-                "-s",
-                "https://raw.githubusercontent.com/nektos/act/master/install.sh",
-                "|",
-                "sudo",
-                "bash",
-            ]
-        )
+        """Install act using GitHub releases (curl-to-tempfile, no shell=True).
+
+        Trust model: install script is downloaded from nektos/act master branch over HTTPS.
+        No checksum or signature verification is performed here.
+        Residual risk: compromised CDN or GitHub branch could serve a malicious script
+        (RCE-by-design of curl-to-sh installs).
+        """
+        if self.dry_run:
+            logger.info("[DRY RUN] Would download act install script and run: sudo bash <script>")
+            return True
+        fd, tmp_path = tempfile.mkstemp(suffix=".sh")
+        try:
+            os.close(fd)
+            ok = self._run_command(
+                [
+                    "curl",
+                    "-s",
+                    "-o",
+                    tmp_path,
+                    "https://raw.githubusercontent.com/nektos/act/master/install.sh",
+                ]
+            ) and self._run_command(["sudo", "bash", tmp_path])
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError as exc:
+                logger.debug("Failed to remove temporary installer file %s: %s", tmp_path, exc)
+        return ok
 
     def _install_pip_audit_python(self):
         """Install pip-audit using Python package manager."""
@@ -457,23 +671,26 @@ class DevToolsInstaller:
             return self._run_command(["pip", "install", "--user", "pip-audit"])
 
     def _install_docker_ubuntu(self):
-        """Install Docker on Ubuntu/Debian."""
+        """Install Docker on Ubuntu/Debian using the keyring file method.
+
+        Downloads the Docker GPG key directly to /etc/apt/keyrings/docker.asc using
+        curl -o, avoiding the previous shell-pipe pattern (curl ... | sudo gpg ...)
+        which passed a literal "|" as a subprocess list element and would fail at
+        runtime because shell=False does not interpret pipes.
+        """
         commands = [
             ["sudo", "apt", "update"],
             ["sudo", "apt", "install", "-y", "ca-certificates", "curl", "gnupg"],
             ["sudo", "install", "-m", "0755", "-d", "/etc/apt/keyrings"],
             [
+                "sudo",
                 "curl",
                 "-fsSL",
                 "https://download.docker.com/linux/ubuntu/gpg",
-                "|",
-                "sudo",
-                "gpg",
-                "--dearmor",
                 "-o",
-                "/etc/apt/keyrings/docker.gpg",
+                "/etc/apt/keyrings/docker.asc",
             ],
-            ["sudo", "chmod", "a+r", "/etc/apt/keyrings/docker.gpg"],
+            ["sudo", "chmod", "a+r", "/etc/apt/keyrings/docker.asc"],
             ["sudo", "apt", "update"],
             [
                 "sudo",
@@ -587,7 +804,7 @@ class DevToolsInstaller:
             "actionlint",
             "shellcheck",
             "act",
-            "bun",  # required by `make ui-build` — installs to ~/.bun/bin/bun
+            "bun",  # required by `make ui-build` -- installs to ~/.bun/bin/bun
         ]
 
         tools_to_install = required_tools

--- a/src/orb/api/dependencies.py
+++ b/src/orb/api/dependencies.py
@@ -393,10 +393,21 @@ def check_destructive_admin_allowed(request: Request) -> None:
 
     container = get_di_container()
 
-    # Guard 0: authentication must be enabled — fail closed if auth is off.
+    # Guard 0: authentication must be enabled with a real strategy.
+    #
+    # Two conditions must both hold:
+    #   (a) auth.enabled is True — an anonymous caller must never reach a
+    #       destructive endpoint.
+    #   (b) auth.strategy is not the "none" pass-through — NoAuthStrategy
+    #       grants permissions=["*"] to every anonymous request, so even when
+    #       enabled=True is set in config the server is effectively unprotected.
+    #       Accepting "none" here would let any caller satisfy this guard while
+    #       logging a misleading "auth enabled" message.
+    _NO_REAL_AUTH_STRATEGIES = frozenset({"none", "", None})
     try:
         server_config = get_server_config()
-        if not server_config.auth.enabled:
+        auth_cfg = server_config.auth
+        if not auth_cfg.enabled:
             _logger.warning(
                 "DESTRUCTIVE_ADMIN blocked: authentication is disabled; "
                 "destructive operations require an authenticated identity"
@@ -406,6 +417,23 @@ def check_destructive_admin_allowed(request: Request) -> None:
                 detail={
                     "code": "AUTH_DISABLED",
                     "message": "Destructive admin requires authentication enabled.",
+                },
+            )
+        if getattr(auth_cfg, "strategy", None) in _NO_REAL_AUTH_STRATEGIES:
+            _logger.warning(
+                "DESTRUCTIVE_ADMIN blocked: auth.strategy=%r is a pass-through "
+                "that grants every anonymous caller full permissions; "
+                "a real authentication strategy is required",
+                getattr(auth_cfg, "strategy", None),
+            )
+            raise HTTPException(  # type: ignore[misc]
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "AUTH_STRATEGY_NONE",
+                    "message": (
+                        "Destructive admin requires a real authentication strategy. "
+                        "The configured strategy enforces no access control."
+                    ),
                 },
             )
     except HTTPException:

--- a/src/orb/api/routers/admin.py
+++ b/src/orb/api/routers/admin.py
@@ -413,11 +413,15 @@ async def cleanup_database(
             ),
         )
     except InvalidCleanupStatusError as exc:
+        logger.warning("Cleanup rejected due to invalid status list: %s", exc)
         return JSONResponse(
             status_code=400,
             content={
                 "success": False,
-                "error": {"code": "INVALID_STATUS", "message": str(exc)},
+                "error": {
+                    "code": "INVALID_STATUS",
+                    "message": "One or more supplied statuses are not valid terminal statuses.",
+                },
             },
         )
 
@@ -490,6 +494,9 @@ async def reload_config(request: Request, _user=Depends(require_role("admin"))) 
             status_code=500,
             content={
                 "reloaded": False,
-                "error": {"code": "RELOAD_FAILED", "message": str(exc)},
+                "error": {
+                    "code": "RELOAD_FAILED",
+                    "message": "Configuration reload failed. Check server logs for details.",
+                },
             },
         )

--- a/src/orb/api/routers/config.py
+++ b/src/orb/api/routers/config.py
@@ -19,8 +19,11 @@ from orb.api.dependencies import (
     get_config_manager,
     require_role,
 )
+from orb.infrastructure.logging.logger import get_logger
 
 router = APIRouter(prefix="/config", tags=["Configuration"])
+
+logger = get_logger(__name__)
 
 CONFIG_MANAGER = Depends(get_config_manager)
 
@@ -191,9 +194,13 @@ async def save_config(
     try:
         written_to = config_manager.save_config(resolved_save_path)
     except ValueError as exc:
+        logger.warning("Config save rejected — no config path resolved: %s", exc)
         raise HTTPException(
             status_code=400,
-            detail={"code": "NO_CONFIG_PATH", "message": str(exc)},
+            detail={
+                "code": "NO_CONFIG_PATH",
+                "message": "No config file path could be resolved. Supply an explicit path or load a config file first.",
+            },
         ) from exc
     return JSONResponse(
         content=SaveResponse(persisted=True, path=written_to).model_dump(),

--- a/src/orb/api/routers/machines.py
+++ b/src/orb/api/routers/machines.py
@@ -35,8 +35,11 @@ from orb.application.services.orchestration.dtos import (
 )
 from orb.domain.base import UnitOfWorkFactory
 from orb.infrastructure.error.decorators import handle_rest_exceptions
+from orb.infrastructure.logging.logger import get_logger
 
 router = APIRouter(prefix="/machines", tags=["Machines"])
+
+logger = get_logger(__name__)
 
 # Module-level dependency variables to avoid B008 warnings
 ACQUIRE_ORCHESTRATOR = Depends(get_acquire_machines_orchestrator)
@@ -309,16 +312,24 @@ async def purge_machine(
     try:
         cleanup_result = service.delete_machine(machine_id)
     except KeyError as exc:
+        logger.warning("Machine purge failed — not found: %s", exc)
         return JSONResponse(
             status_code=404,
-            content={"success": False, "error": {"code": "NOT_FOUND", "message": str(exc)}},
+            content={
+                "success": False,
+                "error": {"code": "NOT_FOUND", "message": "Machine not found."},
+            },
         )
     except NonTerminalStatusError as exc:
+        logger.warning("Machine purge rejected — non-terminal status: %s", exc)
         return JSONResponse(
             status_code=400,
             content={
                 "success": False,
-                "error": {"code": "NON_TERMINAL_STATUS", "message": str(exc)},
+                "error": {
+                    "code": "NON_TERMINAL_STATUS",
+                    "message": "Machine cannot be purged because it is not in a terminal state.",
+                },
             },
         )
 

--- a/src/orb/api/routers/requests.py
+++ b/src/orb/api/routers/requests.py
@@ -321,16 +321,24 @@ async def purge_request(
     try:
         cleanup_result = service.delete_request(request_id, cascade_machines=True)
     except KeyError as exc:
+        _logger.warning("Request purge failed — not found: %s", exc)
         return JSONResponse(
             status_code=404,
-            content={"success": False, "error": {"code": "NOT_FOUND", "message": str(exc)}},
+            content={
+                "success": False,
+                "error": {"code": "NOT_FOUND", "message": "Request not found."},
+            },
         )
     except NonTerminalStatusError as exc:
+        _logger.warning("Request purge rejected — non-terminal status: %s", exc)
         return JSONResponse(
             status_code=400,
             content={
                 "success": False,
-                "error": {"code": "NON_TERMINAL_STATUS", "message": str(exc)},
+                "error": {
+                    "code": "NON_TERMINAL_STATUS",
+                    "message": "Request cannot be purged because it is not in a terminal state.",
+                },
             },
         )
 

--- a/src/orb/api/server.py
+++ b/src/orb/api/server.py
@@ -259,19 +259,22 @@ def create_fastapi_app(server_config: Any) -> Any:
 
     logger = get_logger(__name__)
 
-    # Validate and default configuration
+    # Validate configuration: refuse to boot with a None or structurally invalid
+    # ServerConfig.  Silently falling back to a default would produce an
+    # unauthenticated server with no intentional auth posture, which is
+    # fail-open in production.  Callers must always supply a well-formed config.
     if server_config is None:
-        logger.warning("No server configuration provided, using defaults")
-        from orb.config.schemas.server_schema import ServerConfig
+        raise ConfigurationError(
+            "create_fastapi_app() requires a ServerConfig; received None. "
+            "Ensure server configuration is loaded before calling this function."
+        )
 
-        server_config = ServerConfig()  # type: ignore[call-arg]
-
-    # Validate configuration object has required attributes
     if not hasattr(server_config, "docs_enabled"):
-        logger.error("Invalid server configuration: missing docs_enabled attribute")
-        from orb.config.schemas.server_schema import ServerConfig
-
-        server_config = ServerConfig()  # type: ignore[call-arg]
+        raise ConfigurationError(
+            "create_fastapi_app() received an invalid ServerConfig object "
+            "(missing required attribute 'docs_enabled'). "
+            "Pass a properly constructed ServerConfig instance."
+        )
 
     from orb.api.documentation import configure_openapi
     from orb.api.middleware import (

--- a/src/orb/bootstrap/port_registrations.py
+++ b/src/orb/bootstrap/port_registrations.py
@@ -128,6 +128,13 @@ def register_port_adapters(container):
 
     container.register_singleton(SystemInfoPort, lambda _: PsutilSystemInfoAdapter())
 
+    # Register TokenDenylistPort with an in-process InMemoryTokenDenylist as the
+    # default implementation.  Production deployments that require a shared
+    # denylist (e.g. Redis) should override this registration after bootstrap.
+    from orb.infrastructure.auth.token_denylist import InMemoryTokenDenylist, TokenDenylistPort
+
+    container.register_singleton(TokenDenylistPort, lambda _: InMemoryTokenDenylist())
+
     # Register response formatting service
     from orb.application.ports.scheduler_port import SchedulerPort
     from orb.interface.response_formatting_service import ResponseFormattingService

--- a/src/orb/config/schemas/server_schema.py
+++ b/src/orb/config/schemas/server_schema.py
@@ -128,12 +128,15 @@ class ProviderAuthSubConfig(BaseModel):
     )
 
 
+_NO_AUTH_STRATEGIES: frozenset[str | None] = frozenset({"none", "", None})
+
+
 class AuthConfig(BaseModel):
     """Authentication configuration."""
 
     model_config = ConfigDict(extra="forbid")
 
-    enabled: bool = Field(False, description="Enable authentication")
+    enabled: bool = Field(True, description="Enable authentication")
     strategy: str = Field(
         "none",
         description="Authentication strategy (none, bearer_token, bearer_token_enhanced, iam, cognito)",
@@ -152,6 +155,31 @@ class AuthConfig(BaseModel):
         None, description="Provider-specific auth configuration"
     )
 
+    @model_validator(mode="after")
+    def _reject_enabled_with_no_strategy(self) -> "AuthConfig":
+        """Fail hard when auth.enabled=True but no real strategy is configured.
+
+        The "none" strategy (NoAuthStrategy) is a pass-through that grants every
+        anonymous caller permissions=["*"].  Combining it with enabled=True is a
+        silent fail-open: the server advertises "auth is on" while enforcing
+        nothing.  Any construction that would produce this combination is a
+        misconfiguration and is rejected at build time so the error surfaces
+        immediately rather than at request time.
+
+        To run with authentication disabled, use AuthConfig(enabled=False)
+        explicitly.  To enable auth, also set strategy to a real strategy name
+        (e.g. "bearer_token", "iam", "cognito").
+        """
+        if self.enabled and self.strategy in _NO_AUTH_STRATEGIES:
+            raise ValueError(
+                "auth.enabled=True requires a real authentication strategy. "
+                f"Got strategy={self.strategy!r}, which is a pass-through that enforces nothing. "
+                "Either set enabled=False (to disable auth explicitly) "
+                "or set strategy to a real strategy name "
+                "(e.g. 'bearer_token', 'bearer_token_enhanced', 'iam', 'cognito')."
+            )
+        return self
+
 
 class CORSConfig(BaseModel):
     """CORS configuration.
@@ -161,6 +189,15 @@ class CORSConfig(BaseModel):
     Operators who bind the server to ``0.0.0.0`` (network exposure) MUST also
     update ``origins`` and ``trusted_hosts`` to the actual client origins they
     want to permit.
+
+    **Security note — credentials + wildcard origin:**
+    The combination of ``credentials=True`` and ``origins=["*"]`` is rejected at
+    validation time.  Browsers refuse to honour ``Access-Control-Allow-Credentials:
+    true`` when the server responds with ``Access-Control-Allow-Origin: *``
+    (the spec requires an explicit origin in that case).  Accepting this combo
+    silently would produce a configuration that either breaks browsers or, in
+    environments where the restriction is relaxed, grants credential access to
+    any origin.
     """
 
     enabled: bool = Field(True, description="Enable CORS")
@@ -176,6 +213,49 @@ class CORSConfig(BaseModel):
     )
     headers: list[str] = Field(["*"], description="Allowed headers")
     credentials: bool = Field(False, description="Allow credentials")
+
+    @model_validator(mode="after")
+    def _reject_credentials_with_wildcard_origin(self) -> "CORSConfig":
+        """Reject insecure combinations of allow_credentials=True with wildcard origins/headers.
+
+        Browsers reject ``Access-Control-Allow-Credentials: true`` when the
+        server sends ``Access-Control-Allow-Origin: *``.  Beyond the bare ``*``
+        case, this validator also catches:
+
+        - Whitespace-padded wildcards (e.g. ``" * "`` or ``"  *"``)
+        - Subdomain/path wildcards (any origin containing ``*``, e.g.
+          ``"https://*.example.com"``) — browsers reject credentials with any
+          wildcard origin pattern, not just a bare ``*``
+        - ``headers=["*"]`` with ``credentials=True`` — the spec forbids
+          ``Access-Control-Allow-Headers: *`` when credentials are in play
+
+        When ``credentials=False`` (the default) none of these restrictions apply.
+        """
+        if not self.credentials:
+            return self
+
+        # Check each origin: strip whitespace and reject any that contain '*'.
+        for origin in self.origins:
+            if "*" in origin.strip():
+                raise ValueError(
+                    "cors.credentials=true is incompatible with cors.origins containing "
+                    f"a wildcard pattern (got {origin!r}). "
+                    "Browsers refuse to send credentials to wildcard origins, including "
+                    "subdomain wildcards like 'https://*.example.com'. "
+                    "Replace wildcard entries with the explicit origins you want to permit, "
+                    "or set cors.credentials=false if credentials are not needed."
+                )
+
+        # headers=["*"] with credentials is also forbidden by the CORS spec.
+        if "*" in self.headers:
+            raise ValueError(
+                "cors.credentials=true is incompatible with cors.headers containing '*'. "
+                "The CORS spec forbids 'Access-Control-Allow-Headers: *' when credentials "
+                "are in play.  List the specific request headers you want to allow, "
+                "or set cors.credentials=false if credentials are not needed."
+            )
+
+        return self
 
 
 class ServerConfig(BaseModel):
@@ -203,7 +283,17 @@ class ServerConfig(BaseModel):
     openapi_url: str = Field("/openapi.json", description="OpenAPI schema URL")
 
     # Authentication and CORS
-    auth: AuthConfig = Field(default_factory=AuthConfig, description="Authentication configuration")  # type: ignore[arg-type]
+    #
+    # Default: auth disabled.  The "none" strategy is a pass-through that grants
+    # every anonymous caller permissions=["*"]; combining it with enabled=True
+    # is silently fail-open.  Operators who want auth MUST set both enabled=True
+    # AND a real strategy name in their config file.  A bare ServerConfig()
+    # therefore boots with auth off (honest posture) rather than appearing to
+    # have auth on while enforcing nothing.
+    auth: AuthConfig = Field(  # type: ignore[arg-type]
+        default_factory=lambda: AuthConfig(enabled=False),  # type: ignore[call-arg]
+        description="Authentication configuration",
+    )
     cors: CORSConfig = Field(default_factory=CORSConfig, description="CORS configuration")  # type: ignore[arg-type]
 
     # Security

--- a/src/orb/infrastructure/error/http_response_handler.py
+++ b/src/orb/infrastructure/error/http_response_handler.py
@@ -6,7 +6,7 @@ Provides consistent HTTP status codes and response formatting for all exception 
 """
 
 from http import HTTPStatus
-from typing import Callable
+from typing import Any, Callable
 
 from orb.domain.base.exceptions import (
     BusinessRuleViolationError,
@@ -31,6 +31,28 @@ from orb.domain.template.exceptions import (
 )
 from orb.infrastructure.error.categories import ErrorCategory, ErrorCode
 from orb.infrastructure.error.responses import ErrorResponse
+from orb.infrastructure.logging.logger import get_logger
+
+# Keys that are safe to forward to clients.  Everything else is stripped so that
+# wrap-chain internals (original_error, errno, filename, …) never reach the wire.
+_SAFE_DETAIL_KEYS: frozenset[str] = frozenset(
+    {
+        "entity_type",
+        "entity_id",
+        "field",
+        "field_name",
+        "rule",
+        "expected_version",
+        "new_version",
+        "current_state",
+        "attempted_state",
+    }
+)
+
+
+def _safe_details(raw: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *raw* containing only the keys safe to send to callers."""
+    return {k: v for k, v in raw.items() if k in _SAFE_DETAIL_KEYS}
 
 
 class HTTPErrorResponseHandler:
@@ -43,6 +65,7 @@ class HTTPErrorResponseHandler:
 
     def __init__(self) -> None:
         """Initialize HTTP error response handler."""
+        self._logger = get_logger(__name__)
         self._http_handlers: dict[type[Exception], Callable[[Exception], ErrorResponse]] = {}  # type: ignore[misc]
         self._register_http_handlers()
 
@@ -92,21 +115,31 @@ class HTTPErrorResponseHandler:
 
     def _handle_validation_error_http(self, exception: ValidationError) -> ErrorResponse:
         """Handle validation errors for HTTP responses."""
+        self._logger.warning(
+            "Validation error: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.INVALID_INPUT,
-            message=str(exception),
+            message="Invalid input",
             category=ErrorCategory.VALIDATION,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.BAD_REQUEST,
         )
 
     def _handle_not_found_error_http(self, exception: EntityNotFoundError) -> ErrorResponse:
         """Handle not found errors for HTTP responses."""
+        self._logger.warning(
+            "Resource not found: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.RESOURCE_NOT_FOUND,
-            message=str(exception),
+            message="Resource not found",
             category=ErrorCategory.NOT_FOUND,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.NOT_FOUND,
         )
 
@@ -116,17 +149,22 @@ class HTTPErrorResponseHandler:
             error_code="CONCURRENCY_ERROR",
             message="The resource was modified concurrently; please retry.",
             category=ErrorCategory.BUSINESS_RULE,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.CONFLICT,
         )
 
     def _handle_duplicate_error_http(self, exception: DuplicateError) -> ErrorResponse:
         """Handle duplicate resource errors for HTTP responses."""
+        self._logger.warning(
+            "Duplicate resource: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code="DUPLICATE_ERROR",
-            message=str(exception),
+            message="A duplicate resource already exists",
             category=ErrorCategory.BUSINESS_RULE,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.CONFLICT,
         )
 
@@ -134,96 +172,146 @@ class HTTPErrorResponseHandler:
         self, exception: BusinessRuleViolationError
     ) -> ErrorResponse:
         """Handle business rule violations for HTTP responses."""
+        self._logger.warning(
+            "Business rule violation: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.BUSINESS_RULE_VIOLATION,
-            message=str(exception),
+            message="Request could not be processed",
             category=ErrorCategory.BUSINESS_RULE,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.UNPROCESSABLE_ENTITY,
         )
 
     def _handle_request_not_found_http(self, exception: RequestNotFoundError) -> ErrorResponse:
         """Handle request not found errors for HTTP responses."""
+        self._logger.warning(
+            "Request not found: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.REQUEST_NOT_FOUND,
-            message=str(exception),
+            message="Request not found",
             category=ErrorCategory.NOT_FOUND,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.NOT_FOUND,
         )
 
     def _handle_request_validation_http(self, exception: RequestValidationError) -> ErrorResponse:
         """Handle request validation errors for HTTP responses."""
+        self._logger.warning(
+            "Request validation error: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.INVALID_INPUT,
-            message=str(exception),
+            message="Invalid input",
             category=ErrorCategory.VALIDATION,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.BAD_REQUEST,
         )
 
     def _handle_machine_not_found_http(self, exception: MachineNotFoundError) -> ErrorResponse:
         """Handle machine not found errors for HTTP responses."""
+        self._logger.warning(
+            "Machine not found: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.MACHINE_NOT_FOUND,
-            message=str(exception),
+            message="Machine not found",
             category=ErrorCategory.NOT_FOUND,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.NOT_FOUND,
         )
 
     def _handle_machine_validation_http(self, exception: MachineValidationError) -> ErrorResponse:
         """Handle machine validation errors for HTTP responses."""
+        self._logger.warning(
+            "Machine validation error: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.INVALID_INPUT,
-            message=str(exception),
+            message="Invalid input",
             category=ErrorCategory.VALIDATION,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.BAD_REQUEST,
         )
 
     def _handle_template_not_found_http(self, exception: TemplateNotFoundError) -> ErrorResponse:
         """Handle template not found errors for HTTP responses."""
+        self._logger.warning(
+            "Template not found: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.TEMPLATE_NOT_FOUND,
-            message=str(exception),
+            message="Template not found",
             category=ErrorCategory.NOT_FOUND,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.NOT_FOUND,
         )
 
     def _handle_template_validation_http(self, exception: TemplateValidationError) -> ErrorResponse:
         """Handle template validation errors for HTTP responses."""
+        self._logger.warning(
+            "Template validation error: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.INVALID_INPUT,
-            message=str(exception),
+            message="Invalid input",
             category=ErrorCategory.VALIDATION,
-            details=getattr(exception, "details", {}),
+            details=_safe_details(getattr(exception, "details", {})),
             http_status=HTTPStatus.BAD_REQUEST,
         )
 
     def _handle_infrastructure_error_http(self, exception: InfrastructureError) -> ErrorResponse:
         """Handle infrastructure errors for HTTP responses."""
+        self._logger.error(
+            "Infrastructure error: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.EXTERNAL_SERVICE_ERROR,
             message="An infrastructure error occurred",
             category=ErrorCategory.INFRASTRUCTURE,
-            details={"original_error": str(exception)},
+            details={},
             http_status=HTTPStatus.SERVICE_UNAVAILABLE,
         )
 
     def _handle_configuration_error_http(self, exception: ConfigurationError) -> ErrorResponse:
         """Handle configuration errors for HTTP responses."""
+        self._logger.error(
+            "Configuration error: %s",
+            str(exception),
+            extra={"details": getattr(exception, "details", {})},
+        )
         return ErrorResponse(
             error_code=ErrorCode.INTERNAL_ERROR,
             message="A configuration error occurred",
             category=ErrorCategory.INTERNAL,
-            details={"original_error": str(exception)},
+            details={},
             http_status=HTTPStatus.INTERNAL_SERVER_ERROR,
         )
 
     def _handle_unexpected_error_http(self, exception: Exception) -> ErrorResponse:
         """Handle unexpected errors for HTTP responses."""
+        self._logger.error(
+            "Unexpected error (%s): %s",
+            type(exception).__name__,
+            str(exception),
+        )
         return ErrorResponse(
             error_code=ErrorCode.UNEXPECTED_ERROR,
             message="An unexpected error occurred",

--- a/src/orb/infrastructure/error/responses.py
+++ b/src/orb/infrastructure/error/responses.py
@@ -17,6 +17,28 @@ from orb.domain.base.exceptions import (
 
 from .categories import ErrorCategory
 
+# Keys that are safe to forward to callers.  All other keys are stripped so
+# that wrap-chain internals (original_error, errno, filename, …) never reach
+# the wire.
+_SAFE_DETAIL_KEYS: frozenset[str] = frozenset(
+    {
+        "entity_type",
+        "entity_id",
+        "field",
+        "field_name",
+        "rule",
+        "expected_version",
+        "new_version",
+        "current_state",
+        "attempted_state",
+    }
+)
+
+
+def _safe_details(raw: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *raw* containing only the keys safe to send to callers."""
+    return {k: v for k, v in raw.items() if k in _SAFE_DETAIL_KEYS}
+
 
 class InfrastructureErrorResponse(BaseDTO):
     """
@@ -56,14 +78,18 @@ class InfrastructureErrorResponse(BaseDTO):
 
     @classmethod
     def from_exception(
-        cls, exception: Exception, context: Optional[str] = None
+        cls,
+        exception: Exception,
+        context: Optional[str] = None,
     ) -> "InfrastructureErrorResponse":
-        """Create infrastructure error response from exception."""
+        """Create infrastructure error response from exception.
+
+        The context parameter is accepted for API compatibility but is not
+        forwarded to the caller - internal context strings must not reach the
+        wire.
+        """
         error_code, message, category, details = cls._exception_to_components(exception)
         http_status = cls._determine_http_status(category)
-
-        if context:
-            details["context"] = context
 
         return cls(
             error_code=error_code,
@@ -103,46 +129,51 @@ class InfrastructureErrorResponse(BaseDTO):
     def _exception_to_components(
         exception: Exception,
     ) -> tuple[str, str, str, dict[str, Any]]:
-        """Convert exception to error components."""
+        """Convert exception to error components.
+
+        Messages are intentionally categorical - never str(exception) - so
+        that internal details (host names, SQL queries, file paths) do not
+        reach callers.
+        """
         if isinstance(exception, ValidationError):
             return (
                 "VALIDATION_ERROR",
-                str(exception),
+                "Invalid input",
                 ErrorCategory.VALIDATION,
-                getattr(exception, "details", {}),
+                _safe_details(getattr(exception, "details", {})),
             )
         elif isinstance(exception, EntityNotFoundError):
             return (
                 "ENTITY_NOT_FOUND",
-                str(exception),
+                "Resource not found",
                 ErrorCategory.ENTITY_NOT_FOUND,
-                {"entity_type": getattr(exception, "entity_type", "unknown")},
+                _safe_details({"entity_type": getattr(exception, "entity_type", "unknown")}),
             )
         elif isinstance(exception, BusinessRuleViolationError):
             return (
                 "BUSINESS_RULE_VIOLATION",
-                str(exception),
+                "Request could not be processed",
                 ErrorCategory.BUSINESS_RULE_VIOLATION,
-                getattr(exception, "details", {}),
+                _safe_details(getattr(exception, "details", {})),
             )
         elif isinstance(exception, ConfigurationError):
             return (
                 "CONFIGURATION_ERROR",
-                str(exception),
+                "A configuration error occurred",
                 ErrorCategory.CONFIGURATION,
-                getattr(exception, "details", {}),
+                {},
             )
         elif isinstance(exception, InfrastructureError):
             return (
                 "INFRASTRUCTURE_ERROR",
-                str(exception),
+                "An infrastructure error occurred",
                 ErrorCategory.DATABASE_ERROR,
-                getattr(exception, "details", {}),
+                {},
             )
         else:
             return (
                 "UNEXPECTED_ERROR",
-                str(exception),
+                "An unexpected error occurred",
                 ErrorCategory.UNEXPECTED_ERROR,
                 {"exception_type": type(exception).__name__},
             )

--- a/src/orb/interface/server_command_handlers.py
+++ b/src/orb/interface/server_command_handlers.py
@@ -11,8 +11,9 @@ logs     → tail the daemon's log file
 from __future__ import annotations
 
 import json
-from typing import Any, cast
+from typing import Any
 
+from orb.domain.base.exceptions import ConfigurationError
 from orb.infrastructure.error.decorators import handle_interface_exceptions
 from orb.infrastructure.logging.logger import get_logger
 
@@ -34,20 +35,35 @@ def _resolve_lifecycle_paths(server_config: Any) -> tuple[str, str, str]:
 
 def _resolve_configs(args) -> tuple[Any, Any | None]:
     """Resolve ServerConfig + (optional) UIConfig, applying CLI overrides."""
+    from orb.config.managers.configuration_manager import ConfigurationManager
     from orb.config.schemas.server_schema import ServerConfig
     from orb.domain.base.ports.configuration_port import ConfigurationPort
 
     logger = get_logger(__name__)
     container = args._container
-    config_manager = container.get(ConfigurationPort)
+
+    # Resolve the concrete ConfigurationManager for typed config loads — its
+    # get_typed_with_defaults(config_type) takes a single positional argument
+    # (the type to hydrate), which is the correct call signature.
+    # ConfigurationPort.get_typed_with_defaults has a different signature
+    # (key, expected_type, default) and must NOT be used for typed schema loads.
+    cm = container.get(ConfigurationManager)
 
     try:
-        server_config = cast(Any, config_manager).get_typed_with_defaults(ServerConfig)
+        server_config = cm.get_typed_with_defaults(ServerConfig)
     except Exception as e:
-        logger.warning(f"ServerConfig load failed, using defaults: {e}", exc_info=True)
-        server_config = ServerConfig()  # type: ignore[call-arg]
+        # Refuse to fall back to a default ServerConfig.  A silent fallback
+        # would produce a server with no intentional auth posture (fail-open).
+        # Surface the load failure so the operator can fix the configuration.
+        raise ConfigurationError(
+            f"ServerConfig could not be loaded: {e}. "
+            "Fix the server configuration before starting the server."
+        ) from e
     if server_config is None:
-        server_config = ServerConfig()  # type: ignore[call-arg]
+        raise ConfigurationError(
+            "ServerConfig resolved to None from the configuration manager. "
+            "Ensure the server section is present in the configuration file."
+        )
 
     host = getattr(args, "host", None)
     port = getattr(args, "port", None)
@@ -64,14 +80,17 @@ def _resolve_configs(args) -> tuple[Any, Any | None]:
     if log_level:
         server_config.log_level = log_level
     if scheduler:
-        config_manager.override_scheduler_strategy(scheduler)
+        # override_scheduler_strategy lives on both ConfigurationManager and
+        # ConfigurationPort; use the port reference from the container so
+        # the override propagates through the same object the rest of the
+        # application resolves when it asks for ConfigurationPort.
+        port_manager = container.get(ConfigurationPort)
+        port_manager.override_scheduler_strategy(scheduler)
 
     ui_config = None
     try:
-        from orb.config.managers.configuration_manager import ConfigurationManager
         from orb.config.schemas.ui_schema import UIConfig
 
-        cm = container.get(ConfigurationManager)
         ui_config = cm.get_typed_with_defaults(UIConfig)
     except Exception as ui_e:
         logger.debug("UIConfig load failed, defaults used: %s", ui_e)

--- a/src/orb/providers/aws/auth/cognito_strategy.py
+++ b/src/orb/providers/aws/auth/cognito_strategy.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
+import re
 import time
 from base64 import urlsafe_b64decode
 from typing import TYPE_CHECKING, Any, Optional
@@ -27,10 +30,15 @@ from orb.infrastructure.adapters.ports.auth import (
     AuthResult,
     AuthStatus,
 )
+from orb.infrastructure.auth.token_denylist import InMemoryTokenDenylist, TokenDenylistPort
 from orb.infrastructure.di.injectable import injectable
 
 if TYPE_CHECKING:
     pass
+
+# Minimal structural check for a JWT: three dot-separated base64url segments with a
+# coarse length bound to reject obvious garbage before a denylist lookup.
+_JWT_STRUCTURAL_RE = re.compile(r"^[A-Za-z0-9_-]{2,}\.[A-Za-z0-9_-]{2,}\.[A-Za-z0-9_-]{2,}$")
 
 
 @injectable
@@ -50,6 +58,7 @@ class CognitoAuthStrategy(AuthPort):
         region: str = "us-east-1",
         jwks_url: Optional[str] = None,
         enabled: bool = True,
+        token_denylist: Optional[TokenDenylistPort] = None,
     ) -> None:
         """
         Initialize Cognito authentication strategy.
@@ -60,12 +69,19 @@ class CognitoAuthStrategy(AuthPort):
             region: AWS region
             jwks_url: JWKS URL for token verification (auto-generated if not provided)
             enabled: Whether this strategy is enabled
+            token_denylist: Optional denylist for revoked access tokens. Cognito
+                cannot revoke access tokens server-side, so a denylist is required
+                to reject them before their natural expiry. If not provided,
+                access-token revocation will log a warning and skip denylist
+                enforcement; refresh-token revocation via the Cognito API still
+                proceeds normally.
         """
         self.user_pool_id = user_pool_id
         self.client_id = client_id
         self.region = region
         self.enabled = enabled
         self._logger = logger
+        self._token_denylist: Optional[TokenDenylistPort] = token_denylist
 
         # Generate JWKS URL if not provided
         if jwks_url:
@@ -123,6 +139,25 @@ class CognitoAuthStrategy(AuthPort):
             Authentication result with user information from Cognito
         """
         try:
+            # Structural check: three dot-delimited base64url segments, rough length
+            # bound. Rejects obvious garbage before hitting the denylist or JWKS.
+            if not _JWT_STRUCTURAL_RE.match(token) or len(token) > 8192:
+                return AuthResult(
+                    status=AuthStatus.INVALID,
+                    error_message="Invalid token format",
+                )
+
+            # Check denylist before any cryptographic work (fail fast for revoked tokens).
+            if self._token_denylist is not None and await self._token_denylist.is_denylisted(token):
+                token_hint = token[-8:]
+                self._logger.warning(
+                    "Attempted use of revoked Cognito token (suffix=%s)", token_hint
+                )
+                return AuthResult(
+                    status=AuthStatus.INVALID,
+                    error_message="Token has been revoked",
+                )
+
             # Decode token without verification first to get header
             unverified_header = jwt.get_unverified_header(token)
             kid = unverified_header.get("kid")
@@ -195,7 +230,8 @@ class CognitoAuthStrategy(AuthPort):
             New authentication result with fresh token
         """
         try:
-            response = self.cognito_client.initiate_auth(
+            response = await asyncio.to_thread(
+                self.cognito_client.initiate_auth,
                 ClientId=self.client_id,
                 AuthFlow="REFRESH_TOKEN_AUTH",
                 AuthParameters={"REFRESH_TOKEN": refresh_token},
@@ -222,25 +258,98 @@ class CognitoAuthStrategy(AuthPort):
 
     async def revoke_token(self, token: str) -> bool:
         """
-        Revoke Cognito token.
+        Revoke a Cognito token.
+
+        Cognito supports two token types with different revocation mechanisms:
+
+        - **Refresh tokens**: revoked server-side via the Cognito RevokeToken API,
+          AND also inserted into the local denylist.  The denylist insertion ensures
+          that even a forged ``token_use`` claim in an unsigned payload cannot allow
+          a valid access token to escape denylisting.
+        - **Access tokens**: Cognito cannot revoke these server-side.  They are added
+          to the local denylist so that subsequent calls to ``validate_token`` reject
+          them before their natural expiry.
+
+        Security note: ``token_use`` is read from the UNSIGNED JWT payload.  An
+        attacker could craft a valid access token with a forged ``token_use="refresh"``
+        to steer into the RevokeToken-only path and thereby skip denylist insertion.
+        The fix is to **always** insert the token into the denylist first, then
+        additionally call RevokeToken when the unsigned payload indicates a refresh
+        token.  The two paths are not mutually exclusive.
 
         Args:
-            token: Token to revoke
+            token: Cognito JWT token (access or refresh) to revoke
 
         Returns:
-            True if token was revoked successfully
+            True if all applicable revocation steps succeeded; False if any failed
+            or if no denylist is available (revocation genuinely did not happen).
         """
         try:
-            # Cognito doesn't have a direct revoke endpoint for access tokens
-            # You would typically revoke the refresh token or sign out the user
-            # This is a simplified implementation
-            self._logger.info(
-                "Token revocation requested (Cognito access tokens expire automatically)"
-            )
-            return True
+            # Extract the unverified JWT payload to determine token type and expiry.
+            # The result is untrusted — used only as a hint for the optional Cognito
+            # API call; denylist insertion always happens regardless of this value.
+            token_use: Optional[str] = None
+            expires_at: Optional[int] = None
+            try:
+                payload_part = token.split(".")[1]
+                padding = 4 - len(payload_part) % 4
+                if padding != 4:
+                    payload_part += "=" * padding
+                decoded_payload = json.loads(base64.urlsafe_b64decode(payload_part))
+                token_use = decoded_payload.get("token_use")
+                expires_at = decoded_payload.get("exp")
+            except Exception:
+                # Malformed token: proceed with denylist insertion using no expiry.
+                pass
 
-        except Exception as e:
-            self._logger.error("Token revocation error: %s", e)
+            # Step 1: ALWAYS insert into denylist regardless of token_use.
+            # This prevents a forged token_use claim from bypassing denylist enforcement.
+            if self._token_denylist is None:
+                self._logger.warning(
+                    "Cognito token cannot be fully revoked: no token denylist is configured. "
+                    "The token will remain valid until its natural expiry."
+                )
+                # Return False — revocation genuinely did not happen.
+                return False
+
+            denylist_success = await self._token_denylist.add_token(token, expires_at)
+            if denylist_success:
+                self._logger.info(
+                    "Cognito token added to denylist (token_use=%s, expires_at=%s)",
+                    token_use,
+                    expires_at,
+                )
+            else:
+                self._logger.error("Failed to add Cognito token to denylist")
+                return False
+
+            # Step 2: For refresh tokens, additionally call the Cognito RevokeToken API.
+            # This invalidates all access tokens derived from that refresh token on the
+            # Cognito side.  The unsigned token_use hint is acceptable here: the worst
+            # case of a forged "refresh" claim is a spurious but harmless API call.
+            if token_use == "refresh":
+                try:
+                    await asyncio.to_thread(
+                        self.cognito_client.revoke_token,
+                        Token=token,
+                        ClientId=self.client_id,
+                    )
+                    self._logger.info("Cognito refresh token revoked via RevokeToken API")
+                except ClientError as exc:
+                    error_code = exc.response.get("Error", {}).get("Code", "Unknown")
+                    self._logger.error(
+                        "Cognito RevokeToken API call failed (code=%s); "
+                        "token is still in the local denylist",
+                        error_code,
+                    )
+                    # Denylist insertion succeeded so partial revocation did occur;
+                    # return False to signal that the Cognito API step failed.
+                    return False
+
+            return denylist_success
+
+        except Exception as exc:
+            self._logger.error("Token revocation error: %s", exc)
             return False
 
     @classmethod
@@ -276,18 +385,33 @@ class CognitoAuthStrategy(AuthPort):
 
         # Intentional service-locator: from_auth_config is called by the
         # AuthRegistry as ``strategy_factory.from_auth_config(auth_config)``
-        # with a fixed signature — no logger parameter can be threaded through
-        # without changing the AuthRegistry protocol (a broad, cross-cutting
-        # change).  The DI container is therefore queried here as a best-effort
-        # bootstrap; a plain LoggingAdapter fallback ensures the classmethod
+        # with a fixed signature — no logger or denylist parameters can be
+        # threaded through without changing the AuthRegistry protocol (a broad,
+        # cross-cutting change).  The DI container is therefore queried here as
+        # a best-effort bootstrap; plain fallbacks ensure this classmethod
         # remains self-contained when the container is not yet initialised.
         try:
             from orb.domain.base.ports import LoggingPort
             from orb.infrastructure.di.container import get_container
 
-            logger: LoggingPort = get_container().get(LoggingPort)
+            _container = get_container()
+            logger: LoggingPort = _container.get(LoggingPort)
         except Exception:
             logger = LoggingAdapter()  # type: ignore[assignment]
+            _container = None
+
+        # Resolve a TokenDenylistPort from the container so that access-token
+        # revocation is enforced in production.  Fall back to an in-process
+        # InMemoryTokenDenylist when the container has none registered — this
+        # guarantees _token_denylist is always non-None on live instances.
+        token_denylist: TokenDenylistPort
+        try:
+            if _container is not None:
+                token_denylist = _container.get(TokenDenylistPort)
+            else:
+                token_denylist = InMemoryTokenDenylist()
+        except Exception:
+            token_denylist = InMemoryTokenDenylist()
 
         return cls(
             logger=logger,
@@ -296,6 +420,7 @@ class CognitoAuthStrategy(AuthPort):
             region=region,
             jwks_url=jwks_url,
             enabled=True,
+            token_denylist=token_denylist,
         )
 
     def get_strategy_name(self) -> str:

--- a/src/orb/providers/aws/auth/iam_strategy.py
+++ b/src/orb/providers/aws/auth/iam_strategy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -60,11 +61,16 @@ class IAMAuthStrategy(AuthPort):
         self._admin_role_patterns = admin_role_patterns or self._DEFAULT_ADMIN_ROLE_PATTERNS
         self.region = region
         self.profile = profile
-        self.required_actions = required_actions or [
-            "ec2:DescribeInstances",
-            "ec2:RunInstances",
-            "ec2:TerminateInstances",
-        ]
+        # None means "operator did not configure required_actions" → apply defaults.
+        # [] means "operator explicitly set required_actions to empty" → honour it (no actions required).
+        if required_actions is None:
+            self.required_actions: list[str] = [
+                "ec2:DescribeInstances",
+                "ec2:RunInstances",
+                "ec2:TerminateInstances",
+            ]
+        else:
+            self.required_actions = list(required_actions)
         self.enabled = enabled
 
         # assume_permissions is a dev-only escape hatch. It is only honoured when
@@ -91,14 +97,6 @@ class IAMAuthStrategy(AuthPort):
                 "IAM assume_permissions=True is ACTIVE (ORB_IAM_ASSUME_PERMISSIONS_DEV_ONLY=true). "
                 "All required_actions are granted without AWS evaluation. "
                 "This MUST NOT be used in production."
-            )
-
-        if not self._assume_permissions:
-            self._logger.error(
-                "IAM strategy active with assume_permissions=False. "
-                "IAM permission evaluation (SimulatePrincipalPolicy) is not yet implemented. "
-                "All permission checks will DENY by default. "
-                "Set assume_permissions=True for development/testing only."
             )
 
         # Initialize AWS session
@@ -290,11 +288,14 @@ class IAMAuthStrategy(AuthPort):
         """
         Get AWS caller identity.
 
+        The underlying boto3 call is executed via ``asyncio.to_thread`` so the
+        event loop is not blocked during the synchronous network round-trip.
+
         Returns:
             Caller identity information
         """
         try:
-            response = self.sts_client.get_caller_identity()
+            response: dict[str, Any] = await asyncio.to_thread(self.sts_client.get_caller_identity)
             return response
         except Exception as e:
             self._logger.error("Failed to get caller identity: %s", e)
@@ -302,21 +303,25 @@ class IAMAuthStrategy(AuthPort):
 
     async def _check_permissions(self, identity: dict[str, Any]) -> list[str]:
         """
-        Check IAM permissions for the caller.
+        Check IAM permissions for the caller using SimulatePrincipalPolicy.
 
-        By default this method denies all permissions. Actual IAM policy evaluation
-        (via SimulatePrincipalPolicy) is not yet implemented.
+        The caller's ARN (from ``identity``) is used as the policy-source ARN.
+        All ``required_actions`` are evaluated in a single API call.  Only
+        actions whose ``EvalDecision`` is ``"allowed"`` are returned; explicit-
+        deny, implicit-deny, or any unknown decision are treated as denied.
 
-        Set ``assume_permissions=True`` at construction time to grant all
-        ``required_actions`` unconditionally — intended for development and testing
-        only, never for production use.
+        On any error (API failure, missing permissions to call IAM, network
+        timeout, etc.) the method returns an empty list — fail secure.
+
+        When the ``assume_permissions`` dev-only flag is active the evaluation
+        is bypassed and all ``required_actions`` plus the hostfactory actions
+        are returned unconditionally.
 
         Args:
-            identity: Caller identity
+            identity: Caller identity dict (must contain ``"Arn"``).
 
         Returns:
-            List of permissions/actions the user can perform. Empty list unless
-            ``assume_permissions=True``.
+            List of IAM actions the caller is allowed to perform.
         """
         if self._assume_permissions:
             permissions = list(self.required_actions)
@@ -329,11 +334,66 @@ class IAMAuthStrategy(AuthPort):
             )
             return permissions
 
-        self._logger.warning(
-            "IAM permission evaluation not implemented. All permissions denied by default. "
-            "Set assume_permissions=True to grant all permissions for development."
-        )
-        return []
+        caller_arn = identity.get("Arn", "")
+        if not caller_arn:
+            self._logger.warning("Cannot evaluate IAM permissions: caller ARN is empty.")
+            return []
+
+        actions_to_check = list(self.required_actions)
+
+        # ResourceArns is not passed here, so the simulation evaluates against
+        # the wildcard resource ("*").  This means resource-scoped Condition
+        # keys and resource-level denies in IAM policies are NOT evaluated,
+        # which can produce an over-grant for resource-restricted policies
+        # (e.g. ``ec2:TerminateInstances`` scoped to specific instance IDs).
+        # Passing concrete ResourceArns would require threading request-context
+        # resource identifiers through the auth layer — a broad refactor deferred
+        # to a future enhancement.  The current behaviour is intentional and
+        # documented here so callers understand the limitation.
+
+        granted: list[str] = []
+        try:
+            # Paginate through all EvaluationResults pages (AWS returns ≤100
+            # results per page and paginates via IsTruncated/Marker).  Using
+            # the boto3 paginator ensures every page is consumed before a
+            # permission decision is made, preventing silent over-grant or
+            # wrong-deny when >100 actions are evaluated.
+            paginator = self.iam_client.get_paginator("simulate_principal_policy")
+
+            def _paginate() -> list[dict[str, Any]]:
+                pages: list[dict[str, Any]] = []
+                for page in paginator.paginate(
+                    PolicySourceArn=caller_arn,
+                    ActionNames=actions_to_check,
+                ):
+                    pages.extend(page.get("EvaluationResults", []))
+                return pages
+
+            all_results: list[dict[str, Any]] = await asyncio.to_thread(_paginate)
+
+        except ClientError as exc:
+            error_code = exc.response.get("Error", {}).get("Code", "Unknown")
+            self._logger.error(
+                "SimulatePrincipalPolicy failed (ClientError %s); denying all permissions.",
+                error_code,
+            )
+            return []
+        except Exception as exc:
+            # Log only the exception type to avoid embedding caller ARN or
+            # action lists (present in botocore exception messages) in log output.
+            self._logger.error(
+                "SimulatePrincipalPolicy raised an unexpected error (%s); denying all permissions.",
+                type(exc).__name__,
+            )
+            return []
+
+        for result in all_results:
+            action = result.get("EvalActionName", "")
+            decision = result.get("EvalDecision", "")
+            if decision == "allowed":
+                granted.append(action)
+
+        return granted
 
     async def _determine_roles(self, identity: dict[str, Any], permissions: list[str]) -> list[str]:
         """

--- a/src/orb/providers/aws/configuration/config.py
+++ b/src/orb/providers/aws/configuration/config.py
@@ -3,7 +3,7 @@
 import json
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from orb.infrastructure.interfaces.provider import BaseProviderConfig
@@ -127,8 +127,20 @@ class AWSProviderConfig(BaseSettings, BaseProviderConfig):  # type: ignore[misc]
     # AWS Authentication
     profile: Optional[str] = Field(None, description="AWS profile")
     role_arn: Optional[str] = Field(None, description="AWS role ARN")
-    access_key_id: Optional[str] = Field(None, description="AWS access key ID")
-    secret_access_key: Optional[str] = Field(None, description="AWS secret access key")
+    access_key_id: Optional[SecretStr] = Field(
+        None,
+        description=(
+            "AWS access key ID. Stored as SecretStr so the value is never exposed "
+            "in repr() or log output. Call .get_secret_value() to pass to boto3."
+        ),
+    )
+    secret_access_key: Optional[SecretStr] = Field(
+        None,
+        description=(
+            "AWS secret access key. Stored as SecretStr so the value is never exposed "
+            "in repr() or log output. Call .get_secret_value() to pass to boto3."
+        ),
+    )
     session_token: Optional[str] = Field(None, description="AWS session token")
 
     # AWS Settings

--- a/src/orb/providers/aws/infrastructure/aws_client.py
+++ b/src/orb/providers/aws/infrastructure/aws_client.py
@@ -3,6 +3,59 @@
 import threading
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
+# Exact-match keys whose values are always sensitive, regardless of surrounding
+# characters.  Also used as suffix patterns ("ends with").
+_SECRET_EXACT_KEYS = frozenset({"access_key_id", "secret_access_key", "session_token"})
+
+# Substring fragments that indicate a sensitive key when found anywhere in the
+# lowercased field name.  Deliberately excludes bare "key" to avoid hiding
+# legitimate debug fields such as key_file, public_key, region_key, etc.
+_SECRET_FRAGMENTS = ("secret", "password", "token", "credential")
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """Return True when *key* (case-insensitive) refers to a sensitive value.
+
+    Rules (applied in order, first match wins):
+    1. Exact match against the known-secret set (access_key_id, etc.).
+    2. The lowercased key ends with one of the exact-match suffixes.
+    3. The lowercased key contains one of the sensitive fragments
+       (secret, password, token, credential) — NOT bare "key".
+    """
+    lower = key.lower()
+    if lower in _SECRET_EXACT_KEYS:
+        return True
+    for exact in _SECRET_EXACT_KEYS:
+        if lower.endswith(exact):
+            return True
+    return any(frag in lower for frag in _SECRET_FRAGMENTS)
+
+
+def _mask_config_dict(config: dict) -> dict:
+    """Return a deep copy of *config* with sensitive values replaced by '***'.
+
+    Recursion rules:
+    - dict values: recurse (so nested secrets such as {"auth": {"secret_access_key": "..."}}
+      are masked regardless of depth).
+    - list values: iterate elements, recursing into any dict elements.
+    - scalar values: replaced with '***' only when the key is deemed sensitive
+      by ``_is_sensitive_key``; otherwise passed through unchanged.
+    """
+    masked: dict = {}
+    for k, v in config.items():
+        if isinstance(v, dict):
+            # Recurse unconditionally: the child dict may contain sensitive keys
+            # even when the parent key itself is not sensitive.
+            masked[k] = _mask_config_dict(v)
+        elif isinstance(v, list):
+            masked[k] = [_mask_config_dict(item) if isinstance(item, dict) else item for item in v]
+        elif _is_sensitive_key(k):
+            masked[k] = "***"
+        else:
+            masked[k] = v
+    return masked
+
+
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
@@ -94,11 +147,28 @@ class AWSClient:
         self._logger.debug("AWS client profile determined: %s", self.profile_name)
 
         try:
-            # Initialize session
+            # Initialize session — extract explicit credentials (if any) so
+            # they reach boto3.Session instead of being silently discarded.
             from orb.providers.aws.session_factory import AWSSessionFactory
 
+            _explicit_key_id: Optional[str] = None
+            _explicit_secret: Optional[str] = None
+            _explicit_token: Optional[str] = None
+            _creds_cfg = self.get_selected_aws_provider_config()
+            if _creds_cfg is not None:
+                if _creds_cfg.access_key_id is not None:
+                    _explicit_key_id = _creds_cfg.access_key_id.get_secret_value()
+                if _creds_cfg.secret_access_key is not None:
+                    _explicit_secret = _creds_cfg.secret_access_key.get_secret_value()
+                # session_token is a plain Optional[str] — no SecretStr unwrap needed
+                _explicit_token = _creds_cfg.session_token or None
+
             self.session = AWSSessionFactory.create_session(
-                profile=self.profile_name, region=self.region_name
+                profile=self.profile_name,
+                region=self.region_name,
+                aws_access_key_id=_explicit_key_id,
+                aws_secret_access_key=_explicit_secret,
+                aws_session_token=_explicit_token,
             )
 
             # Initialize service client attributes but don't create clients yet
@@ -248,12 +318,23 @@ class AWSClient:
                             return self._aws_config
 
                         if isinstance(provider.config, dict):
-                            self._logger.debug("Config dict contents: %s", provider.config)
+                            self._logger.debug(
+                                "Config dict contents: %s", _mask_config_dict(provider.config)
+                            )
                             self._aws_config = AWSProviderConfig(**provider.config)
                             return self._aws_config
 
                         config_data = None
                         if hasattr(provider.config, "model_dump"):
+                            # model_dump() (default mode="python") preserves SecretStr
+                            # objects rather than serialising them to plain strings.
+                            # Passing this dict to AWSProviderConfig(**config_data) is
+                            # safe — Pydantic accepts SecretStr for Optional[SecretStr]
+                            # fields.  Do NOT pass this dict to json.dumps or any JSON
+                            # serialiser: SecretStr is not JSON-serialisable and will
+                            # raise TypeError (or emit the masked repr "**********").
+                            # Use model_dump(mode="json") or unwrap via
+                            # .get_secret_value() if a plain-string dict is required.
                             config_data = provider.config.model_dump()
                         elif hasattr(provider.config, "dict"):
                             config_data = provider.config.dict()

--- a/src/orb/providers/aws/session_factory.py
+++ b/src/orb/providers/aws/session_factory.py
@@ -18,21 +18,46 @@ class AWSSessionFactory:
 
     @staticmethod
     def create_session(
-        profile: Optional[str] = None, region: Optional[str] = None
+        profile: Optional[str] = None,
+        region: Optional[str] = None,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
     ) -> boto3.Session:
         """Create AWS session with credential chain fallback.
+
+        When explicit key credentials are supplied they are passed directly to
+        boto3.Session so the operator-configured keys are used instead of the
+        ambient credential chain.  When they are absent (None) boto3 falls back
+        to its normal chain (env vars, ~/.aws/credentials, instance profile,
+        etc.).  Empty strings are treated as absent — never pass them to boto3
+        because boto3 treats "" as a non-None credential and the call will fail
+        or use an unexpected identity.
 
         Args:
             profile: AWS profile name (optional)
             region: AWS region (optional)
+            aws_access_key_id: Explicit access key ID (plain str, optional)
+            aws_secret_access_key: Explicit secret access key (plain str, optional)
+            aws_session_token: Explicit session token (plain str, optional)
 
         Returns:
             Configured boto3 session
         """
+        # Build kwargs dict; only include credential keys when they have a
+        # non-empty value so boto3 credential-chain fallback is unaffected.
+        kwargs: dict = {}
+        if region:
+            kwargs["region_name"] = region
         if profile:
-            return boto3.Session(profile_name=profile, region_name=region)
-        else:
-            return boto3.Session(region_name=region)
+            kwargs["profile_name"] = profile
+        if aws_access_key_id:
+            kwargs["aws_access_key_id"] = aws_access_key_id
+        if aws_secret_access_key:
+            kwargs["aws_secret_access_key"] = aws_secret_access_key
+        if aws_session_token:
+            kwargs["aws_session_token"] = aws_session_token
+        return boto3.Session(**kwargs)
 
     @staticmethod
     def discover_credentials(profile: Optional[str] = None, region: Optional[str] = None) -> dict:

--- a/tests/infrastructure/error/test_http_response_handler.py
+++ b/tests/infrastructure/error/test_http_response_handler.py
@@ -5,6 +5,7 @@ Verifies HTTP error response formatting for all exception types.
 """
 
 from http import HTTPStatus
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -12,6 +13,7 @@ from orb.domain.base.exceptions import (
     BusinessRuleViolationError,
     ConcurrencyError,
     ConfigurationError,
+    DuplicateError,
     EntityNotFoundError,
     InfrastructureError,
     ValidationError,
@@ -41,13 +43,16 @@ class TestHTTPErrorResponseHandler:
         return HTTPErrorResponseHandler()
 
     def test_validation_error_http(self, handler):
-        """Test validation error HTTP response."""
-        exception = ValidationError("Invalid input", details={"field": "name"})
+        """Test validation error HTTP response returns safe message, keeps field-level details."""
+        exception = ValidationError(
+            "Internal field path: user.secret_token", details={"field": "name"}
+        )
 
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.INVALID_INPUT
         assert response.message == "Invalid input"
+        assert "Internal field path" not in response.message
         assert response.category == ErrorCategory.VALIDATION
         assert response.details == {"field": "name"}
         assert response.http_status == HTTPStatus.BAD_REQUEST
@@ -59,19 +64,22 @@ class TestHTTPErrorResponseHandler:
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.RESOURCE_NOT_FOUND
-        assert response.message == "TestEntity with ID '123' not found"
+        assert response.message == "Resource not found"
         assert response.category == ErrorCategory.NOT_FOUND
         assert response.details == {"entity_type": "TestEntity", "entity_id": "123"}
         assert response.http_status == HTTPStatus.NOT_FOUND
 
     def test_business_rule_violation_http(self, handler):
-        """Test business rule violation HTTP response."""
-        exception = BusinessRuleViolationError("Rule violated", details={"rule": "max_count"})
+        """Test business rule violation HTTP response returns safe message, keeps rule details."""
+        exception = BusinessRuleViolationError(
+            "Internal rule detail: db_query_exceeded_limit", details={"rule": "max_count"}
+        )
 
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.BUSINESS_RULE_VIOLATION
-        assert response.message == "Rule violated"
+        assert response.message == "Request could not be processed"
+        assert "Internal rule detail" not in response.message
         assert response.category == ErrorCategory.BUSINESS_RULE
         assert response.details == {"rule": "max_count"}
         assert response.http_status == HTTPStatus.UNPROCESSABLE_ENTITY
@@ -83,19 +91,22 @@ class TestHTTPErrorResponseHandler:
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.REQUEST_NOT_FOUND
-        assert response.message == "Request with ID 'req-123' not found"
+        assert response.message == "Request not found"
         assert response.category == ErrorCategory.NOT_FOUND
         assert response.details == {"entity_type": "Request", "entity_id": "req-123"}
         assert response.http_status == HTTPStatus.NOT_FOUND
 
     def test_request_validation_http(self, handler):
-        """Test request validation error HTTP response."""
-        exception = RequestValidationError("Invalid request", details={"field": "count"})
+        """Test request validation error HTTP response returns safe message, keeps field details."""
+        exception = RequestValidationError(
+            "Invalid request: count must be <= 500", details={"field": "count"}
+        )
 
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.INVALID_INPUT
-        assert response.message == "Invalid request"
+        assert response.message == "Invalid input"
+        assert "count must be" not in response.message
         assert response.category == ErrorCategory.VALIDATION
         assert response.details == {"field": "count"}
         assert response.http_status == HTTPStatus.BAD_REQUEST
@@ -107,19 +118,22 @@ class TestHTTPErrorResponseHandler:
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.MACHINE_NOT_FOUND
-        assert response.message == "Machine with ID 'm-123' not found"
+        assert response.message == "Machine not found"
         assert response.category == ErrorCategory.NOT_FOUND
         assert response.details == {"entity_type": "Machine", "entity_id": "m-123"}
         assert response.http_status == HTTPStatus.NOT_FOUND
 
     def test_machine_validation_http(self, handler):
-        """Test machine validation error HTTP response."""
-        exception = MachineValidationError("Invalid machine", details={"field": "type"})
+        """Test machine validation error HTTP response returns safe message, keeps field details."""
+        exception = MachineValidationError(
+            "Invalid machine: internal type code 0x3F", details={"field": "type"}
+        )
 
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.INVALID_INPUT
-        assert response.message == "Invalid machine"
+        assert response.message == "Invalid input"
+        assert "internal type code" not in response.message
         assert response.category == ErrorCategory.VALIDATION
         assert response.details == {"field": "type"}
         assert response.http_status == HTTPStatus.BAD_REQUEST
@@ -131,45 +145,55 @@ class TestHTTPErrorResponseHandler:
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.TEMPLATE_NOT_FOUND
-        assert response.message == "Template with ID 't-123' not found"
+        assert response.message == "Template not found"
         assert response.category == ErrorCategory.NOT_FOUND
         assert response.details == {"entity_type": "Template", "entity_id": "t-123"}
         assert response.http_status == HTTPStatus.NOT_FOUND
 
     def test_template_validation_http(self, handler):
-        """Test template validation error HTTP response."""
-        exception = TemplateValidationError("Invalid template", details={"field": "config"})
+        """Test template validation error HTTP response returns safe message, keeps field details."""
+        exception = TemplateValidationError(
+            "Invalid template: internal path /etc/templates/secret.yaml",
+            details={"field": "config"},
+        )
 
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.INVALID_INPUT
-        assert response.message == "Invalid template"
+        assert response.message == "Invalid input"
+        assert "internal path" not in response.message
         assert response.category == ErrorCategory.VALIDATION
         assert response.details == {"field": "config"}
         assert response.http_status == HTTPStatus.BAD_REQUEST
 
     def test_infrastructure_error_http(self, handler):
-        """Test infrastructure error HTTP response."""
-        exception = InfrastructureError("Database connection failed")
+        """Test infrastructure error HTTP response does not leak original_error to client."""
+        exception = InfrastructureError(
+            "Database connection failed: host=internal-db.corp port=5432"
+        )
 
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.EXTERNAL_SERVICE_ERROR
         assert response.message == "An infrastructure error occurred"
         assert response.category == ErrorCategory.INFRASTRUCTURE
-        assert response.details == {"original_error": "Database connection failed"}
+        assert "original_error" not in response.details
+        assert "internal-db.corp" not in str(response.details)
         assert response.http_status == HTTPStatus.SERVICE_UNAVAILABLE
 
     def test_configuration_error_http(self, handler):
-        """Test configuration error HTTP response."""
-        exception = ConfigurationError("Invalid config")
+        """Test configuration error HTTP response does not leak original_error to client."""
+        exception = ConfigurationError(
+            "Invalid config: secret_key=abc123 at path /etc/orb/config.yaml"
+        )
 
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.INTERNAL_ERROR
         assert response.message == "A configuration error occurred"
         assert response.category == ErrorCategory.INTERNAL
-        assert response.details == {"original_error": "Invalid config"}
+        assert "original_error" not in response.details
+        assert "secret_key" not in str(response.details)
         assert response.http_status == HTTPStatus.INTERNAL_SERVER_ERROR
 
     def test_unexpected_error_http(self, handler):
@@ -220,12 +244,134 @@ class TestHTTPErrorResponseHandler:
         assert response.http_status == HTTPStatus.BAD_REQUEST
 
     def test_exception_without_details(self, handler):
-        """Test exception without details attribute."""
-        exception = ValidationError("Simple validation error")
+        """Test exception without details attribute returns safe message with empty details."""
+        exception = ValidationError("Simple validation error: internal detail xyz")
 
         response = handler.handle_error_for_http(exception)
 
         assert response.error_code == ErrorCode.INVALID_INPUT
-        assert response.message == "Simple validation error"
+        assert response.message == "Invalid input"
+        assert "internal detail" not in response.message
         assert response.details == {}
         assert response.http_status == HTTPStatus.BAD_REQUEST
+
+    def test_infrastructure_error_does_not_leak_secret_to_client_but_logs_it(self, handler):
+        """Regression: InfrastructureError carrying a sensitive string must not surface it
+        in the HTTP response body or details, but it must be logged server-side."""
+        secret = "db_password=s3cr3t!@internal-host:5432/prod_db"
+        exception = InfrastructureError(f"Connection error: {secret}")
+
+        log_calls: list[tuple] = []
+
+        original_logger = handler._logger
+
+        mock_logger = MagicMock()
+        mock_logger.error.side_effect = lambda *args, **kwargs: log_calls.append(
+            ("error", args, kwargs)
+        )
+        handler._logger = mock_logger
+
+        try:
+            response = handler.handle_error_for_http(exception)
+        finally:
+            handler._logger = original_logger
+
+        # The secret must NOT appear anywhere in the HTTP response
+        assert secret not in response.message
+        assert secret not in str(response.details)
+        assert "original_error" not in response.details
+
+        # The secret MUST have been forwarded to the logger
+        assert len(log_calls) == 1
+        logged_args = log_calls[0][1]
+        assert any(secret in str(a) for a in logged_args)
+
+    def test_duplicate_error_does_not_leak_raw_message(self, handler):
+        """DuplicateError returns a generic safe message; raw detail stays out of response."""
+        exception = DuplicateError("Duplicate key: machine_id=m-secret-prod-123 in table machines")
+
+        response = handler.handle_error_for_http(exception)
+
+        assert response.message == "A duplicate resource already exists"
+        assert "m-secret-prod-123" not in response.message
+        assert "m-secret-prod-123" not in str(response.details)
+
+    # --- Regression tests ---
+
+    def test_not_found_message_does_not_contain_entity_id(self, handler):
+        """Regression (H3): NotFound response message must not echo the caller-supplied entity_id."""
+        exception = EntityNotFoundError("Machine", "m-secret-internal-42")
+
+        response = handler.handle_error_for_http(exception)
+
+        assert "m-secret-internal-42" not in response.message
+
+    def test_request_not_found_message_does_not_contain_entity_id(self, handler):
+        """Regression (H3): RequestNotFoundError message must not echo the request_id."""
+        exception = RequestNotFoundError("req-internal-007")
+
+        response = handler.handle_error_for_http(exception)
+
+        assert "req-internal-007" not in response.message
+
+    def test_machine_not_found_message_does_not_contain_entity_id(self, handler):
+        """Regression (H3): MachineNotFoundError message must not echo the machine_id."""
+        exception = MachineNotFoundError("m-internal-xyz")
+
+        response = handler.handle_error_for_http(exception)
+
+        assert "m-internal-xyz" not in response.message
+
+    def test_template_not_found_message_does_not_contain_entity_id(self, handler):
+        """Regression (H3): TemplateNotFoundError message must not echo the template_id."""
+        exception = TemplateNotFoundError("t-internal-abc")
+
+        response = handler.handle_error_for_http(exception)
+
+        assert "t-internal-abc" not in response.message
+
+    def test_details_with_original_error_are_stripped(self, handler):
+        """Regression (H3): details carrying original_error must not reach the response."""
+        secret = "host=secret-internal-db.corp:5432"
+        exception = ValidationError(
+            "Wrapped error",
+            details={
+                "original_error": secret,
+                "filename": "/etc/orb/config.yaml",
+                "errno": 13,
+                "missing_key": "db_password",
+                "field": "count",
+            },
+        )
+
+        response = handler.handle_error_for_http(exception)
+
+        assert secret not in str(response.details)
+        assert "original_error" not in response.details
+        assert "filename" not in response.details
+        assert "errno" not in response.details
+        assert "missing_key" not in response.details
+        # Safe field is preserved
+        assert response.details.get("field") == "count"
+
+    def test_unexpected_error_is_logged(self, handler):
+        """Regression (H3): _handle_unexpected_error_http must log server-side."""
+        exception = RuntimeError("disk full on /data/orb/prod")
+        logged: list[tuple] = []
+
+        original_logger = handler._logger
+        mock_logger = MagicMock()
+        mock_logger.error.side_effect = lambda *args, **kwargs: logged.append(("error", args))
+        handler._logger = mock_logger
+
+        try:
+            response = handler.handle_error_for_http(exception)
+        finally:
+            handler._logger = original_logger
+
+        # Client response must not contain the sensitive path
+        assert "disk full" not in response.message
+        assert "disk full" not in str(response.details)
+
+        # Server-side log must have been called
+        assert len(logged) >= 1, "Expected at least one logger.error call for unexpected errors"

--- a/tests/infrastructure/error/test_responses.py
+++ b/tests/infrastructure/error/test_responses.py
@@ -1,0 +1,136 @@
+"""
+Tests for InfrastructureErrorResponse and _exception_to_components.
+
+Verifies that sensitive data in exception messages and details never reaches
+the caller via from_exception or _exception_to_components.
+"""
+
+from orb.domain.base.exceptions import (
+    BusinessRuleViolationError,
+    ConfigurationError,
+    EntityNotFoundError,
+    InfrastructureError,
+    ValidationError,
+)
+from orb.infrastructure.error.responses import InfrastructureErrorResponse
+
+
+class TestInfrastructureErrorResponseFromException:
+    """Test InfrastructureErrorResponse.from_exception security properties."""
+
+    def test_infrastructure_error_does_not_leak_message(self):
+        """Regression (H3/HIGH): InfrastructureError message must not surface in response."""
+        exception = InfrastructureError("host=secret-db.corp port=5432 password=abc")
+
+        response = InfrastructureErrorResponse.from_exception(exception)
+
+        assert "secret-db.corp" not in response.message
+        assert "secret-db.corp" not in str(response.details)
+        assert response.message == "An infrastructure error occurred"
+
+    def test_configuration_error_does_not_leak_message(self):
+        """Regression (H3): ConfigurationError message must not surface in response."""
+        exception = ConfigurationError("secret_key=abc123 at /etc/orb/prod.yaml")
+
+        response = InfrastructureErrorResponse.from_exception(exception)
+
+        assert "secret_key" not in response.message
+        assert "abc123" not in response.message
+        assert "secret_key" not in str(response.details)
+        assert response.message == "A configuration error occurred"
+
+    def test_validation_error_does_not_leak_message(self):
+        """Regression (H3): ValidationError message must not surface in response."""
+        exception = ValidationError("field=internal_token must match pattern .*secret.*")
+
+        response = InfrastructureErrorResponse.from_exception(exception)
+
+        assert "internal_token" not in response.message
+        assert response.message == "Invalid input"
+
+    def test_entity_not_found_does_not_leak_message(self):
+        """Regression (H3): EntityNotFoundError message must not surface in response."""
+        exception = EntityNotFoundError("Machine", "m-secret-internal")
+
+        response = InfrastructureErrorResponse.from_exception(exception)
+
+        assert "m-secret-internal" not in response.message
+        assert response.message == "Resource not found"
+
+    def test_business_rule_violation_does_not_leak_message(self):
+        """Regression (H3): BusinessRuleViolationError message must not surface."""
+        exception = BusinessRuleViolationError("db_limit=500 exceeded for tenant=internal-acct")
+
+        response = InfrastructureErrorResponse.from_exception(exception)
+
+        assert "internal-acct" not in response.message
+        assert response.message == "Request could not be processed"
+
+    def test_infrastructure_error_details_are_empty(self):
+        """Regression (H3): InfrastructureError details must be empty on the response."""
+        exception = InfrastructureError(
+            "conn failed",
+            details={"original_error": "host=secret-db.corp:5432", "errno": 111},
+        )
+
+        response = InfrastructureErrorResponse.from_exception(exception)
+
+        assert response.details == {}
+
+    def test_configuration_error_details_are_empty(self):
+        """Regression (H3): ConfigurationError details must be empty on the response."""
+        exception = ConfigurationError(
+            "bad config",
+            details={
+                "original_error": "key=db_password value=s3cr3t",
+                "filename": "/etc/orb/config.yaml",
+            },
+        )
+
+        response = InfrastructureErrorResponse.from_exception(exception)
+
+        assert response.details == {}
+
+    def test_validation_error_strips_unsafe_detail_keys(self):
+        """Regression (H3): ValidationError details with unsafe keys must be filtered."""
+        exception = ValidationError(
+            "validation failed",
+            details={
+                "original_error": "host=secret.corp",
+                "missing_key": "db_password",
+                "field": "count",
+                "field_name": "max_count",
+            },
+        )
+
+        response = InfrastructureErrorResponse.from_exception(exception)
+
+        assert "original_error" not in response.details
+        assert "missing_key" not in response.details
+        assert response.details.get("field") == "count"
+        assert response.details.get("field_name") == "max_count"
+
+    def test_context_parameter_not_forwarded_to_caller(self):
+        """Regression (H3): from_exception context kwarg must not appear in response details."""
+        exception = InfrastructureError("some infra failure")
+
+        response = InfrastructureErrorResponse.from_exception(
+            exception, context="internal-handler-v2"
+        )
+
+        assert "context" not in response.details
+        assert "internal-handler-v2" not in str(response.details)
+        assert "internal-handler-v2" not in response.message
+
+    def test_unexpected_exception_returns_safe_message(self):
+        """Regression: generic Exception must yield safe categorical message."""
+        exception = RuntimeError("disk full at /data/orb/prod-primary")
+
+        response = InfrastructureErrorResponse.from_exception(exception)
+
+        assert "disk full" not in response.message
+        assert "/data/orb/prod-primary" not in response.message
+        assert response.message == "An unexpected error occurred"
+        # Only exception type name is exposed, not message content
+        assert response.details.get("exception_type") == "RuntimeError"
+        assert "disk full" not in str(response.details)

--- a/tests/providers/aws/unit/test_cognito_strategy.py
+++ b/tests/providers/aws/unit/test_cognito_strategy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from base64 import urlsafe_b64encode
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -32,7 +32,7 @@ def _make_logger() -> MagicMock:
     return logger
 
 
-def _make_strategy(enabled: bool = True) -> Any:
+def _make_strategy(enabled: bool = True, token_denylist=None) -> Any:
     from orb.providers.aws.auth.cognito_strategy import CognitoAuthStrategy
 
     logger = _make_logger()
@@ -48,9 +48,41 @@ def _make_strategy(enabled: bool = True) -> Any:
             client_id="abc123",
             region="us-east-1",
             enabled=enabled,
+            token_denylist=token_denylist,
         )
 
     return strategy
+
+
+def _make_mock_denylist(is_denylisted: bool = False, add_token_returns: bool = True):
+    """Build an AsyncMock that satisfies the TokenDenylistPort interface."""
+    denylist = MagicMock()
+    denylist.is_denylisted = AsyncMock(return_value=is_denylisted)
+    denylist.add_token = AsyncMock(return_value=add_token_returns)
+    return denylist
+
+
+def _make_fake_jwt_token(token_use: str = "access", exp_offset: int = 3600) -> str:
+    """Build a syntactically valid (three-part) fake JWT with the given payload fields.
+
+    The token is NOT cryptographically signed — it is used only to test code paths
+    that read the unsigned payload (revoke_token, structural check).
+    """
+    import base64
+    import json
+
+    header = base64.urlsafe_b64encode(b'{"alg":"RS256","typ":"JWT"}').rstrip(b"=").decode()
+    now = int(time.time())
+    payload_data = {
+        "sub": "user-123",
+        "token_use": token_use,
+        "exp": now + exp_offset,
+        "iss": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_EXAMPLE",
+        "aud": "abc123",
+    }
+    payload = base64.urlsafe_b64encode(json.dumps(payload_data).encode()).rstrip(b"=").decode()
+    sig = "fakesignatureAABBCC"
+    return f"{header}.{payload}.{sig}"
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +132,7 @@ async def test_cognito_validate_token_expired():
     import jwt as pyjwt
 
     strategy = _make_strategy()
+    token = _make_fake_jwt_token()
 
     with patch.object(strategy, "_get_public_key", return_value="fake_key"):
         with patch("orb.providers.aws.auth.cognito_strategy.jwt.decode") as mock_decode:
@@ -109,7 +142,7 @@ async def test_cognito_validate_token_expired():
                 "orb.providers.aws.auth.cognito_strategy.jwt.get_unverified_header",
                 return_value={"kid": "test-kid"},
             ):
-                result = await strategy.validate_token("expired.token.here")
+                result = await strategy.validate_token(token)
 
     assert result.status == AuthStatus.EXPIRED
 
@@ -125,14 +158,110 @@ async def test_cognito_validate_token_missing_kid():
     """validate_token returns INVALID when token header has no kid."""
 
     strategy = _make_strategy()
+    token = _make_fake_jwt_token()
 
     with patch(
         "orb.providers.aws.auth.cognito_strategy.jwt.get_unverified_header",
         return_value={},  # no "kid"
     ):
-        result = await strategy.validate_token("some.token.here")
+        result = await strategy.validate_token(token)
 
     assert result.status == AuthStatus.INVALID
+
+
+# ---------------------------------------------------------------------------
+# validate_token() — structural check rejects garbage tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_validate_token_rejects_garbage():
+    """validate_token returns INVALID for strings that are not JWT-shaped."""
+    strategy = _make_strategy()
+
+    for bad_token in ("", "notaJWT", "two.parts", "x" * 9000):
+        result = await strategy.validate_token(bad_token)
+        assert result.status == AuthStatus.INVALID, f"expected INVALID for {bad_token!r}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_validate_token_structural_check_accepts_real_shape():
+    """validate_token does NOT reject a properly shaped token at the structural gate."""
+    strategy = _make_strategy()
+    token = _make_fake_jwt_token()
+
+    # The structural regex should pass; subsequent failure is expected (bad sig / key),
+    # but the error must NOT be "Invalid token format".
+    with patch(
+        "orb.providers.aws.auth.cognito_strategy.jwt.get_unverified_header",
+        return_value={},  # triggers "Token missing key ID", not structural failure
+    ):
+        result = await strategy.validate_token(token)
+
+    assert result.error_message != "Invalid token format"
+
+
+# ---------------------------------------------------------------------------
+# validate_token() — denylist check rejects revoked tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_validate_token_rejects_denylisted_token():
+    """validate_token returns INVALID when the token is on the denylist."""
+    denylist = _make_mock_denylist(is_denylisted=True)
+    strategy = _make_strategy(token_denylist=denylist)
+    token = _make_fake_jwt_token()
+
+    result = await strategy.validate_token(token)
+
+    assert result.status == AuthStatus.INVALID
+    assert "revoked" in (result.error_message or "").lower()
+    denylist.is_denylisted.assert_called_once_with(token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_validate_token_revoked_warning_does_not_leak_token():
+    """The warning log for a revoked token must not contain the full token value."""
+    denylist = _make_mock_denylist(is_denylisted=True)
+    strategy = _make_strategy(token_denylist=denylist)
+    token = _make_fake_jwt_token()
+
+    await strategy.validate_token(token)
+
+    # Collect all warning calls and confirm the raw token is absent.
+    for call_args in strategy._logger.warning.call_args_list:
+        args, kwargs = call_args
+        rendered = " ".join(str(a) for a in args)
+        assert token not in rendered, "Full token leaked in warning log"
+
+
+# ---------------------------------------------------------------------------
+# validate_token() — error_message must not contain the raw token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_validate_token_error_message_no_raw_token():
+    """validate_token error messages must never echo back the raw token."""
+    import jwt as pyjwt
+
+    strategy = _make_strategy()
+    token = _make_fake_jwt_token()
+
+    # Force InvalidTokenError to exercise the except branch
+    with patch(
+        "orb.providers.aws.auth.cognito_strategy.jwt.get_unverified_header",
+        side_effect=pyjwt.InvalidTokenError("bad"),
+    ):
+        result = await strategy.validate_token(token)
+
+    assert token not in (result.error_message or ""), "Raw token leaked in error_message"
 
 
 # ---------------------------------------------------------------------------
@@ -170,13 +299,249 @@ def test_cognito_from_auth_config_defaults():
 
     with patch("boto3.client") as _mock:
         _mock.return_value = MagicMock()
-        from orb.providers.aws.auth.cognito_strategy import CognitoAuthStrategy
+        # get_container is a local import inside from_auth_config; patch at source.
+        with patch(
+            "orb.infrastructure.di.container.get_container",
+            side_effect=Exception("no container"),
+        ):
+            from orb.providers.aws.auth.cognito_strategy import CognitoAuthStrategy
 
-        strategy = CognitoAuthStrategy.from_auth_config(auth_config)
+            strategy = CognitoAuthStrategy.from_auth_config(auth_config)
 
     assert strategy.region == "us-east-1"
     assert strategy.user_pool_id == ""
     assert strategy.client_id == ""
+
+
+@pytest.mark.unit
+def test_cognito_from_auth_config_produces_non_none_denylist():
+    """from_auth_config must always produce an instance with a non-None denylist.
+
+    This test would FAIL on the pre-fix code where from_auth_config never
+    injected token_denylist (leaving it as None on every live instance).
+    """
+    from orb.config.schemas.server_schema import AuthConfig
+    from orb.infrastructure.auth.token_denylist import TokenDenylistPort
+
+    auth_config = AuthConfig(strategy="cognito")  # type: ignore[call-arg]
+
+    with patch("boto3.client") as _mock:
+        _mock.return_value = MagicMock()
+        # Let the container resolution fail so the InMemoryTokenDenylist fallback fires.
+        with patch(
+            "orb.infrastructure.di.container.get_container",
+            side_effect=Exception("no container"),
+        ):
+            from orb.providers.aws.auth.cognito_strategy import CognitoAuthStrategy
+
+            strategy = CognitoAuthStrategy.from_auth_config(auth_config)
+
+    assert strategy._token_denylist is not None
+    assert isinstance(strategy._token_denylist, TokenDenylistPort)
+
+
+@pytest.mark.unit
+def test_cognito_from_auth_config_uses_container_denylist_when_available():
+    """from_auth_config resolves TokenDenylistPort from the DI container when present."""
+    from orb.config.schemas.server_schema import AuthConfig
+    from orb.infrastructure.auth.token_denylist import TokenDenylistPort
+
+    auth_config = AuthConfig(strategy="cognito")  # type: ignore[call-arg]
+
+    mock_denylist = _make_mock_denylist()
+    mock_container = MagicMock()
+    mock_container.get = MagicMock(
+        side_effect=lambda cls: mock_denylist if cls is TokenDenylistPort else MagicMock()
+    )
+
+    with patch("boto3.client") as _mock:
+        _mock.return_value = MagicMock()
+        # get_container is a local import; patch at source.
+        with patch(
+            "orb.infrastructure.di.container.get_container",
+            return_value=mock_container,
+        ):
+            from orb.providers.aws.auth.cognito_strategy import CognitoAuthStrategy
+
+            strategy = CognitoAuthStrategy.from_auth_config(auth_config)
+
+    assert strategy._token_denylist is mock_denylist
+
+
+# ---------------------------------------------------------------------------
+# revoke_token() — zero-test gap filled (H4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_revoke_refresh_token_calls_cognito_api():
+    """revoke_token calls cognito_client.revoke_token for a refresh token.
+
+    This test FAILS on the pre-fix code where a refresh token would skip
+    denylist insertion and only call RevokeToken — the mock denylist would
+    show zero calls.
+    """
+    denylist = _make_mock_denylist()
+    strategy = _make_strategy(token_denylist=denylist)
+    strategy.cognito_client = MagicMock()
+    strategy.cognito_client.revoke_token = MagicMock(return_value={})
+
+    token = _make_fake_jwt_token(token_use="refresh")
+
+    with patch(
+        "orb.providers.aws.auth.cognito_strategy.asyncio.to_thread",
+        new=AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+    ):
+        result = await strategy.revoke_token(token)
+
+    assert result is True
+    strategy.cognito_client.revoke_token.assert_called_once_with(
+        Token=token,
+        ClientId=strategy.client_id,
+    )
+    # Denylist insertion must also have happened (H6 fix).
+    denylist.add_token.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_revoke_access_token_adds_to_denylist():
+    """revoke_token adds an access token to the denylist and does NOT call Cognito API.
+
+    This test FAILS on the pre-fix code if _token_denylist is None (the live
+    behaviour before this fix), since add_token would never be called.
+    """
+    denylist = _make_mock_denylist()
+    strategy = _make_strategy(token_denylist=denylist)
+    strategy.cognito_client = MagicMock()
+
+    token = _make_fake_jwt_token(token_use="access")
+    result = await strategy.revoke_token(token)
+
+    assert result is True
+    denylist.add_token.assert_called_once()
+    # RevokeToken must NOT be called for access tokens.
+    strategy.cognito_client.revoke_token.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_revoke_token_returns_false_without_denylist():
+    """revoke_token returns False when no denylist is configured.
+
+    Before the fix this returned True even though nothing was revoked.
+    This test FAILS on the pre-fix code.
+    """
+    strategy = _make_strategy(token_denylist=None)
+    token = _make_fake_jwt_token(token_use="access")
+
+    result = await strategy.revoke_token(token)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_revoke_refresh_token_without_denylist_returns_false():
+    """revoke_token returns False for a refresh token when no denylist is available.
+
+    On the pre-fix code a refresh token would skip denylist and call RevokeToken,
+    returning True — even though the local denylist was never populated and the
+    token could be re-used against any route that doesn't call Cognito.
+    """
+    strategy = _make_strategy(token_denylist=None)
+    token = _make_fake_jwt_token(token_use="refresh")
+
+    result = await strategy.revoke_token(token)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_revoke_token_forged_token_use_still_denylists():
+    """A token with forged token_use='refresh' is still added to the denylist (H6).
+
+    An attacker could craft a valid access JWT with token_use='refresh' in the
+    UNSIGNED payload to steer the pre-fix code into the Cognito RevokeToken path
+    (which would fail with an error for an access token) and thereby avoid being
+    denylisted.
+
+    After the fix, denylist insertion happens FIRST for ALL tokens regardless of
+    the unsigned token_use claim.  This test verifies that even if token_use
+    claims 'refresh', the denylist is still populated.
+    """
+    denylist = _make_mock_denylist()
+    strategy = _make_strategy(token_denylist=denylist)
+    # Simulate a Cognito client that raises on revoke_token (access token presented
+    # as refresh — Cognito rejects it).
+    mock_client = MagicMock()
+    from botocore.exceptions import ClientError
+
+    mock_client.revoke_token.side_effect = ClientError(
+        {"Error": {"Code": "InvalidParameterException", "Message": "Not a refresh token"}},
+        "RevokeToken",
+    )
+    strategy.cognito_client = mock_client
+
+    # Build a token whose unsigned payload claims token_use="refresh"
+    token = _make_fake_jwt_token(token_use="refresh")
+
+    with patch(
+        "orb.providers.aws.auth.cognito_strategy.asyncio.to_thread",
+        new=AsyncMock(side_effect=lambda fn, **kw: fn(**kw)),
+    ):
+        result = await strategy.revoke_token(token)
+
+    # The Cognito API step failed, so result is False — but denylist MUST have been
+    # populated before the API call was attempted.
+    denylist.add_token.assert_called_once()
+    assert result is False  # API step failed → False, but denylist is populated
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_revoke_token_denylist_failure_returns_false():
+    """revoke_token returns False when the denylist add_token call fails."""
+    denylist = _make_mock_denylist(add_token_returns=False)
+    strategy = _make_strategy(token_denylist=denylist)
+    token = _make_fake_jwt_token(token_use="access")
+
+    result = await strategy.revoke_token(token)
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# validate_token() — denylisted token is rejected after revoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cognito_validate_token_rejects_after_revoke():
+    """validate_token rejects a token that was previously revoked (end-to-end denylist check).
+
+    This test uses a real InMemoryTokenDenylist to confirm the full round-trip:
+    revoke_token adds to denylist → validate_token reads denylist → INVALID.
+    """
+    from orb.infrastructure.auth.token_denylist import InMemoryTokenDenylist
+
+    denylist = InMemoryTokenDenylist()
+    strategy = _make_strategy(token_denylist=denylist)
+    strategy.cognito_client = MagicMock()
+
+    token = _make_fake_jwt_token(token_use="access")
+
+    # Step 1: revoke
+    revoked = await strategy.revoke_token(token)
+    assert revoked is True
+
+    # Step 2: validate should now reject
+    result = await strategy.validate_token(token)
+    assert result.status == AuthStatus.INVALID
+    assert "revoked" in (result.error_message or "").lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/providers/aws/unit/test_iam_strategy.py
+++ b/tests/providers/aws/unit/test_iam_strategy.py
@@ -30,6 +30,29 @@ def _make_logger() -> MagicMock:
     return logger
 
 
+def _make_paginator_mock(pages: list[list[tuple[str, str]]]) -> MagicMock:
+    """Build a mock paginator that yields the given pages of (action, decision) tuples.
+
+    Args:
+        pages: Each item is a list of (action_name, eval_decision) tuples for one page.
+
+    Returns:
+        MagicMock configured so ``paginator.paginate(...)`` iterates over the pages.
+    """
+    paginator = MagicMock()
+    built_pages = [
+        {
+            "EvaluationResults": [
+                {"EvalActionName": action, "EvalDecision": decision}
+                for action, decision in page_entries
+            ]
+        }
+        for page_entries in pages
+    ]
+    paginator.paginate.return_value = iter(built_pages)
+    return paginator
+
+
 def _make_strategy(assume_permissions: bool = True) -> Any:
     """Build IAMAuthStrategy with mocked AWS clients."""
     from orb.providers.aws.auth.iam_strategy import IAMAuthStrategy
@@ -118,20 +141,155 @@ async def test_iam_authenticate_no_credentials():
 
 
 # ---------------------------------------------------------------------------
-# _check_permissions — assume_permissions=False → deny
+# _check_permissions — real SimulatePrincipalPolicy evaluation (via paginator)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_iam_check_permissions_deny_without_assume():
-    """_check_permissions returns empty list when assume_permissions is False."""
+async def test_iam_check_permissions_allowed_action_is_granted():
+    """_check_permissions returns the action when SimulatePrincipalPolicy says allowed."""
     strategy = _make_strategy(assume_permissions=False)
     strategy._assume_permissions = False
+    strategy.required_actions = ["ec2:DescribeInstances"]
+
+    paginator = _make_paginator_mock([[("ec2:DescribeInstances", "allowed")]])
+    strategy.iam_client.get_paginator.return_value = paginator
+
+    permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
+
+    assert "ec2:DescribeInstances" in permissions
+    strategy.iam_client.get_paginator.assert_called_once_with("simulate_principal_policy")
+    paginator.paginate.assert_called_once_with(
+        PolicySourceArn="arn:aws:iam::123:user/u",
+        ActionNames=["ec2:DescribeInstances"],
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_explicit_deny_not_granted():
+    """_check_permissions excludes actions with explicitDeny decision."""
+    strategy = _make_strategy(assume_permissions=False)
+    strategy._assume_permissions = False
+    strategy.required_actions = ["ec2:TerminateInstances"]
+
+    paginator = _make_paginator_mock([[("ec2:TerminateInstances", "explicitDeny")]])
+    strategy.iam_client.get_paginator.return_value = paginator
 
     permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
 
     assert permissions == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_implicit_deny_not_granted():
+    """_check_permissions excludes actions with implicitDeny decision."""
+    strategy = _make_strategy(assume_permissions=False)
+    strategy._assume_permissions = False
+    strategy.required_actions = ["ec2:RunInstances"]
+
+    paginator = _make_paginator_mock([[("ec2:RunInstances", "implicitDeny")]])
+    strategy.iam_client.get_paginator.return_value = paginator
+
+    permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
+
+    assert permissions == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_mixed_decisions():
+    """_check_permissions returns only the allowed subset from a mixed response."""
+    strategy = _make_strategy(assume_permissions=False)
+    strategy._assume_permissions = False
+    strategy.required_actions = [
+        "ec2:DescribeInstances",
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+    ]
+
+    paginator = _make_paginator_mock(
+        [
+            [
+                ("ec2:DescribeInstances", "allowed"),
+                ("ec2:RunInstances", "implicitDeny"),
+                ("ec2:TerminateInstances", "explicitDeny"),
+            ]
+        ]
+    )
+    strategy.iam_client.get_paginator.return_value = paginator
+
+    permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
+
+    assert permissions == ["ec2:DescribeInstances"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_api_error_denies_all():
+    """_check_permissions returns [] (fail secure) when SimulatePrincipalPolicy raises ClientError."""
+    from botocore.exceptions import ClientError
+
+    strategy = _make_strategy(assume_permissions=False)
+    strategy._assume_permissions = False
+    strategy.required_actions = ["ec2:DescribeInstances"]
+
+    error_response = {"Error": {"Code": "AccessDenied", "Message": "Not authorized"}}
+    paginator = MagicMock()
+    paginator.paginate.side_effect = ClientError(error_response, "SimulatePrincipalPolicy")
+    strategy.iam_client.get_paginator.return_value = paginator
+
+    permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
+
+    assert permissions == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_unexpected_error_denies_all():
+    """_check_permissions returns [] (fail secure) on any unexpected exception."""
+    strategy = _make_strategy(assume_permissions=False)
+    strategy._assume_permissions = False
+    strategy.required_actions = ["ec2:DescribeInstances"]
+
+    paginator = MagicMock()
+    paginator.paginate.side_effect = RuntimeError("network timeout")
+    strategy.iam_client.get_paginator.return_value = paginator
+
+    permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
+
+    assert permissions == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_empty_arn_denies_all():
+    """_check_permissions returns [] when caller ARN is missing from identity."""
+    strategy = _make_strategy(assume_permissions=False)
+    strategy._assume_permissions = False
+
+    permissions = await strategy._check_permissions({})
+
+    assert permissions == []
+    strategy.iam_client.get_paginator.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_assume_permissions_dev_flag_bypasses_simulation(monkeypatch):
+    """assume_permissions dev-flag returns all required_actions without calling simulate."""
+    monkeypatch.setenv("ORB_IAM_ASSUME_PERMISSIONS_DEV_ONLY", "true")
+
+    strategy = _make_strategy(assume_permissions=True)
+    assert strategy._assume_permissions is True
+
+    permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
+
+    strategy.iam_client.get_paginator.assert_not_called()
+    assert "ec2:DescribeInstances" in permissions
+    assert "hostfactory:list_templates" in permissions
 
 
 # ---------------------------------------------------------------------------
@@ -283,3 +441,205 @@ def test_iam_assume_permissions_with_env_var_is_active(monkeypatch):
         )
 
     assert strategy._assume_permissions is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: ThrottlingException → deny-all (H1/H2 error path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_throttling_exception_denies_all():
+    """ThrottlingException from SimulatePrincipalPolicy must deny all permissions (fail secure)."""
+    from botocore.exceptions import ClientError
+
+    strategy = _make_strategy(assume_permissions=False)
+    strategy._assume_permissions = False
+    strategy.required_actions = ["ec2:DescribeInstances"]
+
+    error_response = {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}}
+    paginator = MagicMock()
+    paginator.paginate.side_effect = ClientError(error_response, "SimulatePrincipalPolicy")
+    strategy.iam_client.get_paginator.return_value = paginator
+
+    permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
+
+    assert permissions == [], "ThrottlingException must deny all — never grant on error"
+
+
+# ---------------------------------------------------------------------------
+# Regression: >100 actions paginated across two pages (H2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_paginated_results_fully_consumed():
+    """All EvaluationResults pages are consumed — page-2 allowed actions are included."""
+    strategy = _make_strategy(assume_permissions=False)
+    strategy._assume_permissions = False
+
+    # Simulate 101 required actions split across two pages: 100 on page 1, 1 on page 2.
+    page1_actions = [f"ec2:Action{i}" for i in range(100)]
+    page2_actions = ["ec2:ActionPage2"]
+    strategy.required_actions = page1_actions + page2_actions
+
+    # Page 1: all denied except Action0 and Action99.
+    page1_entries: list[tuple[str, str]] = [
+        (f"ec2:Action{i}", "allowed" if i in (0, 99) else "implicitDeny") for i in range(100)
+    ]
+    # Page 2: the sole action is allowed.
+    page2_entries: list[tuple[str, str]] = [("ec2:ActionPage2", "allowed")]
+
+    paginator = _make_paginator_mock([page1_entries, page2_entries])
+    strategy.iam_client.get_paginator.return_value = paginator
+
+    permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
+
+    assert "ec2:Action0" in permissions
+    assert "ec2:Action99" in permissions
+    assert "ec2:ActionPage2" in permissions, "Page-2 allowed result must be included"
+    # Denied actions must not appear.
+    assert "ec2:Action1" not in permissions
+    assert "ec2:Action50" not in permissions
+    # Paginator must have been iterated (paginate called once, yielding 2 pages).
+    paginator.paginate.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Regression: boto3 calls go through asyncio.to_thread (H1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_get_caller_identity_uses_to_thread(monkeypatch):
+    """_get_caller_identity must delegate the sync boto3 call via asyncio.to_thread."""
+    import asyncio as _asyncio
+
+    strategy = _make_strategy(assume_permissions=False)
+    strategy.sts_client.get_caller_identity.return_value = {
+        "UserId": "AIDATEST",
+        "Account": "111122223333",
+        "Arn": "arn:aws:iam::111122223333:user/tester",
+    }
+
+    to_thread_calls: list[Any] = []
+    original_to_thread = _asyncio.to_thread
+
+    async def _spy_to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]
+        to_thread_calls.append(func)
+        return await original_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(_asyncio, "to_thread", _spy_to_thread)
+
+    identity = await strategy._get_caller_identity()
+
+    assert identity is not None
+    assert any(
+        getattr(fn, "__self__", None) is strategy.sts_client
+        or fn is strategy.sts_client.get_caller_identity
+        for fn in to_thread_calls
+    ), "get_caller_identity should have been called via asyncio.to_thread"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_uses_to_thread(monkeypatch):
+    """_check_permissions must delegate the paginator iteration via asyncio.to_thread."""
+    import asyncio as _asyncio
+
+    strategy = _make_strategy(assume_permissions=False)
+    strategy._assume_permissions = False
+    strategy.required_actions = ["ec2:DescribeInstances"]
+
+    paginator = _make_paginator_mock([[("ec2:DescribeInstances", "allowed")]])
+    strategy.iam_client.get_paginator.return_value = paginator
+
+    to_thread_called = False
+    original_to_thread = _asyncio.to_thread
+
+    async def _spy_to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal to_thread_called
+        to_thread_called = True
+        return await original_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(_asyncio, "to_thread", _spy_to_thread)
+
+    permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
+
+    assert "ec2:DescribeInstances" in permissions
+    assert to_thread_called, "_check_permissions must call asyncio.to_thread for the paginator"
+
+
+# ---------------------------------------------------------------------------
+# Regression: required_actions=[] is honoured as empty (LOW)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_iam_required_actions_empty_list_is_honoured(monkeypatch):
+    """required_actions=[] must be kept as-is — not replaced by the EC2 defaults."""
+    monkeypatch.delenv("ORB_IAM_ASSUME_PERMISSIONS_DEV_ONLY", raising=False)
+
+    from orb.providers.aws.auth.iam_strategy import IAMAuthStrategy
+
+    logger = _make_logger()
+
+    with patch("orb.providers.aws.auth.iam_strategy.AWSSessionFactory") as mock_factory:
+        mock_session = MagicMock()
+        mock_session.client.return_value = MagicMock()
+        mock_factory.create_session.return_value = mock_session
+
+        strategy = IAMAuthStrategy(
+            logger=logger,
+            region="us-east-1",
+            required_actions=[],
+        )
+
+    assert strategy.required_actions == [], (
+        "required_actions=[] must be honoured as empty, not silently replaced by EC2 defaults"
+    )
+
+
+@pytest.mark.unit
+def test_iam_required_actions_none_applies_defaults(monkeypatch):
+    """required_actions=None (not provided) must apply the hardcoded EC2 defaults."""
+    monkeypatch.delenv("ORB_IAM_ASSUME_PERMISSIONS_DEV_ONLY", raising=False)
+
+    from orb.providers.aws.auth.iam_strategy import IAMAuthStrategy
+
+    logger = _make_logger()
+
+    with patch("orb.providers.aws.auth.iam_strategy.AWSSessionFactory") as mock_factory:
+        mock_session = MagicMock()
+        mock_session.client.return_value = MagicMock()
+        mock_factory.create_session.return_value = mock_session
+
+        strategy = IAMAuthStrategy(
+            logger=logger,
+            region="us-east-1",
+            required_actions=None,
+        )
+
+    assert "ec2:DescribeInstances" in strategy.required_actions
+    assert "ec2:RunInstances" in strategy.required_actions
+    assert "ec2:TerminateInstances" in strategy.required_actions
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_iam_check_permissions_empty_required_actions_returns_empty_granted():
+    """When required_actions=[], _check_permissions returns [] (nothing to grant)."""
+    strategy = _make_strategy(assume_permissions=False)
+    strategy._assume_permissions = False
+    strategy.required_actions = []
+
+    # Paginator returns no results since there are no actions to check.
+    paginator = _make_paginator_mock([[]])
+    strategy.iam_client.get_paginator.return_value = paginator
+
+    permissions = await strategy._check_permissions({"Arn": "arn:aws:iam::123:user/u"})
+
+    assert permissions == []

--- a/tests/unit/api/test_admin_router.py
+++ b/tests/unit/api/test_admin_router.py
@@ -660,3 +660,163 @@ class TestAdminExecutorOffload:
 
         assert ping_r.status_code == 200, "concurrent GET stalled while wipe was running"
         assert wipe_r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Security: information-leak regression tests for cleanup and reload
+# ---------------------------------------------------------------------------
+
+
+def _cleanup_post(client: TestClient, body: dict | None = None):
+    if body is None:
+        body = {"confirm": "CLEANUP", "request_statuses": ["cancelled"]}
+    return client.post("/admin/database/cleanup", json=body)
+
+
+def _reload_post(client: TestClient):
+    return client.post("/admin/reload-config")
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestCleanupInvalidStatusNoInfoLeak:
+    """InvalidCleanupStatusError text must not appear in the 400 response body
+    but must be visible in the server WARNING log."""
+
+    def test_invalid_status_error_message_not_in_response_body(self, admin_app, caplog):
+        """Raw InvalidCleanupStatusError text must not be returned to the client."""
+        import logging
+
+        from orb.application.services.admin.cleanup_database import InvalidCleanupStatusError
+
+        config_port = _make_config_port(allow_destructive=True, environment="development")
+        machine_repo, request_repo, template_repo = _make_repositories()
+        container = _make_container(config_port, machine_repo, request_repo, template_repo)
+
+        # Inject a recognisable secret into the error message.
+        secret = "valid-statuses-are-secret-enum-abc123"
+        with _patch_ctx(container):
+            with patch(
+                "orb.api.routers.admin.CleanupDatabaseService.bulk_cleanup",
+                side_effect=InvalidCleanupStatusError(secret),
+            ):
+                with caplog.at_level(logging.WARNING, logger="orb.api.routers.admin"):
+                    client = TestClient(admin_app, raise_server_exceptions=False)
+                    r = _cleanup_post(client)
+
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "INVALID_STATUS"
+        assert secret not in r.text, (
+            f"InvalidCleanupStatusError detail leaked: {secret!r} found in {r.text!r}"
+        )
+        warning_messages = [rec.message for rec in caplog.records if rec.levelno >= logging.WARNING]
+        assert any(secret in m for m in warning_messages), (
+            f"Expected {secret!r} in server WARNING log, got: {warning_messages}"
+        )
+
+    def test_invalid_status_error_code_unchanged(self, admin_app):
+        """HTTP status code and error code must not change after the fix."""
+        from orb.application.services.admin.cleanup_database import InvalidCleanupStatusError
+
+        config_port = _make_config_port(allow_destructive=True, environment="development")
+        machine_repo, request_repo, template_repo = _make_repositories()
+        container = _make_container(config_port, machine_repo, request_repo, template_repo)
+
+        with _patch_ctx(container):
+            with patch(
+                "orb.api.routers.admin.CleanupDatabaseService.bulk_cleanup",
+                side_effect=InvalidCleanupStatusError("any detail"),
+            ):
+                client = TestClient(admin_app, raise_server_exceptions=False)
+                r = _cleanup_post(client)
+
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "INVALID_STATUS"
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestReloadConfigNoInfoLeak:
+    """Broad Exception during config reload must not expose internal text in the
+    500 response body, but must be visible in the server ERROR log."""
+
+    def _make_failing_container(
+        self, config_port, machine_repo, request_repo, template_repo, secret
+    ):
+        """Return a DI container whose ConfigurationManager.reload() raises with *secret*."""
+        from orb.domain.base import UnitOfWorkFactory
+        from orb.domain.base.ports.configuration_port import ConfigurationPort
+        from orb.domain.machine.repository import MachineRepository
+        from orb.domain.request.repository import RequestRepository
+        from orb.domain.template.repository import TemplateRepository
+
+        uow = MagicMock()
+        uow.machines = machine_repo
+        uow.requests = request_repo
+        uow.templates = template_repo
+        uow.__enter__ = MagicMock(return_value=uow)
+        uow.__exit__ = MagicMock(return_value=False)
+        uow_factory = MagicMock()
+        uow_factory.create_unit_of_work = MagicMock(return_value=uow)
+
+        # A ConfigurationManager mock whose reload() raises with the secret.
+        cm_mock = MagicMock()
+        cm_mock.reload.side_effect = Exception(secret)
+
+        # Import lazily to match what the router does at call time.
+        from orb.config.managers.configuration_manager import ConfigurationManager
+
+        type_map = {
+            ConfigurationPort: config_port,
+            MachineRepository: machine_repo,
+            RequestRepository: request_repo,
+            TemplateRepository: template_repo,
+            UnitOfWorkFactory: uow_factory,
+            ConfigurationManager: cm_mock,
+        }
+        container = MagicMock()
+        container.get.side_effect = lambda t: type_map[t]
+        return container
+
+    def test_reload_exception_message_not_in_response_body(self, admin_app, caplog):
+        """Raw exception text must not be returned to the client on reload failure."""
+        import logging
+
+        config_port = _make_config_port(allow_destructive=True, environment="development")
+        machine_repo, request_repo, template_repo = _make_repositories()
+
+        secret = "config-file-path-secret-/etc/orb/secret.json"
+        container = self._make_failing_container(
+            config_port, machine_repo, request_repo, template_repo, secret
+        )
+
+        with _patch_ctx(container):
+            with caplog.at_level(logging.ERROR, logger="orb.api.routers.admin"):
+                client = TestClient(admin_app, raise_server_exceptions=False)
+                r = _reload_post(client)
+
+        assert r.status_code == 500
+        assert r.json()["error"]["code"] == "RELOAD_FAILED"
+        assert secret not in r.text, (
+            f"Exception detail leaked into reload response: {secret!r} found in {r.text!r}"
+        )
+        error_messages = [rec.message for rec in caplog.records if rec.levelno >= logging.ERROR]
+        assert any(secret in m for m in error_messages), (
+            f"Expected {secret!r} in server ERROR log, got: {error_messages}"
+        )
+
+    def test_reload_error_code_and_status_unchanged(self, admin_app):
+        """HTTP 500 and code=RELOAD_FAILED must be preserved after the fix."""
+        config_port = _make_config_port(allow_destructive=True, environment="development")
+        machine_repo, request_repo, template_repo = _make_repositories()
+
+        container = self._make_failing_container(
+            config_port, machine_repo, request_repo, template_repo, "any internal detail"
+        )
+
+        with _patch_ctx(container):
+            client = TestClient(admin_app, raise_server_exceptions=False)
+            r = _reload_post(client)
+
+        assert r.status_code == 500
+        assert r.json()["error"]["code"] == "RELOAD_FAILED"

--- a/tests/unit/api/test_cleanup_router.py
+++ b/tests/unit/api/test_cleanup_router.py
@@ -624,3 +624,153 @@ class TestMachinePurgeEndpoint:
         assert body["machine_id"] == "m-1"
         assert body["machines_deleted"] == 1
         uow.machines.delete.assert_called_once_with("m-1")
+
+
+# ---------------------------------------------------------------------------
+# Security: information-leak regression tests
+# Verify raw exception text never reaches the HTTP response body for the
+# purge endpoints and the cleanup (INVALID_STATUS) path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestRequestPurgeNoInfoLeak:
+    """KeyError and NonTerminalStatusError must not expose internal detail in responses."""
+
+    def test_key_error_message_not_in_response_body(self, cleanup_app, caplog):
+        """KeyError text (internal storage key) must not appear in the 404 body."""
+        import logging
+
+        config_port = _make_config_port(allow_destructive=True)
+        uow = _make_uow(request_map={})
+        container = _make_container(config_port, _make_uow_factory(uow))
+
+        # Patch delete_request so KeyError carries a recognisable secret token.
+        secret = "internal-storage-key-secret-abc123"
+        with _patch_containers(
+            "orb.api.routers.admin.get_di_container",
+            "orb.api.routers.requests.get_di_container",
+            container=container,
+        ):
+            with patch(
+                "orb.api.routers.requests.CleanupDatabaseService.delete_request",
+                side_effect=KeyError(secret),
+            ):
+                with caplog.at_level(logging.WARNING, logger="orb.api.routers.requests"):
+                    client = TestClient(cleanup_app, raise_server_exceptions=False)
+                    r = client.post("/requests/req-secret/purge")
+
+        assert r.status_code == 404
+        assert secret not in r.text, (
+            f"Secret KeyError text leaked into response: {secret!r} found in {r.text!r}"
+        )
+        warning_messages = [rec.message for rec in caplog.records if rec.levelno >= logging.WARNING]
+        assert any(secret in m for m in warning_messages), (
+            f"Expected {secret!r} in server WARNING log, got: {warning_messages}"
+        )
+
+    def test_non_terminal_status_error_message_not_in_response_body(self, cleanup_app, caplog):
+        """NonTerminalStatusError text (machine state detail) must not appear in the 400 body."""
+        import logging
+
+        from orb.application.services.admin.cleanup_database import NonTerminalStatusError
+
+        config_port = _make_config_port(allow_destructive=True)
+        uow = _make_uow(request_map={})
+        container = _make_container(config_port, _make_uow_factory(uow))
+
+        secret = "req-secret-state-in_progress-detail-xyz"
+        with _patch_containers(
+            "orb.api.routers.admin.get_di_container",
+            "orb.api.routers.requests.get_di_container",
+            container=container,
+        ):
+            with patch(
+                "orb.api.routers.requests.CleanupDatabaseService.delete_request",
+                side_effect=NonTerminalStatusError(secret),
+            ):
+                with caplog.at_level(logging.WARNING, logger="orb.api.routers.requests"):
+                    client = TestClient(cleanup_app, raise_server_exceptions=False)
+                    r = client.post("/requests/req-active/purge")
+
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "NON_TERMINAL_STATUS"
+        assert secret not in r.text, (
+            f"NonTerminalStatusError detail leaked: {secret!r} found in {r.text!r}"
+        )
+        warning_messages = [rec.message for rec in caplog.records if rec.levelno >= logging.WARNING]
+        assert any(secret in m for m in warning_messages), (
+            f"Expected {secret!r} in server WARNING log, got: {warning_messages}"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestMachinePurgeNoInfoLeak:
+    """KeyError and NonTerminalStatusError must not expose internal detail in responses."""
+
+    def test_key_error_message_not_in_response_body(self, cleanup_app, caplog):
+        """KeyError text (storage key) must not appear in the 404 body."""
+        import logging
+
+        config_port = _make_config_port(allow_destructive=True)
+        uow = _make_uow(machine_map={})
+        container = _make_container(config_port, _make_uow_factory(uow))
+
+        secret = "internal-machine-storage-key-secret-def456"
+        with _patch_containers(
+            "orb.api.routers.admin.get_di_container",
+            "orb.api.routers.machines.get_di_container",
+            container=container,
+        ):
+            with patch(
+                "orb.api.routers.machines.CleanupDatabaseService.delete_machine",
+                side_effect=KeyError(secret),
+            ):
+                with caplog.at_level(logging.WARNING, logger="orb.api.routers.machines"):
+                    client = TestClient(cleanup_app, raise_server_exceptions=False)
+                    r = client.delete("/machines/m-secret?purge=true")
+
+        assert r.status_code == 404
+        assert secret not in r.text, (
+            f"Secret KeyError text leaked into response: {secret!r} found in {r.text!r}"
+        )
+        warning_messages = [rec.message for rec in caplog.records if rec.levelno >= logging.WARNING]
+        assert any(secret in m for m in warning_messages), (
+            f"Expected {secret!r} in server WARNING log, got: {warning_messages}"
+        )
+
+    def test_non_terminal_status_error_message_not_in_response_body(self, cleanup_app, caplog):
+        """NonTerminalStatusError text (machine state detail) must not appear in the 400 body."""
+        import logging
+
+        from orb.application.services.admin.cleanup_database import NonTerminalStatusError
+
+        config_port = _make_config_port(allow_destructive=True)
+        uow = _make_uow(machine_map={})
+        container = _make_container(config_port, _make_uow_factory(uow))
+
+        secret = "m-secret-running-state-detail-ghi789"
+        with _patch_containers(
+            "orb.api.routers.admin.get_di_container",
+            "orb.api.routers.machines.get_di_container",
+            container=container,
+        ):
+            with patch(
+                "orb.api.routers.machines.CleanupDatabaseService.delete_machine",
+                side_effect=NonTerminalStatusError(secret),
+            ):
+                with caplog.at_level(logging.WARNING, logger="orb.api.routers.machines"):
+                    client = TestClient(cleanup_app, raise_server_exceptions=False)
+                    r = client.delete("/machines/m-active?purge=true")
+
+        assert r.status_code == 400
+        assert r.json()["error"]["code"] == "NON_TERMINAL_STATUS"
+        assert secret not in r.text, (
+            f"NonTerminalStatusError detail leaked: {secret!r} found in {r.text!r}"
+        )
+        warning_messages = [rec.message for rec in caplog.records if rec.levelno >= logging.WARNING]
+        assert any(secret in m for m in warning_messages), (
+            f"Expected {secret!r} in server WARNING log, got: {warning_messages}"
+        )

--- a/tests/unit/api/test_config_router.py
+++ b/tests/unit/api/test_config_router.py
@@ -353,3 +353,129 @@ class TestConfigExecutorOffload:
 
         assert ping_r.status_code == 200, "concurrent GET stalled during config file read"
         assert read_r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Security: information-leak regression tests for save_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestSaveConfigNoInfoLeak:
+    """ValueError from save_config must not expose filesystem paths or other
+    internal detail in the HTTP response body, but must be visible in server logs."""
+
+    def _make_save_app(self):
+        """Build a minimal FastAPI app with the config router and destructive-admin
+        guard satisfied (allow_destructive=True, environment=development)."""
+        from unittest.mock import MagicMock
+
+        from fastapi import FastAPI
+
+        from orb.api.dependencies import (
+            CurrentUser,
+            get_current_user,
+        )
+        from orb.api.routers.config import router as config_router
+
+        app = FastAPI()
+        app.include_router(config_router)
+        app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+            username="test-admin", role="admin"
+        )
+
+        # Satisfy the destructive-admin guard embedded in save_config.
+        config_port_for_guard = MagicMock()
+        config_port_for_guard.get_configuration_value.side_effect = lambda key, default=None: {
+            "allow_destructive_admin": True,
+            "environment": "development",
+        }.get(key, default)
+        server_config = MagicMock()
+        server_config.auth.enabled = True
+
+        # We need both get_di_container (for the guard) and get_server_config patched
+        # globally for the lifetime of the test — callers apply them via context managers.
+        return app, config_port_for_guard, server_config
+
+    def test_value_error_text_not_in_response_body(self, config_app, caplog):
+        """ValueError text from save_config (may contain FS paths) must not reach the client."""
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        from fastapi.testclient import TestClient
+
+        from orb.api.dependencies import CurrentUser, get_config_manager, get_current_user
+
+        # Build a config manager that raises ValueError with a secret FS path.
+        secret = "/etc/orb/secret-config-path-abc123.json"
+        port = MagicMock()
+        port.get_configuration_value.side_effect = lambda key, default=None: {
+            "allow_destructive_admin": True,
+            "environment": "development",
+        }.get(key, default)
+        port.save_config.side_effect = ValueError(f"No config file loaded: {secret}")
+        port.get_config_dir.return_value = "/etc/orb"
+
+        config_app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+            username="test-admin", role="admin"
+        )
+        config_app.dependency_overrides[get_config_manager] = lambda: port
+
+        server_config = MagicMock()
+        server_config.auth.enabled = True
+
+        with patch(
+            "orb.api.dependencies.get_di_container",
+            return_value=MagicMock(**{"get.return_value": port}),
+        ):
+            with patch("orb.api.dependencies.get_server_config", return_value=server_config):
+                with caplog.at_level(logging.WARNING, logger="orb.api.routers.config"):
+                    client = TestClient(config_app, raise_server_exceptions=False)
+                    r = client.post("/config/save", json={})
+
+        assert r.status_code == 400
+        body = r.json()
+        assert body["detail"]["code"] == "NO_CONFIG_PATH"
+        assert secret not in r.text, (
+            f"ValueError detail (filesystem path) leaked into response: {secret!r} in {r.text!r}"
+        )
+        warning_messages = [rec.message for rec in caplog.records if rec.levelno >= logging.WARNING]
+        assert any(secret in m for m in warning_messages), (
+            f"Expected {secret!r} in server WARNING log, got: {warning_messages}"
+        )
+
+    def test_no_config_path_error_code_unchanged(self, config_app):
+        """HTTP 400 and code=NO_CONFIG_PATH must be preserved after the fix."""
+        from unittest.mock import MagicMock, patch
+
+        from fastapi.testclient import TestClient
+
+        from orb.api.dependencies import CurrentUser, get_config_manager, get_current_user
+
+        port = MagicMock()
+        port.get_configuration_value.side_effect = lambda key, default=None: {
+            "allow_destructive_admin": True,
+            "environment": "development",
+        }.get(key, default)
+        port.save_config.side_effect = ValueError("no path loaded")
+        port.get_config_dir.return_value = "/etc/orb"
+
+        config_app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+            username="test-admin", role="admin"
+        )
+        config_app.dependency_overrides[get_config_manager] = lambda: port
+
+        server_config = MagicMock()
+        server_config.auth.enabled = True
+
+        with patch(
+            "orb.api.dependencies.get_di_container",
+            return_value=MagicMock(**{"get.return_value": port}),
+        ):
+            with patch("orb.api.dependencies.get_server_config", return_value=server_config):
+                client = TestClient(config_app, raise_server_exceptions=False)
+                r = client.post("/config/save", json={})
+
+        assert r.status_code == 400
+        assert r.json()["detail"]["code"] == "NO_CONFIG_PATH"

--- a/tests/unit/config/test_aws_credentials_secret_str.py
+++ b/tests/unit/config/test_aws_credentials_secret_str.py
@@ -1,0 +1,307 @@
+"""Regression tests: AWSProviderConfig credential fields use SecretStr.
+
+Covers:
+- str/repr/model_dump never leak the raw secret value
+- get_secret_value() returns the real value (for passing to boto3)
+- config dict masking in aws_client before logging
+- explicit credentials are threaded to boto3.Session (not silently dropped)
+- recursive masking of nested dicts and lists
+- precise masking rules: public_key/key_file NOT masked; secrets ARE masked
+- json.dumps safety on model_dump() output
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+class TestAWSProviderConfigSecretStr:
+    """SecretStr enforcement on access_key_id and secret_access_key."""
+
+    def _make_config(self, **kwargs):
+        from orb.providers.aws.configuration.config import AWSProviderConfig
+
+        return AWSProviderConfig(  # type: ignore[call-arg]
+            region="us-east-1",
+            **kwargs,
+        )
+
+    def test_access_key_id_not_exposed_in_str(self):
+        """str(config) must not contain the raw access key value."""
+        config = self._make_config(access_key_id="AKIATEST123SECRET")
+        assert "AKIATEST123SECRET" not in str(config)
+
+    def test_secret_access_key_not_exposed_in_str(self):
+        """str(config) must not contain the raw secret access key."""
+        config = self._make_config(secret_access_key="SuP3rS3cr3tV4lue")  # nosec B105
+        assert "SuP3rS3cr3tV4lue" not in str(config)
+
+    def test_access_key_id_not_exposed_in_repr(self):
+        """repr(config) must not contain the raw access key value."""
+        config = self._make_config(access_key_id="AKIATEST123SECRET")
+        assert "AKIATEST123SECRET" not in repr(config)
+
+    def test_secret_access_key_not_exposed_in_repr(self):
+        """repr(config) must not contain the raw secret access key."""
+        config = self._make_config(secret_access_key="SuP3rS3cr3tV4lue")  # nosec B105
+        assert "SuP3rS3cr3tV4lue" not in repr(config)
+
+    def test_model_dump_does_not_leak_secret_access_key(self):
+        """model_dump() default mode must not expose the raw secret value."""
+        config = self._make_config(secret_access_key="SuP3rS3cr3tV4lue")  # nosec B105
+        dumped = config.model_dump()
+        secret_val = dumped.get("secret_access_key")
+        # SecretStr objects in model_dump() are returned as SecretStr, not plain str
+        assert secret_val is None or str(secret_val) != "SuP3rS3cr3tV4lue"
+
+    def test_model_dump_does_not_leak_access_key_id(self):
+        """model_dump() default mode must not expose the raw access key ID."""
+        config = self._make_config(access_key_id="AKIATEST123SECRET")
+        dumped = config.model_dump()
+        key_val = dumped.get("access_key_id")
+        assert key_val is None or str(key_val) != "AKIATEST123SECRET"
+
+    def test_get_secret_value_returns_real_access_key_id(self):
+        """get_secret_value() must return the real value so boto3 can use it."""
+        config = self._make_config(access_key_id="AKIATEST123SECRET")
+        assert config.access_key_id is not None
+        assert config.access_key_id.get_secret_value() == "AKIATEST123SECRET"
+
+    def test_get_secret_value_returns_real_secret_access_key(self):
+        """get_secret_value() must return the real value so boto3 can use it."""
+        config = self._make_config(secret_access_key="SuP3rS3cr3tV4lue")  # nosec B105
+        assert config.secret_access_key is not None
+        assert config.secret_access_key.get_secret_value() == "SuP3rS3cr3tV4lue"
+
+    def test_none_credentials_remain_none(self):
+        """Omitting credentials leaves both fields as None."""
+        config = self._make_config()
+        assert config.access_key_id is None
+        assert config.secret_access_key is None
+
+    # --- json.dumps safety ---
+
+    def test_model_dump_json_mode_is_serialisable(self):
+        """model_dump(mode='json') produces a dict that json.dumps can serialise."""
+        config = self._make_config(
+            access_key_id="AKIATEST123SECRET",
+            secret_access_key="SuP3rS3cr3tV4lue",  # nosec B105
+        )
+        dumped = config.model_dump(mode="json")
+        # Must not raise
+        serialised = json.dumps(dumped)
+        # The raw values are exposed in json mode — that is expected and
+        # acceptable when intentionally serialising for internal transfer.
+        # The caller is responsible for securing this output.
+        assert isinstance(serialised, str)
+
+    def test_model_dump_default_mode_raises_on_json_dumps(self):
+        """model_dump() (default mode) contains SecretStr which json.dumps cannot handle."""
+        config = self._make_config(
+            access_key_id="AKIATEST123SECRET",
+            secret_access_key="SuP3rS3cr3tV4lue",  # nosec B105
+        )
+        dumped = config.model_dump()
+        # SecretStr is not JSON-serialisable; json.dumps must raise TypeError.
+        # This test documents the known pitfall so callers know to use mode="json"
+        # or get_secret_value() before handing the dict to a JSON serialiser.
+        with pytest.raises(TypeError):
+            json.dumps(dumped)
+
+
+@pytest.mark.unit
+class TestMaskConfigDict:
+    """_mask_config_dict hides sensitive keys before logging."""
+
+    def _mask(self, d):
+        from orb.providers.aws.infrastructure.aws_client import _mask_config_dict
+
+        return _mask_config_dict(d)
+
+    def test_secret_access_key_masked(self):
+        result = self._mask({"secret_access_key": "real-secret", "region": "us-east-1"})
+        assert result["secret_access_key"] == "***"
+        assert result["region"] == "us-east-1"
+
+    def test_access_key_id_masked(self):
+        result = self._mask({"access_key_id": "AKIATEST", "profile": "default"})
+        assert result["access_key_id"] == "***"
+        assert result["profile"] == "default"
+
+    def test_password_key_masked(self):
+        result = self._mask({"db_password": "hunter2"})
+        assert result["db_password"] == "***"
+
+    def test_token_key_masked(self):
+        result = self._mask({"session_token": "tok123"})
+        assert result["session_token"] == "***"
+
+    def test_credential_key_masked(self):
+        result = self._mask({"credential_file": "/path/to/creds"})
+        assert result["credential_file"] == "***"
+
+    def test_non_sensitive_keys_pass_through(self):
+        result = self._mask({"region": "eu-west-1", "endpoint_url": "https://example.com"})
+        assert result["region"] == "eu-west-1"
+        assert result["endpoint_url"] == "https://example.com"
+
+    def test_empty_dict(self):
+        assert self._mask({}) == {}
+
+    def test_masked_value_not_present_in_str_representation(self):
+        """The raw secret must not appear anywhere in the masked dict's repr."""
+        result = self._mask({"secret_access_key": "SuP3rS3cr3t"})  # nosec B105
+        assert "SuP3rS3cr3t" not in str(result)
+
+    # --- Regression: bare "key" must NOT mask legitimate non-secret fields ---
+
+    def test_public_key_not_masked(self):
+        """public_key is a legitimate non-secret field and must not be masked."""
+        result = self._mask({"public_key": "ssh-rsa AAAA...", "region": "us-east-1"})
+        assert result["public_key"] == "ssh-rsa AAAA..."
+
+    def test_key_file_not_masked(self):
+        """key_file holds a path, not a secret value, and must not be masked."""
+        result = self._mask({"key_file": "/path/to/key.pem"})
+        assert result["key_file"] == "/path/to/key.pem"
+
+    def test_region_key_not_masked(self):
+        """Hypothetical region_key metadata field must not be masked."""
+        result = self._mask({"region_key": "ap-southeast-1"})
+        assert result["region_key"] == "ap-southeast-1"
+
+    # --- Regression: recursive masking ---
+
+    def test_nested_dict_secret_masked(self):
+        """Secrets nested inside a child dict must be masked recursively."""
+        result = self._mask({"auth": {"secret_access_key": "nested-secret", "region": "eu-west-1"}})
+        assert result["auth"]["secret_access_key"] == "***"
+        assert result["auth"]["region"] == "eu-west-1"
+
+    def test_deeply_nested_secret_masked(self):
+        """Secrets two levels deep must still be masked."""
+        result = self._mask({"outer": {"inner": {"access_key_id": "deep-key"}}})
+        assert result["outer"]["inner"]["access_key_id"] == "***"
+
+    def test_list_of_dicts_secrets_masked(self):
+        """Dicts inside a list value must have their secrets masked."""
+        result = self._mask(
+            {"credentials": [{"secret_access_key": "list-secret"}, {"region": "eu-west-1"}]}
+        )
+        assert result["credentials"][0]["secret_access_key"] == "***"
+        assert result["credentials"][1]["region"] == "eu-west-1"
+
+    def test_list_of_scalars_not_affected(self):
+        """Scalar lists are passed through unchanged."""
+        result = self._mask({"subnet_ids": ["subnet-aaa", "subnet-bbb"]})
+        assert result["subnet_ids"] == ["subnet-aaa", "subnet-bbb"]
+
+
+@pytest.mark.unit
+class TestAWSSessionFactoryCredentials:
+    """Explicit credentials are threaded to boto3.Session (C3 regression)."""
+
+    def test_explicit_keys_passed_to_boto3_session(self):
+        """boto3.Session must receive aws_access_key_id when the config supplies keys."""
+        from orb.providers.aws.session_factory import AWSSessionFactory
+
+        with patch("orb.providers.aws.session_factory.boto3.Session") as mock_session:
+            AWSSessionFactory.create_session(
+                aws_access_key_id="AKIATEST123",
+                aws_secret_access_key="s3cr3t",  # nosec B105
+            )
+            mock_session.assert_called_once()
+            _, kwargs = mock_session.call_args
+            assert kwargs.get("aws_access_key_id") == "AKIATEST123"
+            assert kwargs.get("aws_secret_access_key") == "s3cr3t"
+
+    def test_absent_keys_do_not_appear_in_boto3_call(self):
+        """When no explicit keys are provided boto3.Session must not receive key kwargs."""
+        from orb.providers.aws.session_factory import AWSSessionFactory
+
+        with patch("orb.providers.aws.session_factory.boto3.Session") as mock_session:
+            AWSSessionFactory.create_session(region="us-east-1")
+            _, kwargs = mock_session.call_args
+            assert "aws_access_key_id" not in kwargs
+            assert "aws_secret_access_key" not in kwargs
+            assert "aws_session_token" not in kwargs
+
+    def test_session_token_passed_when_present(self):
+        """aws_session_token must be forwarded when supplied."""
+        from orb.providers.aws.session_factory import AWSSessionFactory
+
+        with patch("orb.providers.aws.session_factory.boto3.Session") as mock_session:
+            AWSSessionFactory.create_session(
+                aws_access_key_id="AKIATEST",
+                aws_secret_access_key="secret",  # nosec B105
+                aws_session_token="token-abc",
+            )
+            _, kwargs = mock_session.call_args
+            assert kwargs.get("aws_session_token") == "token-abc"
+
+    def test_empty_string_keys_not_passed_to_boto3(self):
+        """Empty strings must be treated as absent — not forwarded to boto3."""
+        from orb.providers.aws.session_factory import AWSSessionFactory
+
+        with patch("orb.providers.aws.session_factory.boto3.Session") as mock_session:
+            AWSSessionFactory.create_session(
+                aws_access_key_id="",
+                aws_secret_access_key="",  # nosec B105
+            )
+            _, kwargs = mock_session.call_args
+            assert "aws_access_key_id" not in kwargs
+            assert "aws_secret_access_key" not in kwargs
+
+    def test_aws_client_extracts_secret_str_for_session(self):
+        """AWSClient.__init__ must unwrap SecretStr and pass keys to create_session.
+
+        This test patches get_selected_aws_provider_config to bypass the
+        provider-lookup machinery and focus purely on the credential-extraction
+        and session-creation logic.
+        """
+        from orb.providers.aws.configuration.config import AWSProviderConfig
+
+        provider_config = AWSProviderConfig(  # type: ignore[call-arg]
+            region="us-east-1",
+            access_key_id="AKIATEST123",
+            secret_access_key="MySuperSecret",  # nosec B105
+        )
+
+        config_mock = MagicMock()
+        config_mock.get_provider_config.return_value = None
+        config_mock.get_metrics_config.return_value = {}
+
+        logger_mock = MagicMock()
+
+        with (
+            patch("orb.providers.aws.session_factory.boto3.Session") as mock_boto_session,
+            patch(
+                "orb.providers.aws.infrastructure.aws_client.AWSClient.get_selected_aws_provider_config",
+                return_value=provider_config,
+            ),
+        ):
+            mock_boto_session.return_value = MagicMock()
+
+            from orb.providers.aws.infrastructure.aws_client import AWSClient
+
+            AWSClient(
+                config=config_mock,
+                logger=logger_mock,
+                provider_name=None,
+                active_provider_name_resolver=None,
+            )
+
+        # boto3.Session must have been called with the unwrapped secret values
+        found_call_with_keys = False
+        for c in mock_boto_session.call_args_list:
+            kw = c[1] if len(c) > 1 else {}
+            if kw.get("aws_access_key_id") == "AKIATEST123":
+                found_call_with_keys = True
+                assert kw.get("aws_secret_access_key") == "MySuperSecret"
+                break
+        assert found_call_with_keys, (
+            "boto3.Session was never called with aws_access_key_id='AKIATEST123'. "
+            f"Actual calls: {mock_boto_session.call_args_list}"
+        )

--- a/tests/unit/config/test_server_schema.py
+++ b/tests/unit/config/test_server_schema.py
@@ -50,3 +50,236 @@ def test_bearer_token_config_rejects_unsupported_algorithms(algo: str):
 
     with pytest.raises(ValidationError):
         BearerTokenAuthSubConfig(secret_key="a" * 32, algorithm=algo)  # type: ignore[call-arg]  # pydantic default fields
+
+
+# ---------------------------------------------------------------------------
+# AuthConfig — fail-closed: enabled=True + strategy="none" is rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_auth_config_bare_construction_raises():
+    """AuthConfig() (enabled=True, strategy='none') must be rejected.
+
+    The 'none' strategy is a pass-through that grants every anonymous caller
+    permissions=['*'].  Combining it with enabled=True is a silent fail-open:
+    the server appears authenticated while enforcing nothing.  Construction
+    must raise so the misconfiguration surfaces at build time.
+    """
+    from orb.config.schemas.server_schema import AuthConfig
+
+    with pytest.raises(ValidationError) as exc_info:
+        AuthConfig()  # type: ignore[call-arg]
+
+    errors = exc_info.value.errors()
+    assert any(
+        "pass-through" in str(e).lower() or "real authentication" in str(e).lower() for e in errors
+    )
+
+
+@pytest.mark.unit
+def test_auth_config_enabled_true_with_none_strategy_raises():
+    """AuthConfig(enabled=True, strategy='none') must be rejected."""
+    from orb.config.schemas.server_schema import AuthConfig
+
+    with pytest.raises(ValidationError):
+        AuthConfig(enabled=True, strategy="none")  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_auth_config_enabled_true_with_empty_strategy_raises():
+    """AuthConfig(enabled=True, strategy='') must be rejected."""
+    from orb.config.schemas.server_schema import AuthConfig
+
+    with pytest.raises(ValidationError):
+        AuthConfig(enabled=True, strategy="")  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_auth_config_explicit_false_preserved():
+    """Callers that pass enabled=False explicitly keep their intended behavior."""
+    from orb.config.schemas.server_schema import AuthConfig
+
+    cfg = AuthConfig(enabled=False)  # type: ignore[call-arg]
+    assert cfg.enabled is False
+
+
+@pytest.mark.unit
+def test_auth_config_enabled_true_with_real_strategy_accepted():
+    """AuthConfig(enabled=True) is accepted when a real strategy is specified."""
+    from orb.config.schemas.server_schema import AuthConfig
+
+    for strategy in ("bearer_token", "bearer_token_enhanced", "iam", "cognito"):
+        cfg = AuthConfig(enabled=True, strategy=strategy)  # type: ignore[call-arg]
+        assert cfg.enabled is True
+        assert cfg.strategy == strategy
+
+
+# ---------------------------------------------------------------------------
+# CORSConfig — credentials + wildcard origin is rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cors_credentials_with_wildcard_origin_raises():
+    """credentials=True + origins=['*'] is an insecure combo and must be rejected."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    with pytest.raises(ValidationError) as exc_info:
+        CORSConfig(credentials=True, origins=["*"])  # type: ignore[call-arg]
+
+    errors = exc_info.value.errors()
+    assert any("credentials" in str(e).lower() for e in errors)
+
+
+@pytest.mark.unit
+def test_cors_credentials_false_with_wildcard_origin_is_allowed():
+    """credentials=False (the default) with origins=['*'] is permitted."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    cfg = CORSConfig(credentials=False, origins=["*"])  # type: ignore[call-arg]
+    assert cfg.credentials is False
+    assert "*" in cfg.origins
+
+
+@pytest.mark.unit
+def test_cors_credentials_true_with_explicit_origin_is_allowed():
+    """credentials=True with explicit (non-wildcard) origins and no wildcard headers is permitted."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    cfg = CORSConfig(  # type: ignore[call-arg]
+        credentials=True,
+        origins=["https://app.example.com"],
+        headers=["Authorization", "Content-Type"],
+    )
+    assert cfg.credentials is True
+    assert cfg.origins == ["https://app.example.com"]
+
+
+@pytest.mark.unit
+def test_cors_credentials_true_with_mixed_origins_raises():
+    """credentials=True raises even when '*' appears alongside explicit origins."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    with pytest.raises(ValidationError):
+        CORSConfig(credentials=True, origins=["https://app.example.com", "*"])  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_cors_default_credentials_is_false():
+    """CORSConfig defaults to credentials=False."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    cfg = CORSConfig()  # type: ignore[call-arg]
+    assert cfg.credentials is False
+
+
+@pytest.mark.unit
+def test_cors_credentials_whitespace_padded_wildcard_raises():
+    """credentials=True with a whitespace-padded '*' entry is rejected."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    with pytest.raises(ValidationError):
+        CORSConfig(credentials=True, origins=[" * "])  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_cors_credentials_subdomain_wildcard_raises():
+    """credentials=True with a subdomain wildcard (https://*.example.com) is rejected."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    with pytest.raises(ValidationError):
+        CORSConfig(credentials=True, origins=["https://*.example.com"])  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_cors_credentials_with_headers_wildcard_raises():
+    """credentials=True + headers=['*'] is rejected even with explicit origins."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    with pytest.raises(ValidationError):
+        CORSConfig(  # type: ignore[call-arg]
+            credentials=True,
+            origins=["https://app.example.com"],
+            headers=["*"],
+        )
+
+
+@pytest.mark.unit
+def test_cors_credentials_false_with_headers_wildcard_allowed():
+    """credentials=False with headers=['*'] is permitted (the default)."""
+    from orb.config.schemas.server_schema import CORSConfig
+
+    cfg = CORSConfig(credentials=False, origins=["*"], headers=["*"])  # type: ignore[call-arg]
+    assert cfg.credentials is False
+
+
+# ---------------------------------------------------------------------------
+# check_destructive_admin_allowed — anonymous cannot pass with strategy="none"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_destructive_admin_blocked_for_no_strategy(monkeypatch):
+    """check_destructive_admin_allowed must refuse when auth strategy is 'none'.
+
+    Even if auth.enabled=True is set in config, the 'none' strategy grants
+    every anonymous caller permissions=['*'].  The guard must detect this and
+    return 403 AUTH_STRATEGY_NONE rather than allowing the destructive action.
+    """
+    from unittest.mock import MagicMock
+
+    from fastapi import HTTPException
+
+    from orb.api.dependencies import check_destructive_admin_allowed
+
+    # Cannot construct AuthConfig(enabled=True, strategy="none") because the
+    # validator rejects it.  Use a MagicMock to simulate a misconfigured or
+    # bypassed config object that presents this invalid state at runtime.
+    mock_auth = MagicMock()
+    mock_auth.enabled = True
+    mock_auth.strategy = "none"
+
+    mock_server_cfg = MagicMock()
+    mock_server_cfg.auth = mock_auth
+
+    mock_request = MagicMock()
+    monkeypatch.setattr(
+        "orb.api.dependencies.get_server_config",
+        lambda: mock_server_cfg,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        check_destructive_admin_allowed(mock_request)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail["code"] == "AUTH_STRATEGY_NONE"
+
+
+@pytest.mark.unit
+def test_destructive_admin_blocked_when_auth_disabled(monkeypatch):
+    """check_destructive_admin_allowed must refuse when auth.enabled=False."""
+    from unittest.mock import MagicMock
+
+    from fastapi import HTTPException
+
+    from orb.api.dependencies import check_destructive_admin_allowed
+
+    mock_auth = MagicMock()
+    mock_auth.enabled = False
+    mock_auth.strategy = "bearer_token"
+
+    mock_server_cfg = MagicMock()
+    mock_server_cfg.auth = mock_auth
+
+    mock_request = MagicMock()
+    monkeypatch.setattr(
+        "orb.api.dependencies.get_server_config",
+        lambda: mock_server_cfg,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        check_destructive_admin_allowed(mock_request)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail["code"] == "AUTH_DISABLED"

--- a/tests/unit/interface/test_server_command_handlers.py
+++ b/tests/unit/interface/test_server_command_handlers.py
@@ -561,3 +561,150 @@ class TestHandleServerLogs:
 
         call_kwargs = mock_daemon.tail_log.call_args.kwargs
         assert call_kwargs["lines"] == 50
+
+
+# ---------------------------------------------------------------------------
+# _resolve_configs — real DI + real ConfigurationManager (regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestResolveConfigsRealDI:
+    """Regression tests that exercise the real ConfigurationManager via a real
+    DIContainer, so a signature mismatch in the get_typed_with_defaults call
+    produces a test failure rather than a silent runtime error.
+
+    Previously the code resolved ConfigurationPort from the container and called
+    get_typed_with_defaults(ServerConfig) against it.  ConfigurationPort's
+    method signature is (self, key: str, expected_type: type, default=None),
+    so passing only ServerConfig (the type) as the sole positional argument
+    silently received ServerConfig as the ``key`` argument, produced a
+    TypeError, and — before the fail-closed change — was swallowed by a broad
+    except clause that returned a bare ServerConfig().
+
+    This test class binds a real ConfigurationManager to both ConfigurationManager
+    and ConfigurationPort in a lightweight DIContainer, then calls _resolve_configs.
+    Any plumbing regression (wrong object resolved, wrong method signature) will
+    raise immediately and fail this test.
+    """
+
+    def _make_args_with_real_container(self, **kwargs) -> argparse.Namespace:
+        """Build args whose _container has a real ConfigurationManager registered."""
+        from orb.config.managers.configuration_manager import ConfigurationManager
+        from orb.domain.base.ports.configuration_port import ConfigurationPort
+        from orb.infrastructure.di.container import DIContainer
+
+        # Build a ConfigurationManager from an empty in-memory dict so no
+        # filesystem access is required.  All config values fall back to
+        # Pydantic defaults, which is exactly what we want for this test.
+        real_cm = ConfigurationManager(config_dict={})
+
+        container = DIContainer()
+        container.register_instance(ConfigurationManager, real_cm)
+        container.register_instance(ConfigurationPort, real_cm)  # type: ignore[arg-type]
+
+        defaults = {
+            "foreground": False,
+            "timeout": None,
+            "host": None,
+            "port": None,
+            "workers": None,
+            "server_log_level": None,
+            "scheduler": None,
+            "api_only": False,
+            "socket_path": None,
+            "reload": False,
+            "lines": None,
+        }
+        defaults.update(kwargs)
+        ns = argparse.Namespace(**defaults)
+        ns._container = container
+        return ns
+
+    def test_resolve_configs_returns_server_config_instance(self):
+        """_resolve_configs must return a ServerConfig (not raise) when wired correctly."""
+        from orb.config.schemas.server_schema import ServerConfig
+        from orb.interface.server_command_handlers import _resolve_configs
+
+        args = self._make_args_with_real_container()
+        server_config, ui_config = _resolve_configs(args)
+
+        assert isinstance(server_config, ServerConfig), (
+            f"Expected ServerConfig instance, got {type(server_config)!r}. "
+            "The container likely resolved ConfigurationPort instead of "
+            "ConfigurationManager, causing get_typed_with_defaults to receive "
+            "ServerConfig as the 'key' argument (wrong signature)."
+        )
+
+    def test_resolve_configs_server_config_has_expected_defaults(self):
+        """ServerConfig loaded via real ConfigurationManager has valid typed fields."""
+        from orb.interface.server_command_handlers import _resolve_configs
+
+        args = self._make_args_with_real_container()
+        server_config, _ = _resolve_configs(args)
+
+        # The result must be a proper ServerConfig with typed attributes, not a
+        # raw dict, string, or MagicMock.  Exact default values depend on the
+        # config loader; the important assertion is that the type system is intact.
+        assert isinstance(server_config.host, str) and server_config.host, (
+            "server_config.host must be a non-empty string"
+        )
+        assert isinstance(server_config.port, int) and server_config.port > 0, (
+            "server_config.port must be a positive integer"
+        )
+        assert isinstance(server_config.workers, int) and server_config.workers >= 1, (
+            "server_config.workers must be >= 1"
+        )
+
+    def test_resolve_configs_cli_overrides_applied(self):
+        """CLI args (host/port/workers) must override values from ServerConfig."""
+        from orb.interface.server_command_handlers import _resolve_configs
+
+        args = self._make_args_with_real_container(host="0.0.0.0", port=9000, workers=4)
+        server_config, _ = _resolve_configs(args)
+
+        assert server_config.host == "0.0.0.0"
+        assert server_config.port == 9000
+        assert server_config.workers == 4
+
+    def test_resolve_configs_port_has_different_signature_than_manager(self):
+        """Confirm ConfigurationPort.get_typed_with_defaults has the legacy (key, expected_type)
+        signature — NOT the (config_type,) signature used by ConfigurationManager.
+
+        This documents WHY the production code must resolve ConfigurationManager
+        rather than ConfigurationPort: calling port.get_typed_with_defaults(ServerConfig)
+        would receive ServerConfig as the 'key' argument, leaving 'expected_type'
+        missing, and raise TypeError at runtime.
+        """
+        import inspect
+
+        from orb.config.managers.configuration_manager import ConfigurationManager
+        from orb.domain.base.ports.configuration_port import ConfigurationPort
+
+        port_sig = inspect.signature(ConfigurationPort.get_typed_with_defaults)
+        manager_sig = inspect.signature(ConfigurationManager.get_typed_with_defaults)
+
+        port_params = list(port_sig.parameters.keys())
+        manager_params = list(manager_sig.parameters.keys())
+
+        # Port: (self, key, expected_type, default) — legacy three-arg variant
+        assert "key" in port_params, (
+            "ConfigurationPort.get_typed_with_defaults no longer has a 'key' parameter — "
+            "update this test and the production code accordingly."
+        )
+        assert "expected_type" in port_params, (
+            "ConfigurationPort.get_typed_with_defaults no longer has an 'expected_type' "
+            "parameter — update this test and the production code accordingly."
+        )
+
+        # Manager: (self, config_type) — single-arg typed-schema variant
+        assert "config_type" in manager_params, (
+            "ConfigurationManager.get_typed_with_defaults no longer has a 'config_type' "
+            "parameter — update this test and the production code accordingly."
+        )
+        assert "key" not in manager_params, (
+            "ConfigurationManager.get_typed_with_defaults now has a 'key' parameter — "
+            "the signatures have converged; revisit whether the production code still "
+            "needs to distinguish between the port and the manager."
+        )

--- a/tests/unit/providers/test_providers_comprehensive.py
+++ b/tests/unit/providers/test_providers_comprehensive.py
@@ -58,8 +58,10 @@ class TestAWSProviderEnvironmentVariables:
                 {"ORB_AWS_ACCESS_KEY_ID": "AKIATEST123", "ORB_AWS_SECRET_ACCESS_KEY": "secret123"},  # nosec B105
             ):
                 config = AWSProviderConfig()  # type: ignore[call-arg]  # type: ignore[call-arg]
-                assert config.access_key_id == "AKIATEST123"
-                assert config.secret_access_key == "secret123"
+                assert config.access_key_id is not None
+                assert config.access_key_id.get_secret_value() == "AKIATEST123"
+                assert config.secret_access_key is not None
+                assert config.secret_access_key.get_secret_value() == "secret123"
 
         except ImportError:
             pytest.skip("AWSProviderConfig not available")

--- a/tests/unit/test_install_dev_tools_security.py
+++ b/tests/unit/test_install_dev_tools_security.py
@@ -1,0 +1,486 @@
+"""Regression tests: install_dev_tools never uses shell=True with curl-piped scripts.
+
+Covers:
+- _run_command accepts only list args (signature-level guard)
+- Generic installers that previously used shell=True now use two-step
+  curl-to-tempfile + sh/bash-on-tempfile pattern (list args only)
+- --dry-run path works for all patched methods without spawning processes
+- _install_syft_generic, _install_bun_generic, _install_actionlint_generic
+  call subprocess with list args, never with a shell=True string command
+- All temp files are unlinked after install (os.unlink called in finally)
+- docker install builds a valid arg list with no literal "|" element
+- windows path uses download-then-execute, not inline iex eval
+- dry-run never calls subprocess
+"""
+
+import inspect
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure dev-tools/setup is importable
+_DEV_TOOLS_PATH = str(Path(__file__).parents[2] / "dev-tools" / "setup")
+if _DEV_TOOLS_PATH not in sys.path:
+    sys.path.insert(0, _DEV_TOOLS_PATH)
+
+from install_dev_tools import DevToolsInstaller  # noqa: E402
+
+
+@pytest.mark.unit
+class TestRunCommandSignature:
+    """_run_command must only accept list args and never use shell=True."""
+
+    def test_run_command_signature_has_no_shell_param(self):
+        """The shell= parameter must not appear in _run_command's signature."""
+        sig = inspect.signature(DevToolsInstaller._run_command)
+        assert "shell" not in sig.parameters, (
+            "_run_command must not expose a shell= parameter — "
+            "callers could accidentally pass shell=True"
+        )
+
+    def test_run_command_accepts_list(self):
+        installer = DevToolsInstaller(dry_run=True)
+        # Should log and return True without spawning anything
+        result = installer._run_command(["echo", "hello"])
+        assert result is True
+
+    def test_run_command_dry_run_does_not_call_subprocess(self):
+        installer = DevToolsInstaller(dry_run=True)
+        with patch("subprocess.run") as mock_run:
+            installer._run_command(["curl", "-o", "/tmp/x", "https://example.com"])
+            mock_run.assert_not_called()
+
+
+@pytest.mark.unit
+class TestInstallScriptsDryRun:
+    """All three previously-shell=True methods must work under --dry-run."""
+
+    def setup_method(self):
+        self.installer = DevToolsInstaller(dry_run=True)
+
+    def test_install_syft_generic_dry_run(self):
+        with patch("subprocess.run") as mock_run:
+            result = self.installer._install_syft_generic()
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_install_bun_generic_dry_run(self):
+        with patch("subprocess.run") as mock_run:
+            result = self.installer._install_bun_generic()
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_install_actionlint_generic_dry_run(self):
+        with patch("subprocess.run") as mock_run:
+            result = self.installer._install_actionlint_generic()
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_install_uv_generic_dry_run(self):
+        with patch("subprocess.run") as mock_run:
+            result = self.installer._install_uv_generic()
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_install_trivy_generic_dry_run(self):
+        with patch("subprocess.run") as mock_run:
+            result = self.installer._install_trivy_generic()
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_install_shellcheck_generic_dry_run(self):
+        with patch("subprocess.run") as mock_run:
+            result = self.installer._install_shellcheck_generic()
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_install_trufflehog_generic_dry_run(self):
+        with patch("subprocess.run") as mock_run:
+            result = self.installer._install_trufflehog_generic()
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_install_act_generic_dry_run(self):
+        with patch("subprocess.run") as mock_run:
+            result = self.installer._install_act_generic()
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_install_bun_windows_dry_run(self):
+        with patch("subprocess.run") as mock_run:
+            result = self.installer._install_bun_windows()
+        assert result is True
+        mock_run.assert_not_called()
+
+
+@pytest.mark.unit
+class TestInstallScriptsUseListArgs:
+    """Installer methods must call subprocess with list args, never shell=True."""
+
+    def setup_method(self):
+        self.installer = DevToolsInstaller(dry_run=False)
+
+    def _capture_subprocess_calls(self, method):
+        """Run *method* with subprocess.run mocked; return list of calls."""
+        captured = []
+
+        def fake_run(cmd, **kwargs):
+            captured.append((cmd, kwargs))
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            return result
+
+        # mkstemp returns (fd, path); we mock it to return a fake fd and path
+        with patch("subprocess.run", side_effect=fake_run):
+            with patch("tempfile.mkstemp") as mock_mkstemp:
+                mock_mkstemp.return_value = (999, "/tmp/fake_install.sh")
+                with patch("os.close"):
+                    with patch("os.unlink"):
+                        method()
+
+        return captured
+
+    def _assert_no_shell_true(self, calls):
+        for cmd, kwargs in calls:
+            assert kwargs.get("shell") is not True, (
+                f"subprocess.run called with shell=True on cmd={cmd!r}. "
+                "All install commands must use list args without shell=True."
+            )
+            assert isinstance(cmd, list), (
+                f"subprocess.run called with a string command {cmd!r}. "
+                "Commands must be lists to prevent shell injection."
+            )
+
+    def test_install_syft_generic_uses_list_args(self):
+        calls = self._capture_subprocess_calls(self.installer._install_syft_generic)
+        assert len(calls) >= 1
+        self._assert_no_shell_true(calls)
+        curl_call_cmds = [c for c, _ in calls if c and c[0] == "curl"]
+        assert curl_call_cmds, "Expected at least one curl call"
+        for cmd in curl_call_cmds:
+            assert "|" not in cmd, f"Pipe character found in list args: {cmd}"
+
+    def test_install_bun_generic_uses_list_args(self):
+        calls = self._capture_subprocess_calls(self.installer._install_bun_generic)
+        assert len(calls) >= 1
+        self._assert_no_shell_true(calls)
+        curl_cmds = [c for c, _ in calls if c and c[0] == "curl"]
+        for cmd in curl_cmds:
+            assert "|" not in cmd
+
+    def test_install_actionlint_generic_uses_list_args(self):
+        calls = self._capture_subprocess_calls(self.installer._install_actionlint_generic)
+        assert len(calls) >= 1
+        self._assert_no_shell_true(calls)
+        curl_cmds = [c for c, _ in calls if c and c[0] == "curl"]
+        for cmd in curl_cmds:
+            assert "|" not in cmd
+
+    def test_install_uv_generic_uses_list_args(self):
+        calls = self._capture_subprocess_calls(self.installer._install_uv_generic)
+        assert len(calls) >= 1
+        self._assert_no_shell_true(calls)
+
+    def test_install_trivy_generic_uses_list_args(self):
+        calls = self._capture_subprocess_calls(self.installer._install_trivy_generic)
+        assert len(calls) >= 1
+        self._assert_no_shell_true(calls)
+
+    def test_install_shellcheck_generic_uses_list_args(self):
+        calls = self._capture_subprocess_calls(self.installer._install_shellcheck_generic)
+        assert len(calls) >= 1
+        self._assert_no_shell_true(calls)
+        curl_cmds = [c for c, _ in calls if c and c[0] == "curl"]
+        assert curl_cmds, "Expected curl call for shellcheck"
+        for cmd in curl_cmds:
+            assert "|" not in cmd
+
+    def test_install_trufflehog_generic_uses_list_args(self):
+        calls = self._capture_subprocess_calls(self.installer._install_trufflehog_generic)
+        assert len(calls) >= 1
+        self._assert_no_shell_true(calls)
+        curl_cmds = [c for c, _ in calls if c and c[0] == "curl"]
+        assert curl_cmds, "Expected curl call for trufflehog"
+        for cmd in curl_cmds:
+            assert "|" not in cmd
+
+    def test_install_act_generic_uses_list_args(self):
+        calls = self._capture_subprocess_calls(self.installer._install_act_generic)
+        assert len(calls) >= 1
+        self._assert_no_shell_true(calls)
+        curl_cmds = [c for c, _ in calls if c and c[0] == "curl"]
+        assert curl_cmds, "Expected curl call for act"
+        for cmd in curl_cmds:
+            assert "|" not in cmd
+
+    def test_install_syft_two_step_pattern(self):
+        """syft install must be curl-download then sh-execute (two subprocess calls)."""
+        calls = self._capture_subprocess_calls(self.installer._install_syft_generic)
+        cmds = [c for c, _ in calls]
+        assert len(cmds) >= 2, "Expected two subprocess calls: curl download then sh execute"
+        assert cmds[0][0] == "curl", f"First call should be curl, got {cmds[0][0]}"
+        assert cmds[1][0] == "sh", f"Second call should be sh, got {cmds[1][0]}"
+
+    def test_install_bun_two_step_pattern(self):
+        """bun install must be curl-download then bash-execute."""
+        calls = self._capture_subprocess_calls(self.installer._install_bun_generic)
+        cmds = [c for c, _ in calls]
+        assert len(cmds) >= 2
+        assert cmds[0][0] == "curl"
+        assert cmds[1][0] == "bash"
+
+    def test_install_actionlint_two_step_pattern(self):
+        """actionlint install must be curl-download then bash-execute."""
+        calls = self._capture_subprocess_calls(self.installer._install_actionlint_generic)
+        cmds = [c for c, _ in calls]
+        assert len(cmds) >= 2
+        assert cmds[0][0] == "curl"
+        assert cmds[1][0] == "bash"
+
+    def test_install_shellcheck_two_step_pattern(self):
+        """shellcheck install must be curl-download then tar-extract (two subprocess calls)."""
+        calls = self._capture_subprocess_calls(self.installer._install_shellcheck_generic)
+        cmds = [c for c, _ in calls]
+        assert len(cmds) >= 2
+        assert cmds[0][0] == "curl"
+        assert cmds[1][0] == "sudo"
+        assert "tar" in cmds[1], f"Second call should invoke tar, got: {cmds[1]}"
+
+    def test_install_trufflehog_two_step_pattern(self):
+        """trufflehog install must be curl-download then tar-extract (two subprocess calls)."""
+        calls = self._capture_subprocess_calls(self.installer._install_trufflehog_generic)
+        cmds = [c for c, _ in calls]
+        assert len(cmds) >= 2
+        assert cmds[0][0] == "curl"
+        assert cmds[1][0] == "sudo"
+        assert "tar" in cmds[1], f"Second call should invoke tar, got: {cmds[1]}"
+
+    def test_install_act_two_step_pattern(self):
+        """act install must be curl-download then bash-execute (two subprocess calls)."""
+        calls = self._capture_subprocess_calls(self.installer._install_act_generic)
+        cmds = [c for c, _ in calls]
+        assert len(cmds) >= 2
+        assert cmds[0][0] == "curl"
+        assert cmds[1][0] == "sudo"
+        assert cmds[1][1] == "bash"
+
+
+@pytest.mark.unit
+class TestTempFileCleanup:
+    """All temp-file-based installers must call os.unlink after install."""
+
+    _TEMP_METHODS = [
+        "_install_trivy_generic",
+        "_install_syft_generic",
+        "_install_uv_generic",
+        "_install_bun_generic",
+        "_install_actionlint_generic",
+        "_install_shellcheck_generic",
+        "_install_trufflehog_generic",
+        "_install_act_generic",
+    ]
+
+    def _run_with_mocks(self, method_name):
+        """Run installer method with subprocess + mkstemp fully mocked."""
+        installer = DevToolsInstaller(dry_run=False)
+        method = getattr(installer, method_name)
+
+        fake_fd = 42
+        fake_path = f"/tmp/fake_{method_name}.sh"
+
+        def fake_run(cmd, **kwargs):
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        with patch("subprocess.run", side_effect=fake_run):
+            with patch("tempfile.mkstemp", return_value=(fake_fd, fake_path)):
+                with patch("os.close") as mock_close:
+                    with patch("os.unlink") as mock_unlink:
+                        method()
+                        return mock_close, mock_unlink, fake_fd, fake_path
+
+    @pytest.mark.parametrize("method_name", _TEMP_METHODS)
+    def test_temp_file_unlinked_on_success(self, method_name):
+        """os.unlink must be called with the temp path after a successful install."""
+        _, mock_unlink, _, fake_path = self._run_with_mocks(method_name)
+        mock_unlink.assert_called_once_with(fake_path)
+
+    @pytest.mark.parametrize("method_name", _TEMP_METHODS)
+    def test_temp_file_unlinked_on_subprocess_failure(self, method_name):
+        """os.unlink must be called even when subprocess.run raises CalledProcessError."""
+        import subprocess as sp
+
+        installer = DevToolsInstaller(dry_run=False)
+        method = getattr(installer, method_name)
+
+        fake_path = f"/tmp/fake_{method_name}_fail.sh"
+
+        def fake_run_fail(cmd, **kwargs):
+            raise sp.CalledProcessError(1, cmd)
+
+        with patch("subprocess.run", side_effect=fake_run_fail):
+            with patch("tempfile.mkstemp", return_value=(42, fake_path)):
+                with patch("os.close"):
+                    with patch("os.unlink") as mock_unlink:
+                        method()
+                        mock_unlink.assert_called_once_with(fake_path)
+
+    @pytest.mark.parametrize("method_name", _TEMP_METHODS)
+    def test_no_delete_false_in_source(self, method_name):
+        """The method source must not contain NamedTemporaryFile(delete=False)."""
+        installer = DevToolsInstaller(dry_run=False)
+        method = getattr(installer, method_name)
+        source = inspect.getsource(method)
+        assert "delete=False" not in source, (
+            f"{method_name} still uses NamedTemporaryFile(delete=False) "
+            "which leaks temp files on failure"
+        )
+
+
+@pytest.mark.unit
+class TestDockerInstallNoLiteralPipe:
+    """_install_docker_ubuntu must not contain a literal '|' element in any command list."""
+
+    def test_docker_ubuntu_no_pipe_element(self):
+        """No command list passed to _run_command may contain '|' as an element."""
+        installer = DevToolsInstaller(dry_run=False)
+        all_commands = []
+
+        def capture_run_command(cmd, description=""):
+            all_commands.append(cmd)
+            return True
+
+        installer._run_command = capture_run_command
+        installer._install_docker_ubuntu()
+
+        for cmd in all_commands:
+            assert "|" not in cmd, (
+                f"Literal '|' found in command list {cmd!r}. "
+                "subprocess with shell=False does not interpret pipes — "
+                "use two separate subprocess calls or curl -o directly."
+            )
+
+    def test_docker_ubuntu_commands_are_lists(self):
+        """Every command dispatched by _install_docker_ubuntu must be a list."""
+        installer = DevToolsInstaller(dry_run=False)
+
+        def capture_run_command(cmd, description=""):
+            assert isinstance(cmd, list), f"Command must be a list, got {type(cmd)}: {cmd!r}"
+            return True
+
+        installer._run_command = capture_run_command
+        result = installer._install_docker_ubuntu()
+        assert result is True
+
+    def test_docker_ubuntu_gpg_step_uses_curl_dash_o(self):
+        """The GPG key step must use curl -o to write directly to the keyring path."""
+        installer = DevToolsInstaller(dry_run=False)
+        captured = []
+
+        def capture_run_command(cmd, description=""):
+            captured.append(cmd)
+            return True
+
+        installer._run_command = capture_run_command
+        installer._install_docker_ubuntu()
+
+        # Find the curl command that downloads the GPG key
+        curl_cmds = [
+            c for c in captured if c and c[0] in ("curl", "sudo") and "docker.com" in " ".join(c)
+        ]
+        assert curl_cmds, "Expected a curl command fetching the Docker GPG key"
+        for cmd in curl_cmds:
+            assert "|" not in cmd, f"Pipe element found in GPG key command: {cmd}"
+            # Must write to a file path, not pipe to gpg
+            assert "-o" in cmd or "--output" in cmd, (
+                f"GPG key download must use -o to write to file, got: {cmd}"
+            )
+
+
+@pytest.mark.unit
+class TestWindowsNoPipeToExec:
+    """Windows installers must not use irm ... | iex or DownloadString + iex patterns."""
+
+    def test_bun_windows_not_in_tools_as_iex_string(self):
+        """The bun windows entry must not be the old irm|iex string command."""
+        installer = DevToolsInstaller(dry_run=True)
+        bun_windows = installer.tools["bun"]["install"]["windows"]
+        if isinstance(bun_windows, list):
+            cmd_str = " ".join(bun_windows)
+            assert "iex" not in cmd_str.lower(), (
+                f"bun windows installer still uses iex inline eval: {cmd_str!r}"
+            )
+        else:
+            # It's a callable (_install_bun_windows) — that's the correct fix
+            assert callable(bun_windows), "bun windows entry must be callable or a safe list"
+
+    def test_install_bun_windows_method_exists(self):
+        """_install_bun_windows must exist as a method (the fixed Windows path)."""
+        installer = DevToolsInstaller(dry_run=True)
+        assert hasattr(installer, "_install_bun_windows"), (
+            "_install_bun_windows method must exist to handle Windows bun install "
+            "without inline iex eval"
+        )
+        assert callable(installer._install_bun_windows)
+
+    def test_ensure_chocolatey_source_has_no_iex_inline(self):
+        """_ensure_chocolatey must not use DownloadString + iex inline eval."""
+        installer = DevToolsInstaller(dry_run=True)
+        source = inspect.getsource(installer._ensure_chocolatey)
+        # The old pattern: iex ((New-Object...).DownloadString(...))
+        assert "DownloadString" not in source or "Invoke-WebRequest" in source, (
+            "_ensure_chocolatey still uses DownloadString + iex inline eval. "
+            "Must use Invoke-WebRequest -OutFile then execute the saved file."
+        )
+        # iex may appear in comments but not as a PowerShell command
+        # Strip comment lines and check
+        non_comment_lines = [
+            line for line in source.splitlines() if not line.strip().startswith("#")
+        ]
+        for line in non_comment_lines:
+            assert "| iex" not in line and "iex (" not in line, (
+                f"_ensure_chocolatey has inline iex eval on line: {line!r}"
+            )
+
+    def test_install_bun_windows_dry_run_no_subprocess(self):
+        """_install_bun_windows dry-run must not call subprocess."""
+        installer = DevToolsInstaller(dry_run=True)
+        with patch("subprocess.run") as mock_run:
+            result = installer._install_bun_windows()
+        assert result is True
+        mock_run.assert_not_called()
+
+
+@pytest.mark.unit
+class TestDryRunNoSubprocess:
+    """--dry-run must prevent ALL subprocess calls across every installer method."""
+
+    _ALL_GENERIC_METHODS = [
+        "_install_trivy_generic",
+        "_install_syft_generic",
+        "_install_uv_generic",
+        "_install_bun_generic",
+        "_install_bun_windows",
+        "_install_actionlint_generic",
+        "_install_shellcheck_generic",
+        "_install_trufflehog_generic",
+        "_install_act_generic",
+        "_install_yq_generic",
+        "_install_hadolint_generic",
+    ]
+
+    @pytest.mark.parametrize("method_name", _ALL_GENERIC_METHODS)
+    def test_dry_run_no_subprocess(self, method_name):
+        installer = DevToolsInstaller(dry_run=True)
+        method = getattr(installer, method_name)
+        with patch("subprocess.run") as mock_run:
+            result = method()
+        assert result is True, f"{method_name} dry-run returned {result!r}, expected True"
+        assert mock_run.call_count == 0, (
+            f"{method_name} called subprocess.run under --dry-run: {mock_run.call_args_list}"
+        )


### PR DESCRIPTION
## Description

Hardens the platform's authentication posture, credential handling, and error/output paths. The first pass fixed a set of auth, credential, and error-leak issues; an adversarial re-review then found several places where a fix was applied at one chokepoint while the live code path flowed through a different one. This PR closes those gaps so the fixes take effect on the paths that actually run in production.

**Authentication**
- Fail-closed configuration: an `enabled=True` auth config combined with a no-op strategy (`none`/empty) is now rejected at construction. A bare `ServerConfig()` yields auth *disabled* — an honest "unconfigured" posture — instead of "enabled with no real strategy", which previously let every anonymous caller through with full permissions while logging that auth was on.
- The bare-config fallbacks in server startup and the CLI now raise a `ConfigurationError` rather than silently booting an unauthenticated server.
- The destructive-admin guard no longer passes when the active strategy is a no-op pass-through.
- Cognito: the token denylist is now resolved from the container (falling back to an in-process denylist) so access-token revocation actually takes effect; revocation always denylists the token before any API call, so a forged unsigned `token_use` claim can no longer skip denylisting.
- IAM: STS/IAM calls run off the event loop, `SimulatePrincipalPolicy` is fully paginated, and deny-by-default is preserved on every error path.

**CORS**
- The credentials-plus-wildcard rejection also covers whitespace-padded wildcards, subdomain wildcards, and wildcard headers.

**Error / output leakage**
- Not-found handlers return categorical messages instead of echoing caller-supplied entity ids; a details whitelist strips internal fields; unexpected errors are now logged; the sibling response builder no longer echoes raw exception text.
- REST routers return safe messages and log the detail server-side instead of returning raw exception strings to callers.

**Credentials & tooling**
- The AWS session factory now actually forwards explicit credentials to boto3; the config-dict debug mask is recursive and no longer over-masks non-secret keys.
- Dev-tools installers clean up temp files, fix a broken pipe in the Docker install, and download-then-execute on Windows instead of piping to a shell.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code cleanup or refactor
- [ ] Dependencies update
- [ ] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed

New and updated regression tests target each fix, written so they fail if the vulnerability is reintroduced (e.g. asserting the Cognito `RevokeToken` API is actually invoked, that a forged `token_use` still denylists, that `enabled=True` + `strategy=none` raises, that not-found responses omit the entity id, that explicit AWS keys reach `boto3.Session`, and that installers use list args with temp-file cleanup).

## Test Configuration
* Python version: 3.12
* OS: macOS (darwin), Linux CI
* AWS region: n/a (mocked)
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes

Verification on this branch: `pyright src/` — 0 errors; `ruff check --select W,F,I --ignore E501` — clean; architecture suite — 4156 passed; auth/config/error/router/provider/security suites — 1104 passed; DI/bootstrap/interface/integration ripple check — 874 passed.

## Screenshots (if appropriate)
n/a

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

Wrapping the STS/IAM boto3 calls in `asyncio.to_thread` removes an event-loop block under concurrent auth load — a latency improvement under load rather than a regression.

## Dependencies
None.

## Migration Guide

This is a breaking change for deployments that relied on auth being effectively off without saying so:

- A config with `auth.enabled: true` and `auth.strategy: none` (or empty) now fails validation at startup. Set a real strategy (`bearer_token`, `cognito`, `iam`, …) or set `auth.enabled: false` explicitly.
- Startup paths that previously fell back to an implicit default `ServerConfig` when config failed to load now raise a `ConfigurationError` instead of booting unauthenticated — fix the config rather than relying on the fallback.
- Error-response bodies for not-found / validation / infrastructure errors now return categorical messages and no longer echo raw exception text or `original_error` details. Clients that parsed those strings should key off the HTTP status and the stable `code` field instead.

## Deployment Notes

Confirm each environment's config sets an explicit `auth.strategy` (or explicit `auth.enabled: false` for local/dev) before rolling out, since an `enabled=true` + `strategy=none` config will now refuse to start.

## Reviewers
@finos/open-resource-broker-maintainers
