### PR TITLE
ci: fix imposter codeql-action pin across workflows

### DIFF
--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -203,7 +203,7 @@ jobs:
         severity: ${{ env.SCAN_LEVEL == 'full' && 'CRITICAL,HIGH,MEDIUM' || 'CRITICAL,HIGH' }}
 
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+      uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
       if: always()
       with:
         sarif_file: 'trivy-results-py${{ matrix.python-version }}.sarif'
@@ -219,7 +219,7 @@ jobs:
 
     - name: Upload Hadolint scan results
       if: matrix.python-version == needs.config.outputs.default-python-version
-      uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+      uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
       with:
         sarif_file: hadolint-dockerfile.sarif
 

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload Semgrep SARIF results
         if: inputs.scan-type == 'semgrep' && always()
-        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           sarif_file: semgrep.sarif
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload Trivy filesystem scan results
         if: inputs.scan-type == 'trivy-fs' && always()
-        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           sarif_file: 'trivy-fs-results.sarif'
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload Hadolint SARIF results
         if: inputs.scan-type == 'hadolint' && always()
-        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           sarif_file: hadolint-results.sarif
 
@@ -144,7 +144,7 @@ jobs:
       #   TODO: ensure branch protection prevents direct pushes to main.
       - name: Initialize CodeQL
         if: inputs.scan-type == 'codeql'
-        uses: github/codeql-action/init@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           languages: python
           queries: security-extended,security-and-quality
@@ -153,13 +153,13 @@ jobs:
 
       - name: Initialize CodeQL (fallback)
         if: inputs.scan-type == 'codeql' && steps.codeql-init-extended.outcome == 'failure'
-        uses: github/codeql-action/init@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           languages: python
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
         if: inputs.scan-type == 'codeql'
-        uses: github/codeql-action/analyze@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           category: "/language:python"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,6 +35,6 @@ jobs:
           publish_results: true
 
       - name: Upload Scorecard SARIF results
-        uses: github/codeql-action/upload-sarif@dc73d59c2d7bd4f8194098a91219eeee6d8a1719  # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## Description

After the Scorecard action pin was corrected (#306), the Scorecard workflow *ran* and scored the project (7.4) — but the run still failed at the publish step with:

```
workflow verification failed: imposter commit: dc73d59c2d7bd4f8194098a91219eeee6d8a1719
does not belong to github/codeql-action/upload-sarif
```

**Root cause:** the pinned commit SHA for `github/codeql-action` does not exist in that repository (upstream returns "no commit found" — a fabricated/imposter SHA, same bad-paste class as the Scorecard pin). The OpenSSF Scorecard publish endpoint validates action pins and rejects imposter commits with HTTP 400, so the run fails even though the analysis itself succeeded. The same bad SHA was pinned in **9 places** across three workflows (`scorecard.yml`, `dev-containers.yml`, `reusable-security.yml`), covering `codeql-action/init`, `analyze`, and `upload-sarif`.

**Fix:** repin every `github/codeql-action` use to the verified commit for `v4.37.0` (`99df26d4f13ea111d4ec1a7dddef6063f76b97e9`).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Confirmed the old SHA resolves to no commit in `github/codeql-action` (HTTP 422) and the new SHA is the real `v4.37.0` commit (dated 2026-07-08). All three workflow files parse as valid YAML. The imposter SHA no longer appears anywhere under `.github/`.

## Test Configuration
* Python version: n/a
* OS: Linux CI
* AWS region: n/a
* Dependencies changed: github/codeql-action pin corrected → v4.37.0

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes

Complements #306 (which fixed the Scorecard action's own imposter pin). This is the second imposter SHA in the same security-hardening commit. Only `scorecard.yml` *failed* on it (its publish step validates pins), but the same broken pin affected CodeQL init/analyze/upload across `dev-containers.yml` and `reusable-security.yml`, so all nine occurrences are corrected together. With both #306 and this merged, the Scorecard run should complete green and populate the securityscorecards.dev API (prerequisite for adding the OpenSSF badge later).

## Screenshots (if appropriate)
n/a

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

## Dependencies
`github/codeql-action` pin corrected to v4.37.0.

## Migration Guide
n/a

## Deployment Notes
None.

## Reviewers
@finos/open-resource-broker-maintainers
