### PR TITLE
ci: fix corrupted OpenSSF Scorecard action pin

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b3f5e0ba  # v2.4.1
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif


### PR DESCRIPTION
## Description

The OpenSSF Scorecard workflow was failing at job setup with:

```
Unable to resolve action `ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b3f5e0ba`, unable to find version
```

**Root cause:** the pinned commit SHA for `ossf/scorecard-action` does not exist. The comment claims `v2.4.1`, but the real v2.4.1 commit is `f49aabe0b5af0936a0987cfb85d86b75731b0186` — the pinned value has a mangled tail (`...b3f5e0ba` instead of `...731b0186`), i.e. a bad paste. Since no such commit exists, the action can't be resolved and the job dies before running.

**Fix:** pin the verified commit SHA for the current `v2.4.3` release (`4eaacf0543bb3f2c246792bd56e8cdeffafb205a`, confirmed by dereferencing the annotated tag). This also moves the action forward two patch releases.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Verified the new SHA against the upstream repo: `v2.4.3` annotated tag dereferences to commit `4eaacf0543bb3f2c246792bd56e8cdeffafb205a`. YAML parses cleanly. The other two pinned actions in the file (`actions/checkout@v7.0.0`, `github/codeql-action/upload-sarif@v4`) were sanity-checked and resolve.

## Test Configuration
* Python version: n/a (CI workflow change)
* OS: Linux CI
* AWS region: n/a
* Dependencies changed: ossf/scorecard-action v2.4.1(broken pin) → v2.4.3

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes

Pre-existing issue, unrelated to recent docs work — the broken pin was introduced when the Scorecard workflow was added. The SHA is pinned (not a floating tag) per the repo's supply-chain hardening convention, with the human-readable version in the trailing comment.

## Screenshots (if appropriate)
n/a

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

## Dependencies
`ossf/scorecard-action` pin corrected to v2.4.3.

## Migration Guide
n/a

## Deployment Notes
None.

## Reviewers
@finos/open-resource-broker-maintainers
