### PR TITLE
ci: fix three unresolvable pinned action SHAs

### DIFF
--- a/.github/actions/setup-uv-cached/action.yml
+++ b/.github/actions/setup-uv-cached/action.yml
@@ -13,7 +13,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install UV
-      uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9  # v7
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
 
     - name: Restore UV environment
       id: restore-cache

--- a/.github/actions/setup-uv-fresh/action.yml
+++ b/.github/actions/setup-uv-fresh/action.yml
@@ -21,7 +21,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Install UV
-      uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9  # v7
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
       with:
         version: "0.9.6"
         enable-cache: true

--- a/.github/workflows/dev-pypi.yml
+++ b/.github/workflows/dev-pypi.yml
@@ -89,7 +89,7 @@ jobs:
         fail-on-cache-miss: false
 
     - name: Setup Bun (for UI static bundle)
-      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f4b11  # v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
       with:
         bun-version: "1.2.15"  # pinned; update intentionally to avoid surprise breakage
 

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -62,7 +62,7 @@ jobs:
         fail-on-cache-miss: false
 
     - name: Setup Bun (for UI static bundle)
-      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f4b11  # v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
       with:
         bun-version: "1.2.15"  # pinned; update intentionally to avoid surprise breakage
 
@@ -114,7 +114,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Download release wheel
-      uses: actions/download-artifact@fa0a91b85d4f404e444306234a8ac7fed6c1d3f4  # v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
       with:
         name: release-wheel-${{ needs.config.outputs.package-version }}
         path: dist/
@@ -228,7 +228,7 @@ jobs:
         fail-on-cache-miss: false
 
     - name: Download release wheel
-      uses: actions/download-artifact@fa0a91b85d4f404e444306234a8ac7fed6c1d3f4  # v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
       with:
         name: release-wheel-${{ needs.config.outputs.package-version }}
         path: dist/
@@ -324,7 +324,7 @@ jobs:
         fail-on-cache-miss: false
 
     - name: Download release wheel
-      uses: actions/download-artifact@fa0a91b85d4f404e444306234a8ac7fed6c1d3f4  # v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
       with:
         name: release-wheel-${{ needs.config.outputs.package-version }}
         path: dist/

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -113,7 +113,7 @@ jobs:
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
 
       - name: Setup Bun (for UI static bundle)
-        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f4b11  # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: "1.2.15"  # pinned; update intentionally to avoid surprise breakage
 


### PR DESCRIPTION
## Description
Dependabot pinned commit SHAs that do not exist in the upstream action repos, breaking the Semantic Release, dev-pypi, and prod-release workflows with errors like:

```
Unable to resolve action `oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f4b11`, unable to find version `735343b667d3e6f658f44d0eca948eb6282f4b11`
```

Audited all 39 pinned `action@sha` refs across `.github/` against the GitHub API. Three were unresolvable. Fixed them and, where the repo already used a newer major elsewhere, aligned these stragglers to it (so pins are latest + consistent repo-wide):

| Action | Was | Now | Note |
|---|---|---|---|
| `actions/download-artifact` | `fa0a91b` (#v4, not found) | `3e5f45b` (**#v8**, latest) | matches the v8 pin already used in ci-tests; all usages here are single-name downloads, unaffected by v5+ changes |
| `astral-sh/setup-uv` | `94527f2` (#v7) | `11f9893` (**#v8.3.2**, latest) | old value was a **tag object** SHA, not a commit — Actions requires a commit SHA; new pin matches semantic-release |
| `oven-sh/setup-bun` | `735343b` (#v2, not found) | `0c5077e` (#v2, latest v2) | current major |

The remaining 36 pinned SHAs all resolve correctly against the API.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [x] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Re-ran the full GitHub API SHA-resolution audit across every `uses: <action>@<sha>` ref in `.github/` after applying the fixes — zero unresolvable SHAs remain, each confirmed to resolve as a **commit** (not a tag object). Reviewed the affected usages for breaking-change exposure before bumping:
- **download-artifact v4→v8**: all three usages (prod-release) download a single named artifact via `name:`+`path:`; v5+ breaking changes affect only the no-name download-all path and upload immutability — not used here.
- **setup-uv v7→v8**: both composite actions pass only `version`/`enable-cache`/`cache-*` inputs, all stable across v7→v8.

## Test Configuration
* Python version: n/a (workflow-only change)
* OS: n/a
* AWS region: n/a
* Dependencies changed: three GitHub Action pins corrected + bumped to latest major

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes
Root cause is Dependabot occasionally writing a non-existent or tag-object SHA when bumping actions. A CI guard that validates every pinned action SHA on PR (fails on any unresolvable ref) would prevent recurrence — happy to add it as a follow-up if wanted.

## Security Considerations
- [x] No security implications

All three remain full 40-char commit-SHA pins — no loosening to tags/branches, so supply-chain pinning posture is unchanged (and `setup-uv` is now pinned to an actual commit rather than a tag object).

## Reviewers
@finos/open-resource-broker-maintainers
