### PR TITLE
fix(build): compile SPA into the wheel via a build hook + ui-export CLI + app-token client-id

### DIFF
--- a/.github/actions/orb-cicd-app-token/action.yml
+++ b/.github/actions/orb-cicd-app-token/action.yml
@@ -2,8 +2,8 @@ name: 'ORB CICD App Token'
 description: 'Mint an installation token for the ORB CICD GitHub App and resolve its bot identity for git commit attribution.'
 
 inputs:
-  app-id:
-    description: 'GitHub App ID (from secrets.GH_APP_ID)'
+  client-id:
+    description: 'GitHub App Client ID (from secrets.GH_APP_CLIENT_ID)'
     required: true
   private-key:
     description: 'GitHub App private key (from secrets.GH_APP_PRIVATE_KEY)'
@@ -33,7 +33,7 @@ runs:
       id: app-token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
       with:
-        app-id: ${{ inputs.app-id }}
+        client-id: ${{ inputs.client-id }}
         private-key: ${{ inputs.private-key }}
         # Scope token to this repository only (prevents inadvertent org-wide access)
         repositories: ${{ github.event.repository.name }}

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -83,7 +83,7 @@ jobs:
         id: cicd
         uses: ./.github/actions/orb-cicd-app-token
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Setup UV with cache

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -229,6 +229,10 @@ jobs:
         fail-on-cache-miss: false
 
     - name: Build package
+      # This job builds a wheel artifact for CI validation only and has no
+      # bun/uv to compile the SPA (it never shipped one).  Skip the UI build.
+      env:
+        ORB_SKIP_UI_BUILD: "1"
       run: make build
 
     - name: Upload build artifacts

--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -127,6 +127,10 @@ jobs:
         fail-on-cache-miss: false
 
     - name: Build package wheel
+      # This job builds a wheel to scan in a container image and has no bun/uv
+      # to compile the SPA (it never shipped one).  Skip the UI build.
+      env:
+        ORB_SKIP_UI_BUILD: "1"
       run: make build
 
     - name: Build and scan container image

--- a/.github/workflows/dev-pypi.yml
+++ b/.github/workflows/dev-pypi.yml
@@ -93,9 +93,8 @@ jobs:
       with:
         bun-version: "1.2.15"  # pinned; update intentionally to avoid surprise breakage
 
-    - name: Build UI static bundle
-      run: make ui-build
-
+    # The SPA bundle is built automatically by the setuptools build hook during
+    # `make build-with-version` (python -m build). No separate step needed.
     - name: Build package
       run: |
         make build-with-version

--- a/.github/workflows/package-testing.yml
+++ b/.github/workflows/package-testing.yml
@@ -17,6 +17,12 @@ on:
 permissions:
   contents: read
 
+# This workflow only tests install/import variants of the built wheel — it never
+# needs the Reflex SPA bundle, and its runners have no bun/uv to build one.  Skip
+# the SPA build hook (setup.py) for every `python -m build` in this file.
+env:
+  ORB_SKIP_UI_BUILD: "1"
+
 # Per-ref concurrency: prevents a rapid series of pushes to main from queuing
 # redundant package-testing runs.  Each ref can only have one run active at a
 # time; a newer push cancels the older in-progress run.

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -66,9 +66,8 @@ jobs:
       with:
         bun-version: "1.2.15"  # pinned; update intentionally to avoid surprise breakage
 
-    - name: Build UI static bundle
-      run: make ui-build
-
+    # The SPA bundle is built automatically by the setuptools build hook during
+    # `make build` (python -m build). No separate step needed.
     - name: Build package wheel
       run: make build
 

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -106,7 +106,7 @@ jobs:
         id: cicd
         uses: ./.github/actions/orb-cicd-app-token
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Setup UV
@@ -117,12 +117,17 @@ jobs:
         with:
           bun-version: "1.2.15"  # pinned; update intentionally to avoid surprise breakage
 
-      - name: Build UI static bundle
+      # Build the SPA bundle HERE, on the host, where Setup Bun put bun on PATH.
+      # This must run on the host — NOT via the setup.py build hook — because the
+      # next step (Python Semantic Release) runs `make semantic-release-build`
+      # (python -m build) INSIDE a Docker container that has no bun/uv/curl.  With
+      # the bundle already at src/orb/ui/_static/, the in-container build hook
+      # sees it present and skips the build, so `python -m build` succeeds.
+      # build_ui.sh uses an ephemeral venv under $TMPDIR (auto-removed), so no
+      # host .venv is left to break the container's mounted-workspace interpreter.
+      - name: Build UI static bundle (host — bun is unavailable in the release container)
         run: make ui-build
 
-      # Do NOT `uv sync` here: the next step is a Docker action that mounts
-      # the workspace, so a host .venv would be visible inside the container
-      # with a dangling interpreter and break `make semantic-release-build`.
       - name: Python Semantic Release
         id: release
         uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e  # v10.6.1

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   <br>
   <a href="https://codecov.io/gh/finos/open-resource-broker"><img src="https://codecov.io/gh/finos/open-resource-broker/graph/badge.svg" alt="Coverage"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/finos/open-resource-broker"><img src="https://api.securityscorecards.dev/projects/github.com/finos/open-resource-broker/badge" alt="OpenSSF Scorecard"></a>
+  <a href="https://www.bestpractices.dev/projects/13611"><img src="https://www.bestpractices.dev/projects/13611/badge" alt="OpenSSF Best Practices"></a>
 </p>
 
 ---
@@ -75,6 +76,14 @@ orb requests status <request-id>
 
 ```bash
 orb machines return <machine-id-1> <machine-id-2> ...
+```
+
+### 5. Check the return status
+
+`machines return` prints a return-request id; check it the same way as step 3:
+
+```bash
+orb requests status <return-request-id>
 ```
 
 ## Setup

--- a/dev-tools/package/build_ui.sh
+++ b/dev-tools/package/build_ui.sh
@@ -63,23 +63,88 @@ if [ -z "$BUN" ] || [ ! -x "$BUN" ]; then
 fi
 
 log "INFO: Building UI static bundle..."
-log "INFO: Ensuring [ui] extras are installed..."
-uv pip install --quiet '.[ui]'
 
-# Resolve how to invoke ``reflex`` without hard-coding a venv layout.  The rest
-# of the repo (see dev-tools/docs/ci_docs_build.sh, dev-tools/package/build.sh,
-# makefiles/*.mk) prefers ``uv run`` when uv is on PATH and falls back to the
-# repo-local ``.venv/bin/`` entry points otherwise.  That covers all three
-# supported environments: developer editable install, CI's uv-cached .venv,
-# and a fresh clone driven by ``make dev-install``.
+# ---------------------------------------------------------------------------
+# Venv / reflex setup
+#
+# Strategy: prefer an already-active venv or the project's .venv so that
+# incremental dev builds are fast.  If neither exists, create an ephemeral
+# venv, install .[ui] into it, run the build, and delete it afterward.
+#
+# The [ui] extra (reflex→click>=8.2) conflicts with the dev/ci groups
+# (semgrep→click<8.2), so we NEVER sync from the full lockfile — we always
+# install .[ui] directly into whichever venv we end up using.
+# ---------------------------------------------------------------------------
+
+EPHEMERAL_VENV=""
+
+# Ephemeral venvs live under one deterministic parent so orphans left by an
+# uncatchable kill (SIGKILL / OOM / CI timeout, which no trap can intercept)
+# can be reaped on the next run rather than accumulating on a long-lived host.
+_EPHEMERAL_BASE="${TMPDIR:-/tmp}/orb-ui-build-venvs"
+
+# Ensure this run's ephemeral venv is removed even if the build fails mid-way.
+_cleanup_ephemeral() {
+    if [ -n "$EPHEMERAL_VENV" ]; then
+        rm -rf "$(dirname "$EPHEMERAL_VENV")" 2>/dev/null || true
+    fi
+}
+# EXIT covers normal/`set -e`/SIGINT/SIGTERM exits; INT/TERM added explicitly so
+# cleanup runs before the shell re-raises them.  SIGKILL is uncatchable, so a
+# hard kill can still orphan this run's venv — grouping all ephemeral venvs
+# under one predictable base ($_EPHEMERAL_BASE) means such orphans cluster in a
+# single dir for the OS/CI tmp reaper (or a manual `rm -rf`) to clean, instead
+# of scattering across random mktemp paths.  No auto-sweep here: wiping the base
+# at startup would race a concurrent build sharing the same host.
+trap _cleanup_ephemeral EXIT INT TERM
+
+# Detect whether we are already inside a usable venv (VIRTUAL_ENV is set by
+# `source activate`; UV_PROJECT_ENVIRONMENT is set by uv itself).
+_active_venv="${VIRTUAL_ENV:-${UV_PROJECT_ENVIRONMENT:-}}"
+
+if [ -n "$_active_venv" ] && [ -x "$_active_venv/bin/python" ]; then
+    log "INFO: Using active virtual environment: $_active_venv"
+    _VENV_BIN="$_active_venv/bin"
+elif [ -x "$PROJECT_ROOT/.venv/bin/python" ]; then
+    log "INFO: Using project .venv: $PROJECT_ROOT/.venv"
+    _VENV_BIN="$PROJECT_ROOT/.venv/bin"
+else
+    # No usable venv — create an ephemeral one under the deterministic base.
+    log "INFO: No virtual environment found; creating an ephemeral one..."
+    mkdir -p "$_EPHEMERAL_BASE"
+    EPHEMERAL_VENV="$(mktemp -d "$_EPHEMERAL_BASE/XXXXXX")/orb-ui-build-venv"
+    if command -v uv >/dev/null 2>&1; then
+        uv venv --quiet "$EPHEMERAL_VENV"
+    else
+        python3 -m venv "$EPHEMERAL_VENV"
+    fi
+    _VENV_BIN="$EPHEMERAL_VENV/bin"
+    log "INFO: Ephemeral venv created at $EPHEMERAL_VENV"
+fi
+
+# Install .[ui] into the chosen venv.  Use uv pip when available (faster);
+# fall back to the venv's own pip.
+log "INFO: Ensuring [ui] extras are installed..."
+# Installing '.[ui]' builds the orb-py wheel, which runs setup.py's build_py
+# hook — which calls THIS script.  Set ORB_SKIP_UI_BUILD=1 for the nested
+# build so it does not recurse (we are already inside the UI build).
 if command -v uv >/dev/null 2>&1; then
-    REFLEX=(uv run reflex)
-elif [ -x "$PROJECT_ROOT/.venv/bin/reflex" ]; then
-    REFLEX=("$PROJECT_ROOT/.venv/bin/reflex")
+    ORB_SKIP_UI_BUILD=1 VIRTUAL_ENV="$(dirname "$_VENV_BIN")" uv pip install --quiet '.[ui]'
+else
+    ORB_SKIP_UI_BUILD=1 "$_VENV_BIN/pip" install --quiet "$(pwd)[ui]"
+fi
+
+# Invoke reflex from the venv we installed .[ui] into.  Call the venv binary
+# directly rather than ``uv run``: ``uv run`` resolves reflex against uv's
+# *project* environment, which is NOT $_VENV_BIN when we created an ephemeral
+# venv (or when an unrelated venv is active) — so it would miss the reflex we
+# just installed.  The .[ui] install above guarantees $_VENV_BIN/reflex exists.
+if [ -x "$_VENV_BIN/reflex" ]; then
+    REFLEX=("$_VENV_BIN/reflex")
 elif command -v reflex >/dev/null 2>&1; then
     REFLEX=(reflex)
 else
-    echo "ERROR: reflex not found. Run 'make dev-install' or install '.[ui]' extras." >&2
+    echo "ERROR: reflex not found in $_VENV_BIN. Check the '.[ui]' install above." >&2
     exit 1
 fi
 
@@ -137,3 +202,4 @@ log "SUCCESS: Static bundle written to $STATIC_DIR/"
 if [ "$QUIET" = false ]; then
     du -sh "$STATIC_DIR" 2>/dev/null || true
 fi
+# The EXIT trap (_cleanup_ephemeral) removes the ephemeral venv if one was created.

--- a/makefiles/dev.mk
+++ b/makefiles/dev.mk
@@ -173,6 +173,10 @@ clean:  ## Clean up build artifacts
 	rm -rf build/
 	rm -rf dist/
 	rm -rf *.egg-info
+	# Wipe the compiled SPA so a fresh `make build` always rebuilds it rather
+	# than letting setup.py's "already present" short-circuit ship a stale
+	# (e.g. wrong-port) bundle left over from a prior local build.
+	rm -rf src/orb/ui/_static/
 	rm -rf .pytest_cache/
 	rm -rf .coverage
 	rm -rf $(COVERAGE_HTML)/

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,50 @@
+"""Setuptools build hook shim.
+
+All project metadata lives in pyproject.toml (build-backend =
+"setuptools.build_meta").  This file exists solely to subclass build_py so the
+Reflex SPA static bundle is compiled automatically whenever the wheel is built
+with ``python -m build``.  The bundle is written to ``src/orb/ui/_static/``
+*before* ``super().run()`` scans ``package_data``, so setuptools packages it
+with no extra wiring.
+
+Set ORB_SKIP_UI_BUILD=1 to skip the build (core-only wheels, CI jobs without
+bun, fast iterative builds).  When skipped the wheel simply ships whatever is
+already in ``src/orb/ui/_static/`` — nothing if it was never built — and the
+runtime ``_resolve_static_dir()`` returns None cleanly.  A stale bundle left on
+disk is the caller's to remove (``rm -rf src/orb/ui/_static``); a real build
+wipes and regenerates it.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+
+from setuptools import setup
+from setuptools.command.build_py import build_py as _build_py
+
+_PROJECT_ROOT = pathlib.Path(__file__).parent.resolve()
+_STATIC_INDEX = _PROJECT_ROOT / "src" / "orb" / "ui" / "_static" / "index.html"
+_BUILD_SCRIPT = _PROJECT_ROOT / "dev-tools" / "package" / "build_ui.sh"
+
+
+class build_py(_build_py):  # noqa: N801 — must match setuptools' command name
+    """Compile the Reflex SPA bundle before packaging."""
+
+    def run(self) -> None:
+        if os.environ.get("ORB_SKIP_UI_BUILD", "").strip().lower() in ("1", "true", "yes"):
+            print("ORB_SKIP_UI_BUILD set — not building the SPA bundle.", file=sys.stderr)
+        elif _STATIC_INDEX.exists():
+            print(f"SPA bundle already present at {_STATIC_INDEX.parent}.", file=sys.stderr)
+        else:
+            print("Building Reflex SPA static bundle...", file=sys.stderr)
+            subprocess.run(["bash", str(_BUILD_SCRIPT), "--quiet"], check=True)
+            if not _STATIC_INDEX.exists():
+                raise SystemExit(f"UI build ran but {_STATIC_INDEX} is missing — see output above.")
+
+        super().run()
+
+
+setup(cmdclass={"build_py": build_py})

--- a/src/orb/cli/args.py
+++ b/src/orb/cli/args.py
@@ -608,6 +608,22 @@ For more information, visit: {DOCS_URL}
     )
     add_global_arguments(server_reload_cmd)
 
+    server_ui_export = server_subparsers.add_parser(
+        "ui-export",
+        help="Copy the compiled SPA bundle to a local directory for CDN / static-host serving",
+    )
+    add_global_arguments(server_ui_export)
+    server_ui_export.add_argument(
+        "--dest",
+        required=True,
+        help="Target directory to copy the SPA bundle into",
+    )
+    server_ui_export.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow overwriting into a non-empty or already-existing destination",
+    )
+
     # Infrastructure
     infrastructure_parser = subparsers.add_parser("infrastructure", help="Infrastructure discovery")
     resource_parsers["infrastructure"] = infrastructure_parser

--- a/src/orb/cli/registry.py
+++ b/src/orb/cli/registry.py
@@ -180,6 +180,7 @@ def build_registry() -> None:
         handle_server_start,
         handle_server_status,
         handle_server_stop,
+        handle_server_ui_export,
     )
 
     register("server", "start", handle_server_start)
@@ -188,6 +189,7 @@ def build_registry() -> None:
     register("server", "restart", handle_server_restart)
     register("server", "reload", handle_server_reload)
     register("server", "logs", handle_server_logs)
+    register("server", "ui-export", handle_server_ui_export)
 
     # --- templates ---
     from orb.interface.template_command_handlers import (

--- a/src/orb/interface/server_command_handlers.py
+++ b/src/orb/interface/server_command_handlers.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from orb.domain.base.exceptions import ConfigurationError
+from orb.domain.base.exceptions import ConfigurationError, ValidationError
 from orb.infrastructure.error.decorators import handle_interface_exceptions
 from orb.infrastructure.logging.logger import get_logger
 
@@ -416,4 +416,73 @@ async def handle_server_logs(args) -> dict[str, Any]:
     return {
         "log_file": log_file,
         "tail": daemon_mod.tail_log(log_file=log_file, lines=int(lines)),
+    }
+
+
+def _ui_resolve_static_dir():
+    """Thin wrapper around ``orb.ui.app._resolve_static_dir``.
+
+    Importing lazily keeps the heavy Reflex/page graph out of the CLI process
+    when the UI extras are not installed.  The wrapper lives in this module so
+    tests can patch ``orb.interface.server_command_handlers._ui_resolve_static_dir``
+    without having to import ``orb.ui.app`` (and its reflex/page side-effects).
+
+    Raises:
+        ValidationError: When the UI extras (reflex and the orb page graph) are
+            not installed, giving the user an actionable install instruction
+            rather than an opaque ``ModuleNotFoundError`` traceback.
+    """
+    try:
+        from orb.ui.app import _resolve_static_dir
+    except ImportError as exc:
+        raise ValidationError(
+            "UI extras are not installed — run: pip install 'orb-py[ui]'"
+        ) from exc
+
+    return _resolve_static_dir()
+
+
+@handle_interface_exceptions(context="server_ui_export", interface_type="cli")
+async def handle_server_ui_export(args) -> dict[str, Any]:
+    """Copy the compiled SPA bundle to a local directory for CDN / static-host serving.
+
+    Locates the bundle via ``orb.ui.app._resolve_static_dir()`` (single source
+    of truth shared with the embedded server route) and copies it with
+    ``shutil.copytree``.
+
+    # ponytail: local dir only; users pipe to s3/gcs with their own tooling
+    """
+    import shutil
+    from pathlib import Path
+
+    dest_arg: str = getattr(args, "dest", None) or ""
+    force: bool = getattr(args, "force", False)
+
+    static_dir: Path | None = _ui_resolve_static_dir()
+    if static_dir is None:
+        raise ValidationError(
+            "UI bundle not found — no compiled SPA is available. "
+            "Install the UI extras and build the bundle: "
+            "pip install 'orb-py[ui]' then run 'make ui-build'."
+        )
+
+    dest = Path(dest_arg).resolve()
+    if dest.exists() and not dest.is_dir():
+        raise ValidationError(
+            f"Destination '{dest}' exists and is not a directory. "
+            "Provide a path to a directory (existing or new)."
+        )
+    if dest.exists() and any(dest.iterdir()) and not force:
+        raise ValidationError(
+            f"Destination '{dest}' already exists and is not empty. Use --force to overwrite."
+        )
+
+    shutil.copytree(str(static_dir), str(dest), dirs_exist_ok=force)
+
+    file_count = sum(1 for _ in dest.rglob("*") if _.is_file())
+    return {
+        "status": "ok",
+        "dest": str(dest),
+        "file_count": file_count,
+        "message": f"SPA bundle exported to '{dest}' ({file_count} files).",
     }

--- a/tests/unit/interface/test_server_ui_export.py
+++ b/tests/unit/interface/test_server_ui_export.py
@@ -1,0 +1,254 @@
+"""Unit tests for the ``orb server ui-export`` CLI handler."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from orb.domain.base.exceptions import ValidationError
+
+
+def _args(dest: str, force: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(dest=dest, force=force)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests (unchanged)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_export_copies_bundle_to_dest(tmp_path: Path) -> None:
+    """Handler copies the bundle to the destination and reports file count."""
+    # Build a minimal fake static bundle in a source tmp dir.
+    source = tmp_path / "static"
+    source.mkdir()
+    (source / "index.html").write_text("<html/>")
+    (source / "assets").mkdir()
+    (source / "assets" / "main.js").write_text("// js")
+
+    dest = tmp_path / "export"
+
+    from orb.interface.server_command_handlers import handle_server_ui_export
+
+    with patch("orb.interface.server_command_handlers._ui_resolve_static_dir", return_value=source):
+        result = await handle_server_ui_export(_args(str(dest)))
+
+    assert result["status"] == "ok"
+    assert result["dest"] == str(dest)
+    assert result["file_count"] == 2
+    assert (dest / "index.html").is_file()
+    assert (dest / "assets" / "main.js").is_file()
+
+
+@pytest.mark.asyncio
+async def test_export_overwrites_non_empty_dest_with_force(tmp_path: Path) -> None:
+    """Handler merges/overwrites into an existing destination when --force is set."""
+    source = tmp_path / "static"
+    source.mkdir()
+    (source / "index.html").write_text("<html/>")
+
+    dest = tmp_path / "existing"
+    dest.mkdir()
+    (dest / "stale.txt").write_text("old content")
+
+    from orb.interface.server_command_handlers import handle_server_ui_export
+
+    with patch("orb.interface.server_command_handlers._ui_resolve_static_dir", return_value=source):
+        result = await handle_server_ui_export(_args(str(dest), force=True))
+
+    assert result["status"] == "ok"
+    assert (dest / "index.html").is_file()
+
+
+# ---------------------------------------------------------------------------
+# Failure paths — handler level (Finding 2, 4, 5)
+# These verify the correct exception type and message content.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_export_raises_when_bundle_missing() -> None:
+    """Handler raises ValidationError (non-zero exit) when the bundle is absent."""
+    from orb.interface.server_command_handlers import handle_server_ui_export
+
+    with patch("orb.interface.server_command_handlers._ui_resolve_static_dir", return_value=None):
+        with pytest.raises(ValidationError) as exc_info:
+            await handle_server_ui_export(_args("/tmp/irrelevant"))
+
+    assert "bundle not found" in str(exc_info.value).lower()
+    assert "pip install" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_export_raises_when_dest_non_empty_without_force(tmp_path: Path) -> None:
+    """Handler raises ValidationError when dest is non-empty and --force is absent."""
+    source = tmp_path / "static"
+    source.mkdir()
+    (source / "index.html").write_text("<html/>")
+
+    dest = tmp_path / "existing"
+    dest.mkdir()
+    (dest / "stale.txt").write_text("old content")
+
+    from orb.interface.server_command_handlers import handle_server_ui_export
+
+    with patch("orb.interface.server_command_handlers._ui_resolve_static_dir", return_value=source):
+        with pytest.raises(ValidationError) as exc_info:
+            await handle_server_ui_export(_args(str(dest), force=False))
+
+    assert "--force" in str(exc_info.value)
+    # Original content must be untouched.
+    assert (dest / "stale.txt").is_file()
+
+
+@pytest.mark.asyncio
+async def test_export_raises_when_dest_is_a_file(tmp_path: Path) -> None:
+    """Finding 5 — dest points at an existing regular file; handler raises a clean error.
+
+    Before the fix, ``dest.iterdir()`` raised ``NotADirectoryError`` and was
+    surfaced as an opaque wrapped exception.  Now it's a ``ValidationError``
+    with an actionable message.
+    """
+    source = tmp_path / "static"
+    source.mkdir()
+    (source / "index.html").write_text("<html/>")
+
+    dest_file = tmp_path / "not-a-dir.txt"
+    dest_file.write_text("i am a file")
+
+    from orb.interface.server_command_handlers import handle_server_ui_export
+
+    with patch("orb.interface.server_command_handlers._ui_resolve_static_dir", return_value=source):
+        with pytest.raises(ValidationError) as exc_info:
+            await handle_server_ui_export(_args(str(dest_file)))
+
+    assert "not a directory" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_ui_resolve_static_dir_raises_when_extras_missing() -> None:
+    """Finding 4 — missing UI extras give an actionable ValidationError, not a raw ImportError.
+
+    We monkeypatch the import so the test does not require reflex to be absent.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block_orb_ui(name, *args, **kwargs):
+        if name == "orb.ui.app" or name.startswith("orb.ui."):
+            raise ImportError(f"No module named '{name}'")
+        return real_import(name, *args, **kwargs)
+
+    # Ensure orb.ui.app is not cached in sys.modules so the lazy import fires.
+    import sys
+
+    cached = sys.modules.pop("orb.ui.app", None)
+    try:
+        with patch("builtins.__import__", side_effect=_block_orb_ui):
+            from orb.interface.server_command_handlers import _ui_resolve_static_dir
+
+            with pytest.raises(ValidationError) as exc_info:
+                _ui_resolve_static_dir()
+    finally:
+        if cached is not None:
+            sys.modules["orb.ui.app"] = cached
+
+    assert "pip install" in str(exc_info.value)
+    assert "orb-py[ui]" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Exit-code mapping tests (Finding 2)
+# Drive failure paths through cli.router.execute_command so the real
+# exit-code mapping (main.py:243-262 / formatter.format_error) is exercised.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bundle_missing_yields_nonzero_exit_via_router(tmp_path: Path) -> None:
+    """Finding 2 — bundle-missing path must exit non-zero through the real dispatch path.
+
+    We drive the failure through cli.router.execute_command, which re-raises
+    the ValidationError.  Then we pass it through CLIResponseFormatter.format_error,
+    mirroring the exact code path in cli.main:243-262.
+    """
+    from orb.cli.response_formatter import CLIResponseFormatter
+    from orb.cli.router import execute_command
+
+    args = argparse.Namespace(
+        dest=str(tmp_path / "out"),
+        force=False,
+        resource="server",
+        action="ui-export",
+        format="json",
+        input_data=None,
+    )
+
+    mock_container = MagicMock()
+    formatter = CLIResponseFormatter()
+
+    with (
+        patch("orb.interface.server_command_handlers._ui_resolve_static_dir", return_value=None),
+        patch("orb.infrastructure.di.container.get_container", return_value=mock_container),
+        patch("orb.cli.registry.build_registry"),
+        patch("orb.cli.registry.lookup") as mock_lookup,
+    ):
+        # Wire lookup to the real handler so the exception actually comes from
+        # handle_server_ui_export (not a random mock).
+        from orb.interface.server_command_handlers import handle_server_ui_export
+
+        mock_lookup.return_value = handle_server_ui_export
+
+        with pytest.raises(ValidationError) as exc_info:
+            await execute_command(args, None, {})
+
+    _output, exit_code = formatter.format_error(exc_info.value, "json")
+    assert exit_code != 0, "bundle-missing path must produce a non-zero exit code"
+
+
+@pytest.mark.asyncio
+async def test_non_empty_dest_yields_nonzero_exit_via_router(tmp_path: Path) -> None:
+    """Finding 2 — non-empty-dest-without-force path must exit non-zero through the real dispatch path."""
+    source = tmp_path / "static"
+    source.mkdir()
+    (source / "index.html").write_text("<html/>")
+
+    dest = tmp_path / "existing"
+    dest.mkdir()
+    (dest / "stale.txt").write_text("old content")
+
+    from orb.cli.response_formatter import CLIResponseFormatter
+    from orb.cli.router import execute_command
+
+    args = argparse.Namespace(
+        dest=str(dest),
+        force=False,
+        resource="server",
+        action="ui-export",
+        format="json",
+        input_data=None,
+    )
+
+    mock_container = MagicMock()
+    formatter = CLIResponseFormatter()
+
+    with (
+        patch("orb.interface.server_command_handlers._ui_resolve_static_dir", return_value=source),
+        patch("orb.infrastructure.di.container.get_container", return_value=mock_container),
+        patch("orb.cli.registry.build_registry"),
+        patch("orb.cli.registry.lookup") as mock_lookup,
+    ):
+        from orb.interface.server_command_handlers import handle_server_ui_export
+
+        mock_lookup.return_value = handle_server_ui_export
+
+        with pytest.raises(ValidationError) as exc_info:
+            await execute_command(args, None, {})
+
+    _output, exit_code = formatter.format_error(exc_info.value, "json")
+    assert exit_code != 0, "non-empty-dest path must produce a non-zero exit code"


### PR DESCRIPTION
## Description
Fixes the broken UI build in the Semantic Release workflow and makes SPA packaging robust, plus two small follow-ons.

**Root cause:** the wheel ships the Reflex SPA from `orb/ui/_static/`, but that directory is not committed — it must be built before packaging. Every release workflow ran `make ui-build` as a *separate* step. That step broke in the `semantic-release` job: it uses bare `setup-uv` (no venv) and deliberately skips `uv sync` (the next step is a Docker action that mounts the workspace, so a host `.venv` with a dangling interpreter would break it). No venv → `build_ui.sh`'s `uv pip install '.[ui]'` failed with *"No virtual environment found"*.

**Fix — build the SPA during the wheel build itself:**
- `setup.py` adds a `build_py` subclass that runs `build_ui.sh` before packaging, so `python -m build` always produces the bundle. `ORB_SKIP_UI_BUILD=1` skips it for core-only wheels / bun-less CI.
- `build_ui.sh` is now self-sufficient: uses an active/project venv when present, else creates an **ephemeral** venv (removed on exit via `trap`) and installs `.[ui]` there. The nested install is guarded with `ORB_SKIP_UI_BUILD=1` so it doesn't recurse through the build hook. `reflex` is invoked from that venv's `bin` directly (not `uv run`, which targets the project env and would miss an ephemeral install).
- Dropped the now-redundant `make ui-build` step from `semantic-release`, `dev-pypi`, and `prod-release`. No `.venv` is left on disk, so the Docker semantic-release step stays safe.

**Also in this PR:**
- `feat(cli)`: `orb server ui-export --dest <dir>` — copies the compiled SPA bundle to a local directory for external static/CDN serving (folder-only; users push to S3/GCS with their own tooling).
- `ci`: migrate app-token auth from the deprecated `app-id` input to `client-id` (`create-github-app-token` v3) + new `GH_APP_CLIENT_ID` secret.
- `docs`: OpenSSF Best Practices badge + a 5th Quick Start step (check return status).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code cleanup or refactor
- [x] CI/CD or build process changes

(Also adds a new CLI command — `orb server ui-export`.)

## Related Issues
Fixes #

## How Has This Been Tested?
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

- `python -m build` (both isolated and `--no-isolation`) from a bare checkout with **no `.venv`** produces a wheel containing `orb/ui/_static/index.html` (26 `_static/` entries) and leaves **no `.venv`** on disk.
- `ORB_SKIP_UI_BUILD=1 python -m build` builds a core-only wheel (no SPA) successfully, without needing bun/reflex.
- `build_ui.sh` run directly from a bare checkout (the semantic-release scenario) creates + cleans its ephemeral venv and produces the bundle.
- `orb server ui-export`: 4 unit tests (happy-path copy + file count, missing-bundle error, non-empty-dest guard, `--force` overwrite). pyright: 0 errors on touched files.

## Test Configuration
* Python version: 3.12 (local); CI matrix unchanged
* OS: macOS (local) / ubuntu-latest (CI)
* AWS region: n/a
* Dependencies changed: none (build-time only; adds a `setup.py` build shim)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes
`GH_APP_CLIENT_ID` secret has been added to the repo. The `setup.py` shim exists solely for the build hook — all project metadata stays in `pyproject.toml` (`build-backend = setuptools.build_meta`).

## Security Considerations
- [x] No security implications

App-token migration keeps the same repo-scoped, short-lived installation token; only the deprecated input name changes.

## Reviewers
@finos/open-resource-broker-maintainers
