### PR TITLE
test(api): stop SSE role-gate test from draining the stream body

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -534,6 +534,7 @@ markers = [
     "security: marks security tests",
     "serial: forces serial execution (use ``-n0`` or filter with ``-m 'not serial'`` under xdist)",
     "k8s_live: Live Kubernetes integration tests (require a real cluster — pass --run-k8s to enable)",
+    "timeout: Per-test wall-clock timeout (requires pytest-timeout; value in seconds)",
 ]
 # Provider-specific fake credentials live in
 # tests/providers/<name>/mocked/conftest.py.  The global pytest-env block

--- a/tests/unit/api/test_role_enforcement.py
+++ b/tests/unit/api/test_role_enforcement.py
@@ -472,11 +472,6 @@ _READ_ENDPOINTS: list[tuple[Any, str, str, dict | None]] = [
     (requests_router, "GET", "/requests/return", None),
     (requests_router, "GET", "/requests/req-1/status", None),
     (requests_router, "POST", "/requests/status", {"request_ids": ["req-1"]}),
-    # ?timeout=1 keeps the SSE stream from blocking on its 300s default: this
-    # test only asserts the role gate does not 403, which fires before the
-    # stream generator runs.  Without the override the generator loops until
-    # pytest-timeout kills it at 300s, dominating the whole unit leg.
-    (requests_router, "GET", "/requests/req-1/stream?timeout=1", None),
     # machines router
     (machines_router, "GET", "/machines/", None),
     (machines_router, "GET", "/machines/m-1/status", None),
@@ -540,6 +535,93 @@ def test_read_endpoint_viewer_is_not_denied(router_obj, method, path, body):
     assert resp.status_code != 403, (
         f"Viewer should not be denied on {method} {path}, got {resp.status_code}"
     )
+
+
+# ---------------------------------------------------------------------------
+# SSE stream endpoint: role-gate tests that do not drain the streaming body
+#
+# GET /{request_id}/stream is a viewer-guarded SSE endpoint whose generator
+# loops with asyncio.sleep().  Draining it via client.get() would block until
+# the timeout expires — deadlocking under anyio >= 4.14.2 in xdist workers.
+#
+# Strategy: stub the status orchestrator so it returns a terminal status on
+# the first call.  The generator yields one event, sees "cancelled", and
+# returns immediately without ever reaching asyncio.sleep().  Both directions
+# of the role gate are covered: anonymous (role="none") → 403, and
+# viewer → not 403.
+# ---------------------------------------------------------------------------
+
+
+def _stub_terminal_status_orchestrator():
+    """Stub orchestrator that returns a terminal 'cancelled' status on execute.
+
+    Causes the SSE generator to exit after one iteration without sleeping.
+    """
+    from orb.application.services.orchestration.dtos import GetRequestStatusOutput
+
+    orc = AsyncMock()
+    orc.execute = AsyncMock(
+        return_value=GetRequestStatusOutput(
+            requests=[{"request_id": "req-1", "status": "cancelled"}]
+        )
+    )
+    return orc
+
+
+def _stub_request_formatter_terminal():
+    """Stub formatter that returns a terminal-status payload.
+
+    format_request_status() is called by the SSE generator; returning a
+    MagicMock whose .data is a dict with a cancelled request ensures
+    _is_terminal_status() fires on the first iteration.
+    """
+    fmt = MagicMock()
+    result = MagicMock()
+    result.data = {"requests": [{"request_id": "req-1", "status": "cancelled"}]}
+    fmt.format_request_status.return_value = result
+    return fmt
+
+
+def _stream_overrides():
+    from orb.api.dependencies import (
+        get_request_formatter,
+        get_request_status_orchestrator,
+    )
+
+    return {
+        get_request_status_orchestrator: _stub_terminal_status_orchestrator,
+        get_request_formatter: _stub_request_formatter_terminal,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.api
+@pytest.mark.timeout(30)
+def test_stream_endpoint_anonymous_gets_403():
+    """Zero-rank caller is denied 403 on the SSE stream endpoint.
+
+    The role gate fires during FastAPI dependency resolution, before the
+    streaming generator is entered, so no body is produced.
+    """
+    app = _app_with_no_rank_user(requests_router)
+    for dep, factory in _stream_overrides().items():
+        app.dependency_overrides[dep] = factory
+    resp = _client(app).get("/requests/req-1/stream?timeout=1&interval=0.5")
+    assert resp.status_code == 403
+
+
+@pytest.mark.unit
+@pytest.mark.api
+@pytest.mark.timeout(30)
+def test_stream_endpoint_viewer_is_not_denied():
+    """Viewer-role caller passes the role gate on the SSE stream endpoint.
+
+    The orchestrator stub returns a terminal status so the generator exits
+    after one iteration — asyncio.sleep() is never reached.
+    """
+    app = _app_with_router(requests_router, "viewer", _stream_overrides())
+    resp = _client(app).get("/requests/req-1/stream?timeout=1&interval=0.5")
+    assert resp.status_code != 403
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The role-gate test for the SSE endpoint (`GET /requests/{id}/stream`) drove the endpoint through a body-draining `client.get(...)`, which entered the stream generator's poll loop and its `asyncio.sleep`. Under a newer `anyio` the `TestClient` streaming teardown can deadlock there when the full unit suite runs in parallel under `pytest-xdist`, hanging the unit leg for the whole per-test timeout.

The test only needs to assert the role gate — that a `viewer` is not `403`'d — which is decided at response-header time, before the stream body is produced. It never needs to consume the stream.

This removes the streaming endpoint from the shared body-draining parametrization and replaces it with dedicated stream tests that:
- assert the role gate in both directions (anonymous → 403, viewer → not 403), and
- stub the request-status orchestrator to a terminal state so the generator yields once and returns without ever hitting `asyncio.sleep`.

A `@pytest.mark.timeout(30)` marker is added as a backstop so any future stream hang fails fast instead of stalling the leg (the marker is registered because `addopts` uses `--strict-markers`).

Verified against the incoming `anyio` bump by pip-installing that version locally and running the file under `xdist` — no hang (`uv.lock` is untouched; the version bump lands via its own dependency PR).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code cleanup or refactor
- [ ] Dependencies update
- [ ] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

Ran `tests/unit/api/test_role_enforcement.py` under `pytest -n 2 --timeout=30` with the newer `anyio` installed in the venv — 62 passed, no hang. New stream tests pass without xdist. `pyright src/` 0, `ruff` clean.

## Test Configuration
* Python version: 3.12
* OS: macOS (darwin), Linux CI
* AWS region: n/a
* Dependencies changed: none (uv.lock untouched)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes

The streaming endpoint itself is unchanged — the fragility was entirely test-side (draining a live SSE poll loop in a unit test). This unblocks the pending dependency bump, which was surfacing the deadlock.

## Screenshots (if appropriate)
n/a

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

## Dependencies
None.

## Migration Guide
n/a

## Deployment Notes
None.

## Reviewers
@finos/open-resource-broker-maintainers
