### PR TITLE
ci(docs): trigger docs deploy when deploy scripts change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'dev-tools/docs/**'
       - 'src/**/cli/**'
       - 'README.md'
       - '*.md'
@@ -14,10 +15,12 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'dev-tools/docs/**'
       - 'src/**/cli/**'
       - 'README.md'
       - '*.md'
       - 'pyproject.toml'
+      - '.github/workflows/docs.yml'
   # workflow_dispatch: allows triggering docs builds manually from the Actions UI
   workflow_dispatch:
   # NOTE: workflow_run trigger removed.  It fired after "Quality Checks" and


### PR DESCRIPTION
## Description

The docs site root is still 404 even though the root-redirect fix (#305) merged.

**Why:** #305 changed only `dev-tools/docs/mike_deploy.sh`, but the Documentation workflow's `push`/`pull_request` path filters do not include `dev-tools/docs/**`. The workflow *runs* those scripts (`mike_deploy.sh`, `smoke_check_pages.sh`) but isn't *triggered* when they change — so the merge never re-ran the docs deploy and the live site stayed stale.

**Fix:** add `dev-tools/docs/**` to both the `push` and `pull_request` path filters (and add `.github/workflows/docs.yml` to the PR filter for parity with `push`). Merging this PR touches `docs.yml`, which is in the filter, so it triggers the docs deploy — which now runs the merged root-redirect fix and restores the site.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Confirmed the current live state: `/versions.json`, `/dev/`, and `/dev/getting_started/quick_start/` all return 200, but `/` returns 404 because the root-redirect fix never deployed. YAML validated. Merging this triggers the deploy that applies the already-merged fix.

## Test Configuration
* Python version: n/a
* OS: Linux CI
* AWS region: n/a
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes

This is the trigger-side complement to #305 (the logic fix). The path-filter gap is why a correct fix appeared not to take effect.

## Screenshots (if appropriate)
n/a

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

## Dependencies
None.

## Migration Guide
n/a

## Deployment Notes

On merge, the Documentation workflow runs and republishes `dev` with the root redirect from #305, restoring the site root.

## Reviewers
@finos/open-resource-broker-maintainers
