### PR TITLE
ci(docs): fix Pages 404 and publish versioned documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ on:
   # sufficient — it runs immediately and is path-scoped to docs-relevant files.
 
 permissions:
-  contents: read
+  contents: write  # mike pushes to gh-pages branch
   pages: write
 
 concurrency:
@@ -75,10 +75,10 @@ jobs:
       - name: Build documentation
         run: |
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            # Build and deploy locally with mike (no push to remote)
-            make ci-docs-build-for-pages
+            # Deploy dev alias via mike, export docs/site for Pages upload.
+            bash dev-tools/docs/mike_deploy.sh dev --push
           else
-            # Build for PRs (validation only)
+            # PR path: strict build validation only — no versioning, no push.
             make ci-docs-build
           fi
 
@@ -103,3 +103,9 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Smoke-check deployed site
+        run: bash dev-tools/docs/smoke_check_pages.sh "${{ steps.deployment.outputs.page_url }}"

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -249,13 +249,15 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     permissions:
-      contents: read
+      contents: write
       pages: write
       id-token: write
 
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        fetch-depth: 0
 
     - name: Setup Python and UV
       uses: ./.github/actions/setup-uv-cached
@@ -263,8 +265,14 @@ jobs:
         cache-key: prod-docs-${{ needs.config.outputs.package-version }}
         fail-on-cache-miss: false
 
-    - name: Build documentation
-      run: make ci-docs-build-for-pages
+    - name: Compute minor version
+      id: version
+      run: |
+        VERSION_MINOR=$(echo "${{ needs.config.outputs.package-version }}" | cut -d. -f1,2)
+        echo "minor=${VERSION_MINOR}" >> "$GITHUB_OUTPUT"
+
+    - name: Deploy versioned docs via mike
+      run: bash dev-tools/docs/mike_deploy.sh release "${{ steps.version.outputs.minor }}" --push
 
     - name: Upload Pages artifact
       id: upload
@@ -275,6 +283,9 @@ jobs:
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5
+
+    - name: Smoke-check deployed site
+      run: bash dev-tools/docs/smoke_check_pages.sh "${{ steps.deployment.outputs.page_url }}"
 
   container-cleanup:
     name: Cleanup Old Container Images

--- a/dev-tools/docs/mike_deploy.sh
+++ b/dev-tools/docs/mike_deploy.sh
@@ -21,7 +21,6 @@ PUSH=false
 case "$MODE" in
     dev)
         VERSION_ARG=""
-        ALIAS="dev"
         PUSH_ARG="${2:-}"
         ;;
     release)

--- a/dev-tools/docs/mike_deploy.sh
+++ b/dev-tools/docs/mike_deploy.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+set -euo pipefail
+
+# mike_deploy.sh — deploy versioned docs via mike to the gh-pages branch,
+# then export the branch content to docs/site for Pages artifact upload.
+#
+# Usage:
+#   mike_deploy.sh dev [--push]
+#       Deploy/update the 'dev' alias from the current working tree.
+#
+#   mike_deploy.sh release <X.Y> [--push]
+#       Deploy version X.Y, update the 'latest' alias, and set latest as default.
+#
+# The --push flag (optional, must come last) pushes gh-pages to origin.
+# Omit it for local-only builds (PR validation, local testing).
+# Workflows pass --push on main/release deployments only.
+
+MODE="${1:-}"
+PUSH=false
+
+case "$MODE" in
+    dev)
+        VERSION_ARG=""
+        ALIAS="dev"
+        PUSH_ARG="${2:-}"
+        ;;
+    release)
+        VERSION_ARG="${2:-}"
+        if [ -z "$VERSION_ARG" ]; then
+            echo "ERROR: 'release' mode requires a version argument (e.g. mike_deploy.sh release 1.7)" >&2
+            exit 1
+        fi
+        PUSH_ARG="${3:-}"
+        ;;
+    *)
+        echo "ERROR: Unknown mode '${MODE}'. Use: dev [--push] | release <X.Y> [--push]" >&2
+        exit 1
+        ;;
+esac
+
+if [ "${PUSH_ARG:-}" = "--push" ]; then
+    PUSH=true
+fi
+
+echo "==> mike_deploy.sh: mode=${MODE}${VERSION_ARG:+ version=${VERSION_ARG}} push=${PUSH}"
+
+# Configure git identity in CI (mike needs a committer to write to gh-pages).
+if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "==> Configuring git identity for CI..."
+    git config --global user.name "github-actions[bot]"
+    git config --global user.email "github-actions[bot]@users.noreply.github.com"
+fi
+
+# Ensure local gh-pages branch exists for mike to write to.
+# The branch may not exist yet on origin (first deploy creates it).
+# If it does exist on origin, fetch it so mike sees the existing version history.
+echo "==> Checking for gh-pages branch on origin..."
+if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+    echo "==> Found gh-pages on origin — fetching..."
+    git fetch origin gh-pages:gh-pages 2>/dev/null || git fetch origin gh-pages
+else
+    echo "==> gh-pages branch not found on origin — mike will initialise it on first deploy."
+fi
+
+# Run mike deploy.
+echo "==> Running mike deploy (mode=${MODE})..."
+case "$MODE" in
+    dev)
+        uv run mike deploy \
+            --config-file docs/mkdocs.yml \
+            --branch gh-pages \
+            dev
+        ;;
+    release)
+        uv run mike deploy \
+            --config-file docs/mkdocs.yml \
+            --branch gh-pages \
+            --update-aliases \
+            "${VERSION_ARG}" latest
+        echo "==> Setting 'latest' as default..."
+        uv run mike set-default \
+            --config-file docs/mkdocs.yml \
+            --branch gh-pages \
+            latest
+        ;;
+esac
+echo "==> mike deploy complete."
+
+# Optionally push gh-pages to origin.
+if [ "$PUSH" = "true" ]; then
+    echo "==> Pushing gh-pages to origin..."
+    git push origin gh-pages
+    echo "==> Push complete."
+fi
+
+# Export the gh-pages branch content to docs/site for artifact upload.
+# actions/upload-pages-artifact expects a plain directory tree.
+echo "==> Exporting gh-pages branch to docs/site..."
+rm -rf docs/site
+mkdir -p docs/site
+
+# Use git archive to extract the branch content — avoids worktree cleanup issues
+# in CI environments where the worktree directory may already be in use.
+git archive gh-pages | tar -x -C docs/site
+
+# Strip any stray .git file/directory that git archive might have included.
+rm -rf docs/site/.git
+
+echo "==> Verifying docs/site content..."
+if [ ! -f "docs/site/versions.json" ]; then
+    echo "ERROR: docs/site/versions.json not found — mike deploy may have failed." >&2
+    exit 1
+fi
+
+# Root index.html (redirect to default alias) is only created by 'mike set-default'.
+# On the very first dev deploy, no default has been set yet, so index.html may be
+# absent — that is expected.  The release path always calls set-default, so by the
+# time the full site is live, index.html will exist.
+if [ ! -f "docs/site/index.html" ]; then
+    if [ "$MODE" = "release" ]; then
+        echo "ERROR: docs/site/index.html not found after release deploy — root redirect is missing." >&2
+        exit 1
+    else
+        echo "==> NOTE: docs/site/index.html not present yet (no default alias set). This is expected on first dev deploy."
+    fi
+fi
+
+echo "==> docs/site contents (top-level):"
+ls -1 docs/site/
+
+echo "==> versions.json:"
+cat docs/site/versions.json
+
+echo "==> mike_deploy.sh complete. docs/site is ready for Pages artifact upload."

--- a/dev-tools/docs/smoke_check_pages.sh
+++ b/dev-tools/docs/smoke_check_pages.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -euo pipefail
+
+# smoke_check_pages.sh — post-deploy smoke check for GitHub Pages docs site.
+#
+# Usage: smoke_check_pages.sh <base_url>
+#   base_url: the root URL of the deployed Pages site, e.g.
+#             https://finos.github.io/open-resource-broker/
+#
+# Checks performed:
+#   1. Root URL (/) returns HTTP 200 and contains real HTML content.
+#   2. /versions.json returns HTTP 200 and is valid JSON with at least one version.
+#   3. A versioned index page (/dev/ or /latest/) returns HTTP 200.
+#   4. A known nav page under /latest/ returns HTTP 200.
+#
+# Exit code 0 = all checks passed.
+# Exit code 1 = one or more checks failed (details printed to stderr).
+
+BASE_URL="${1:-}"
+if [ -z "$BASE_URL" ]; then
+    echo "ERROR: base_url argument is required." >&2
+    echo "Usage: smoke_check_pages.sh <base_url>" >&2
+    exit 1
+fi
+
+# Normalise: strip trailing slash for consistent path joining.
+BASE_URL="${BASE_URL%/}"
+
+PASS=0
+FAIL=0
+
+check_url() {
+    local label="$1"
+    local url="$2"
+    local grep_pattern="${3:-}"
+
+    echo "==> Checking: ${label} (${url})"
+
+    http_code=$(curl --silent --show-error --write-out "%{http_code}" \
+        --max-time 30 --retry 3 --retry-delay 5 \
+        --location --output /tmp/smoke_check_body.html \
+        "${url}" 2>/tmp/smoke_check_curl_err.txt || true)
+
+    if [ "${http_code}" != "200" ]; then
+        echo "  FAIL: expected HTTP 200, got ${http_code}" >&2
+        cat /tmp/smoke_check_curl_err.txt >&2 || true
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if [ -n "${grep_pattern}" ]; then
+        if ! grep -q "${grep_pattern}" /tmp/smoke_check_body.html 2>/dev/null; then
+            echo "  FAIL: pattern '${grep_pattern}' not found in response body." >&2
+            FAIL=$((FAIL + 1))
+            return
+        fi
+    fi
+
+    # Soft-404 guard: real pages should not contain common 404 page markers.
+    if grep -qi "page not found\|404 - not found\|isn't available\|File not found" \
+            /tmp/smoke_check_body.html 2>/dev/null; then
+        echo "  FAIL: response body looks like a soft-404 page." >&2
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    echo "  PASS: HTTP 200 OK"
+    PASS=$((PASS + 1))
+}
+
+check_versions_json() {
+    local url="${BASE_URL}/versions.json"
+    echo "==> Checking: versions.json (${url})"
+
+    http_code=$(curl --silent --show-error --write-out "%{http_code}" \
+        --max-time 30 --retry 3 --retry-delay 5 \
+        --location --output /tmp/smoke_check_versions.json \
+        "${url}" 2>/tmp/smoke_check_curl_err.txt || true)
+
+    if [ "${http_code}" != "200" ]; then
+        echo "  FAIL: versions.json returned HTTP ${http_code} (expected 200)." >&2
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    # Validate JSON and require at least one version entry.
+    if ! python3 -c "
+import json, sys
+data = json.load(open('/tmp/smoke_check_versions.json'))
+if not isinstance(data, list) or len(data) == 0:
+    print('  FAIL: versions.json is empty or not an array', file=sys.stderr)
+    sys.exit(1)
+print(f'  versions.json contains {len(data)} version(s): {[v.get(\"version\",\"?\") for v in data]}')
+" 2>/tmp/smoke_check_versions_err.txt; then
+        echo "  FAIL: versions.json is not valid JSON or contains no versions." >&2
+        cat /tmp/smoke_check_versions_err.txt >&2 || true
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    echo "  PASS: versions.json is valid JSON with at least one version."
+    PASS=$((PASS + 1))
+}
+
+echo "==> Starting smoke check for: ${BASE_URL}"
+echo ""
+
+# Check 1: Root returns 200 and looks like a real HTML page (not a 404).
+check_url "Root redirect" "${BASE_URL}/" "<html"
+
+# Check 2: versions.json exists and is valid.
+check_versions_json
+
+# Check 3: versioned index (try 'latest' first, fall back to 'dev').
+# We attempt both aliases; a passing result on either satisfies the check.
+echo "==> Checking: versioned alias index (/latest/ or /dev/)"
+latest_code=$(curl --silent --write-out "%{http_code}" --max-time 15 \
+    --location --output /dev/null "${BASE_URL}/latest/" 2>/dev/null || echo "000")
+dev_code=$(curl --silent --write-out "%{http_code}" --max-time 15 \
+    --location --output /dev/null "${BASE_URL}/dev/" 2>/dev/null || echo "000")
+
+if [ "${latest_code}" = "200" ] || [ "${dev_code}" = "200" ]; then
+    echo "  PASS: versioned alias reachable (latest=${latest_code}, dev=${dev_code})"
+    PASS=$((PASS + 1))
+else
+    echo "  FAIL: neither /latest/ (${latest_code}) nor /dev/ (${dev_code}) returned 200." >&2
+    FAIL=$((FAIL + 1))
+fi
+
+# Check 4: A known nav page under /latest/; fall back to /dev/ if latest not deployed.
+if [ "${latest_code}" = "200" ]; then
+    alias_prefix="latest"
+else
+    alias_prefix="dev"
+fi
+check_url "Nav page (${alias_prefix}/getting_started/quick_start/)" \
+    "${BASE_URL}/${alias_prefix}/getting_started/quick_start/" "<html"
+
+echo ""
+echo "==> Smoke check results: ${PASS} passed, ${FAIL} failed."
+
+if [ "${FAIL}" -gt 0 ]; then
+    echo "FAIL: smoke check failed — ${FAIL} check(s) did not pass." >&2
+    exit 1
+fi
+
+echo "PASS: all smoke checks passed."

--- a/makefiles/deploy.mk
+++ b/makefiles/deploy.mk
@@ -50,8 +50,8 @@ docs-clean:  ## Clean documentation build files
 ci-docs-build:  ## Build documentation for CI PR testing (matches docs.yml PR builds)
 	@dev-tools/docs/ci_docs_build.sh
 
-ci-docs-build-for-pages:  ## Build documentation for GitHub Pages deployment (no push)
-	@dev-tools/docs/ci_docs_build_for_pages.sh
+ci-docs-build-for-pages:  ## Deploy dev alias via mike and export docs/site (no push)
+	@bash dev-tools/docs/mike_deploy.sh dev
 
 ci-docs-deploy:  ## Deploy documentation to GitHub Pages (matches docs.yml main branch)
 	@dev-tools/docs/ci_docs_deploy.sh


### PR DESCRIPTION
## Description

Fixes the docs 404 and adds versioned documentation.

**Root cause of the 404:** GitHub Pages was set to the *legacy* build type (serve from the `main` branch root). GitHub ran its own Jekyll build of the repo root — which has no `index.html` (docs live under `docs/`) — so it served nothing while the docs workflow's artifact deploy reported green. Two publishers, one site: the legacy build won and served a 404. Pages has been switched to the **GitHub Actions build type** so the workflow is the sole publisher; a failed workflow can no longer replace the live site.

**Versioned docs (this PR):** wires `mike` into CI so documentation is versioned:
- Pushes to `main` update a `dev` alias (unreleased tip).
- Production releases publish docs at their `MAJOR.MINOR` version and move the `latest` alias to it; the site root redirects to the newest release.
- Pull requests build with `--strict` for validation only and never publish.
- The version switcher shows released versions plus `dev`; feature branches do not create version entries.

Two shared scripts back this: `mike_deploy.sh` (deploy dev/release to the `gh-pages` version store, then export that tree into `docs/site` for the Pages artifact) and `smoke_check_pages.sh` (post-deploy verification — asserts the live site serves real content and a valid versions manifest, failing the run otherwise so a broken deploy shows red).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Ran `mike_deploy.sh dev` and `mike_deploy.sh release 1.7` locally: `docs/site` is produced with a valid `versions.json` (dev + 1.7 + latest), and the release path writes the root `index.html` redirect to `latest/`. Both workflows pass YAML/actionlint validation. `smoke_check_pages.sh` asserts status, content, and the versions manifest against the deployed URL.

## Test Configuration
* Python version: 3.12
* OS: macOS (darwin), Linux CI
* AWS region: n/a
* Dependencies changed: none (mike already a CI dependency)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes

Two repository-settings changes were made alongside this PR (not in the diff): Pages build type switched legacy → GitHub Actions, and the stale `gh-pages` branch (old, unused build output) was removed. `mike` recreates `gh-pages` cleanly as its version store on the first deploy. Versioning starts fresh at the current release; older versions can be backfilled later with the existing `make docs-deploy-version` target if wanted.

## Screenshots (if appropriate)
n/a

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

## Dependencies
None.

## Migration Guide

The release docs job (`prod-docs` in `prod-release.yml`) now requires `contents: write` (scoped to that job only) so `mike` can push the `gh-pages` version store. No action needed by consumers; the docs site URL is unchanged.

## Deployment Notes

Pages must remain on the GitHub Actions build type (already set). The first release after merge initialises the `gh-pages` version store and sets the root redirect; the post-deploy smoke check will fail the run red if the live site does not serve correctly.

## Reviewers
@finos/open-resource-broker-maintainers
