### PR TITLE
ci: scope CI dependencies per job for faster, reliable installs

### DIFF
--- a/.github/actions/setup-uv-cached/action.yml
+++ b/.github/actions/setup-uv-cached/action.yml
@@ -1,9 +1,19 @@
 name: 'Setup UV with Cache'
-description: 'Install UV and restore cached environment'
+description: 'Install UV and restore cached environment, syncing only the requested dependency group'
 inputs:
   cache-key:
-    description: 'Cache key for UV environment'
+    description: 'Cache key for UV environment (caller-supplied; keyed per group)'
     required: true
+  group:
+    description: >-
+      PEP 735 dependency-group to sync (e.g. lint, typecheck, arch, test, docs,
+      security, build, ci, dev).  When supplied the action runs
+      `uv sync --frozen --no-default-groups --group <group>` on a cache miss so
+      each job installs only the packages it needs.  When empty the action falls
+      back to `uv sync --frozen --all-groups` (preserves legacy callers that
+      have not yet been updated to pass a group).
+    required: false
+    default: ''
   fail-on-cache-miss:
     description: 'Whether to fail if cache is not found'
     required: false
@@ -14,6 +24,11 @@ runs:
   steps:
     - name: Install UV
       uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
+    - name: Setup Python 3.12
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+      with:
+        python-version: '3.12'
 
     - name: Restore UV environment
       id: restore-cache
@@ -27,7 +42,17 @@ runs:
         key: ${{ inputs.cache-key }}
         fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
 
-    - name: Install dependencies if cache miss
+    - name: Install dependencies (scoped, on cache miss)
       if: steps.restore-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: make dev-install
+      env:
+        ORB_SKIP_UI_BUILD: "1"
+        UV_GROUP: ${{ inputs.group }}
+      run: |
+        if [ -n "$UV_GROUP" ]; then
+          # Scoped install: only the packages this job needs (~2-15 pkgs, fast even cold)
+          uv sync --frozen --no-default-groups --group "$UV_GROUP"
+        else
+          # Legacy fallback: full install (used by callers that predate group scoping)
+          uv sync --frozen --all-groups
+        fi

--- a/.github/workflows/cache-management.yml
+++ b/.github/workflows/cache-management.yml
@@ -19,6 +19,15 @@ on:
         description: 'Python version for cache key'
         required: true
         type: string
+      group:
+        description: >-
+          PEP 735 dependency-group to prime (e.g. lint, typecheck, test).
+          When provided the prime job runs `uv sync --frozen --no-default-groups
+          --group <group>` so only the relevant slice is cached.  When empty the
+          prime installs --all-groups (legacy / umbrella callers).
+        required: false
+        type: string
+        default: ''
     outputs:
       cache-key:
         description: 'Generated cache key for use in setup-uv-cached'
@@ -36,12 +45,27 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
+    - name: Install UV
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
+    - name: Setup Python 3.12
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+      with:
+        python-version: '3.12'
+
     - name: Generate cache key
       id: cache-key
       run: |
         case "${{ inputs.cache-type }}" in
           dependencies)
-            KEY="${{ inputs.cache-key-base }}-py${{ inputs.python-version }}-${{ hashFiles('.project.yml', 'pyproject.toml', 'uv.lock') }}"
+            # Key encodes the group so per-group caches are independent;
+            # a uv.lock bump invalidates only that group's slice.
+            GROUP="${{ inputs.group }}"
+            if [ -n "$GROUP" ]; then
+              KEY="${{ inputs.cache-key-base }}-py3.12-${GROUP}-${{ hashFiles('.project.yml', 'pyproject.toml', 'uv.lock') }}"
+            else
+              KEY="${{ inputs.cache-key-base }}-py3.12-${{ hashFiles('.project.yml', 'pyproject.toml', 'uv.lock') }}"
+            fi
             ;;
           *)
             KEY="${{ inputs.cache-key-base }}-${{ github.sha }}"
@@ -50,7 +74,7 @@ jobs:
         echo "key=$KEY" >> "$GITHUB_OUTPUT"
         echo "Generated cache key: $KEY"
 
-    - name: Restore cache
+    - name: Restore cache (check for existing warm cache)
       id: cache
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v5
       with:
@@ -61,5 +85,22 @@ jobs:
           .pytest_cache
         key: ${{ steps.cache-key.outputs.key }}
         restore-keys: |
-          ${{ inputs.cache-key-base }}-py${{ inputs.python-version }}-
+          ${{ inputs.cache-key-base }}-py3.12-${{ inputs.group != '' && format('{0}-', inputs.group) || '' }}
           ${{ inputs.cache-key-base }}-
+
+    - name: Prime cache (populate on miss)
+      # Only runs when there is no existing warm cache for this key.
+      # Installs the scoped group so the post-step cache save writes a populated
+      # .venv rather than an empty one.  Each job's setup-uv-cached composite
+      # also syncs-on-miss, so correctness never depends on the prime winning
+      # the race; this is best-effort warming.
+      if: steps.cache.outputs.cache-hit != 'true'
+      env:
+        ORB_SKIP_UI_BUILD: "1"
+        UV_GROUP: ${{ inputs.group }}
+      run: |
+        if [ -n "$UV_GROUP" ]; then
+          uv sync --frozen --no-default-groups --group "$UV_GROUP"
+        else
+          uv sync --frozen --all-groups
+        fi

--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -32,8 +32,9 @@ jobs:
     uses: ./.github/workflows/cache-management.yml
     with:
       cache-type: dependencies
-      cache-key-base: changelog-validation
+      cache-key-base: deps
       python-version: ${{ needs.config.outputs.default-python-version }}
+      group: build
 
   validate-changelog:
     name: Validate Changelog Format
@@ -53,6 +54,7 @@ jobs:
       uses: ./.github/actions/setup-uv-cached
       with:
         cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+        group: build
         fail-on-cache-miss: false
     
     - name: Install changelog dependencies

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -45,14 +45,37 @@ jobs:
     name: Configuration
     uses: ./.github/workflows/shared-config.yml
 
-  setup-cache:
-    name: Setup Cache
+  # One setup-cache job per group that needs priming.
+  # Each installs only its slice so cache misses are cheap even cold.
+  setup-cache-lint:
+    name: Setup Cache (lint)
     needs: config
     uses: ./.github/workflows/cache-management.yml
     with:
       cache-type: dependencies
-      cache-key-base: quality-deps
+      cache-key-base: deps
       python-version: ${{ needs.config.outputs.default-python-version }}
+      group: lint
+
+  setup-cache-typecheck:
+    name: Setup Cache (typecheck)
+    needs: config
+    uses: ./.github/workflows/cache-management.yml
+    with:
+      cache-type: dependencies
+      cache-key-base: deps
+      python-version: ${{ needs.config.outputs.default-python-version }}
+      group: typecheck
+
+  setup-cache-arch:
+    name: Setup Cache (arch)
+    needs: config
+    uses: ./.github/workflows/cache-management.yml
+    with:
+      cache-type: dependencies
+      cache-key-base: deps
+      python-version: ${{ needs.config.outputs.default-python-version }}
+      group: arch
 
   auto-format:
     name: Auto-Format Code
@@ -64,7 +87,7 @@ jobs:
       && github.actor != 'open-resource-broker-cicd[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [config, setup-cache]
+    needs: [config, setup-cache-lint]
     # Override the workflow-level concurrency so this job is never cancelled
     # mid-run.  If it were interrupted after `ruff` rewrites files but before
     # `git push`, the PR branch would be left in a half-formatted state.
@@ -94,7 +117,8 @@ jobs:
       - name: Setup UV with cache
         uses: ./.github/actions/setup-uv-cached
         with:
-          cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+          cache-key: ${{ needs.setup-cache-lint.outputs.cache-key }}
+          group: lint
           fail-on-cache-miss: false
 
       - name: Auto-format code
@@ -128,7 +152,7 @@ jobs:
       && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [config, setup-cache]
+    needs: [config, setup-cache-lint]
     permissions:
       contents: read
       pull-requests: write
@@ -142,7 +166,8 @@ jobs:
       - name: Setup UV with cache
         uses: ./.github/actions/setup-uv-cached
         with:
-          cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+          cache-key: ${{ needs.setup-cache-lint.outputs.cache-key }}
+          group: lint
           fail-on-cache-miss: false
 
       - name: Run formatter
@@ -159,7 +184,7 @@ jobs:
     name: Ruff (Code Quality)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [config, setup-cache]
+    needs: [config, setup-cache-lint]
     permissions:
       contents: read
     steps:
@@ -169,7 +194,8 @@ jobs:
       - name: Setup UV with cache
         uses: ./.github/actions/setup-uv-cached
         with:
-          cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+          cache-key: ${{ needs.setup-cache-lint.outputs.cache-key }}
+          group: lint
           fail-on-cache-miss: false
 
       - name: Check code quality
@@ -179,7 +205,7 @@ jobs:
     name: Ruff (Extended Checks)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [config, setup-cache, lint-ruff]
+    needs: [config, setup-cache-lint, lint-ruff]
     permissions:
       contents: read
     steps:
@@ -189,7 +215,8 @@ jobs:
       - name: Setup UV with cache
         uses: ./.github/actions/setup-uv-cached
         with:
-          cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+          cache-key: ${{ needs.setup-cache-lint.outputs.cache-key }}
+          group: lint
           fail-on-cache-miss: false
 
       - name: Extended linting (warnings)
@@ -200,7 +227,7 @@ jobs:
     name: Type Checking (pyright)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [config, setup-cache, lint-ruff]
+    needs: [config, setup-cache-typecheck, lint-ruff]
     permissions:
       contents: read
     steps:
@@ -210,7 +237,8 @@ jobs:
     - name: Setup UV with cache
       uses: ./.github/actions/setup-uv-cached
       with:
-        cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+        cache-key: ${{ needs.setup-cache-typecheck.outputs.cache-key }}
+        group: typecheck
         fail-on-cache-miss: false
 
     - name: Run pyright type check
@@ -221,7 +249,7 @@ jobs:
     name: Architecture Validation
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [config, setup-cache, lint-ruff]
+    needs: [config, setup-cache-arch, lint-ruff]
     permissions:
       contents: read
     strategy:
@@ -243,7 +271,8 @@ jobs:
     - name: Setup UV with cache
       uses: ./.github/actions/setup-uv-cached
       with:
-        cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+        cache-key: ${{ needs.setup-cache-arch.outputs.cache-key }}
+        group: arch
         fail-on-cache-miss: false
 
     - name: Run architecture validation (${{ matrix.description }})
@@ -254,16 +283,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Runs independently of lint to give early signal on version drift.
-    # Only needs a checkout + pyyaml — no UV venv required.
-    needs: config
+    # pyyaml is available via the project's core [dependencies] so any
+    # group that installs the project also provides it.  Use the arch
+    # group (smallest group that triggers a uv sync with the project).
+    needs: [config, setup-cache-arch]
     permissions:
       contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-    - name: Install PyYAML
-      run: pip install --quiet pyyaml
+    - name: Setup UV with cache
+      uses: ./.github/actions/setup-uv-cached
+      with:
+        cache-key: ${{ needs.setup-cache-arch.outputs.cache-key }}
+        group: arch
+        fail-on-cache-miss: false
 
     - name: Check Python version drift
       run: make ci-check-python-version-drift

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -35,6 +35,11 @@ concurrency:
 permissions:
   contents: read
 
+# Belt-and-suspenders: prevent any accidental implicit uv sync from firing
+# the SPA build hook (setup.py build_ui.sh) in this workflow.
+env:
+  ORB_SKIP_UI_BUILD: "1"
+
 jobs:
   config:
     name: Configuration

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -38,6 +38,13 @@ concurrency:
 permissions:
   contents: read
 
+# Belt-and-suspenders: prevent any accidental implicit uv sync from firing
+# the SPA build hook (setup.py build_ui.sh) in this workflow.
+# Exception: build-and-package sets ORB_SKIP_UI_BUILD=1 on its own step env
+# because it intentionally skips the UI build for the CI-only wheel artifact.
+env:
+  ORB_SKIP_UI_BUILD: "1"
+
 jobs:
   config:
     name: Configuration

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -56,8 +56,9 @@ jobs:
     uses: ./.github/workflows/cache-management.yml
     with:
       cache-type: dependencies
-      cache-key-base: test-deps
+      cache-key-base: deps
       python-version: ${{ needs.config.outputs.default-python-version }}
+      group: test
 
   # Parallel test-group matrix (T2613): splits the non-provider test corpus
   # into independent legs that each run on their own runner with xdist within
@@ -217,11 +218,21 @@ jobs:
       environment: ${{ needs.config.outputs.environment }}
       testing-flag: ${{ needs.config.outputs.testing-flag }}
 
+  setup-cache-build:
+    name: Setup Build Cache
+    needs: config
+    uses: ./.github/workflows/cache-management.yml
+    with:
+      cache-type: dependencies
+      cache-key-base: deps
+      python-version: ${{ needs.config.outputs.default-python-version }}
+      group: build
+
   build-and-package:
     name: Build & Package
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [config, setup-cache]
+    needs: [config, setup-cache-build]
     permissions:
       contents: read
 
@@ -232,7 +243,8 @@ jobs:
     - name: Setup UV with cache
       uses: ./.github/actions/setup-uv-cached
       with:
-        cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+        cache-key: ${{ needs.setup-cache-build.outputs.cache-key }}
+        group: build
         fail-on-cache-miss: false
 
     - name: Build package
@@ -271,6 +283,7 @@ jobs:
       uses: ./.github/actions/setup-uv-cached
       with:
         cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+        group: test
         fail-on-cache-miss: false
 
     - name: Download test results
@@ -311,6 +324,7 @@ jobs:
       uses: ./.github/actions/setup-uv-cached
       with:
         cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+        group: test
         fail-on-cache-miss: false
 
     - name: Download coverage artifacts
@@ -361,6 +375,7 @@ jobs:
     needs:
       - config
       - setup-cache
+      - setup-cache-build
       - test-groups
       - e2e-tests
       - providers-tests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,11 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+# Belt-and-suspenders: prevent any accidental implicit uv sync from firing
+# the SPA build hook (setup.py build_ui.sh) in this workflow.
+env:
+  ORB_SKIP_UI_BUILD: "1"
+
 jobs:
   config:
     name: Get Configuration

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,8 +61,9 @@ jobs:
     uses: ./.github/workflows/cache-management.yml
     with:
       cache-type: dependencies
-      cache-key-base: docs-deps
+      cache-key-base: deps
       python-version: ${{ needs.config.outputs.default-python-version }}
+      group: docs
 
   build:
     needs: [config, setup-cache]
@@ -78,6 +79,7 @@ jobs:
         uses: ./.github/actions/setup-uv-cached
         with:
           cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+          group: docs
           fail-on-cache-miss: false
 
       - name: Build documentation

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -45,19 +45,17 @@ jobs:
         if: contains('bandit,safety,codeql', inputs.scan-type)
         uses: ./.github/actions/setup-uv-cached
         with:
-          # Use the caller-supplied cache key when available so this job hits
-          # the warm cache primed by the caller's setup-cache job (which uses
-          # cache-management.yml with the canonical deps-py3.12-<uv.lock hash>
-          # key).  Fallback mirrors that format so at least restore-keys can
-          # provide a partial hit on a first run.
+          # Use the caller-supplied cache key (keyed to the security group).
+          # Fallback mirrors the canonical group-keyed format so restore-keys
+          # can still provide a partial hit on a first run.
           cache-key: >-
             ${{
               inputs.cache-key != ''
               && inputs.cache-key
-              || format('deps-py{0}-{1}',
-                   inputs.python-version || inputs.default-python-version,
+              || format('deps-py3.12-security-{0}',
                    hashFiles('.project.yml', 'pyproject.toml', 'uv.lock'))
             }}
+          group: security
           fail-on-cache-miss: false
 
       # Bandit Security Scan

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -15,6 +15,15 @@ on:
         description: 'Default Python version (fallback)'
         required: true
         type: string
+      cache-key:
+        description: >-
+          Pre-computed cache key from the caller's setup-cache step.  When
+          provided the job hits the warm cache primed by the caller's
+          cache-management job.  When omitted the job falls back to installing
+          from scratch (always cold).
+        required: false
+        type: string
+        default: ''
 
 jobs:
   security-scan:
@@ -36,7 +45,19 @@ jobs:
         if: contains('bandit,safety,codeql', inputs.scan-type)
         uses: ./.github/actions/setup-uv-cached
         with:
-          cache-key: deps-${{ inputs.python-version || inputs.default-python-version }}-${{ hashFiles('.project.yml', 'pyproject.toml', 'requirements*.txt') }}
+          # Use the caller-supplied cache key when available so this job hits
+          # the warm cache primed by the caller's setup-cache job (which uses
+          # cache-management.yml with the canonical deps-py3.12-<uv.lock hash>
+          # key).  Fallback mirrors that format so at least restore-keys can
+          # provide a partial hit on a first run.
+          cache-key: >-
+            ${{
+              inputs.cache-key != ''
+              && inputs.cache-key
+              || format('deps-py{0}-{1}',
+                   inputs.python-version || inputs.default-python-version,
+                   hashFiles('.project.yml', 'pyproject.toml', 'uv.lock'))
+            }}
           fail-on-cache-miss: false
 
       # Bandit Security Scan

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -92,6 +92,9 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-key }}
   ENVIRONMENT: ${{ inputs.environment }}
   TESTING: ${{ inputs.testing-flag }}
+  # Belt-and-suspenders: prevent any accidental implicit uv sync from firing
+  # the SPA build hook (setup.py build_ui.sh) in test jobs.
+  ORB_SKIP_UI_BUILD: "1"
 
 jobs:
   test:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -74,6 +74,14 @@ on:
         required: false
         type: string
         default: ''
+      group:
+        description: >-
+          PEP 735 dependency-group to sync on a cache miss (default: test).
+          All test legs use the test group; pass a different value only for
+          non-test consumers of this reusable workflow.
+        required: false
+        type: string
+        default: 'test'
       artifact-prefix:
         description: >-
           Caller-supplied prefix prepended to artifact names to prevent
@@ -113,16 +121,17 @@ jobs:
         with:
           # Use the caller-supplied cache key when available so this job hits the
           # warm cache primed by the caller's cache-management job.  Fallback
-          # mirrors the key format used by cache-management (dependencies type)
-          # so at least restore-keys can provide a partial hit.
+          # mirrors the key format used by cache-management (dependencies type,
+          # group-keyed) so at least restore-keys can provide a partial hit.
           cache-key: >-
             ${{
               inputs.cache-key != ''
               && inputs.cache-key
-              || format('test-deps-py{0}-{1}',
-                   inputs.python-version || inputs.default-python-version,
+              || format('deps-py3.12-{0}-{1}',
+                   inputs.group,
                    hashFiles('.project.yml', 'pyproject.toml', 'uv.lock'))
             }}
+          group: ${{ inputs.group }}
           fail-on-cache-miss: false
 
       - name: Run tests

--- a/.github/workflows/security-code.yml
+++ b/.github/workflows/security-code.yml
@@ -44,6 +44,7 @@ jobs:
       cache-type: dependencies
       cache-key-base: deps
       python-version: ${{ needs.config.outputs.default-python-version }}
+      group: security
 
   security-bandit:
     name: Bandit (Security Scan)

--- a/.github/workflows/security-code.yml
+++ b/.github/workflows/security-code.yml
@@ -26,14 +26,28 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Belt-and-suspenders: prevent any accidental implicit uv sync from firing
+# the SPA build hook (setup.py build_ui.sh) in this workflow.
+env:
+  ORB_SKIP_UI_BUILD: "1"
+
 jobs:
   config:
     name: Configuration
     uses: ./.github/workflows/shared-config.yml
 
+  setup-cache:
+    name: Setup Cache
+    needs: config
+    uses: ./.github/workflows/cache-management.yml
+    with:
+      cache-type: dependencies
+      cache-key-base: deps
+      python-version: ${{ needs.config.outputs.default-python-version }}
+
   security-bandit:
     name: Bandit (Security Scan)
-    needs: config
+    needs: [config, setup-cache]
     permissions:
       contents: read
       actions: read
@@ -43,10 +57,11 @@ jobs:
       scan-type: bandit
       default-python-version: ${{ needs.config.outputs.default-python-version }}
       python-version: ${{ needs.config.outputs.default-python-version }}
+      cache-key: ${{ needs.setup-cache.outputs.cache-key }}
 
   security-safety:
     name: Safety (Dependency Scan)
-    needs: config
+    needs: [config, setup-cache]
     permissions:
       contents: read
       actions: read
@@ -56,6 +71,7 @@ jobs:
       scan-type: safety
       default-python-version: ${{ needs.config.outputs.default-python-version }}
       python-version: ${{ needs.config.outputs.default-python-version }}
+      cache-key: ${{ needs.setup-cache.outputs.cache-key }}
 
   security-semgrep:
     name: Semgrep (Static Analysis)
@@ -146,7 +162,7 @@ jobs:
 
   codeql-analysis:
     name: CodeQL Analysis
-    needs: config
+    needs: [config, setup-cache]
     if: github.event_name == 'pull_request' || github.event_name == 'schedule' || contains(github.event.head_commit.message, '[security]')
     permissions:
       contents: read
@@ -157,3 +173,4 @@ jobs:
       scan-type: codeql
       default-python-version: ${{ needs.config.outputs.default-python-version }}
       python-version: ${{ needs.config.outputs.default-python-version }}
+      cache-key: ${{ needs.setup-cache.outputs.cache-key }}

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -28,8 +28,9 @@ jobs:
     uses: ./.github/workflows/cache-management.yml
     with:
       cache-type: dependencies
-      cache-key-base: test-deps
+      cache-key-base: deps
       python-version: ${{ needs.config.outputs.default-python-version }}
+      group: test
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -35,8 +35,9 @@ jobs:
     uses: ./.github/workflows/cache-management.yml
     with:
       cache-type: dependencies
-      cache-key-base: workflow-validation
+      cache-key-base: deps
       python-version: ${{ needs.config.outputs.default-python-version }}
+      group: lint
 
   validate-workflows:
     name: Validate Workflow Files
@@ -53,6 +54,7 @@ jobs:
       uses: ./.github/actions/setup-uv-cached
       with:
         cache-key: ${{ needs.setup-cache.outputs.cache-key }}
+        group: lint
         fail-on-cache-miss: false
 
     - name: Validate workflow syntax and logic

--- a/dev-tools/setup/run_tool.sh
+++ b/dev-tools/setup/run_tool.sh
@@ -4,6 +4,12 @@ set -e
 # Centralized tool execution script with environment setup
 # Usage: run_tool.sh <tool_name> [args...]
 # Handles environment setup and tries different execution methods
+#
+# In CI the venv is pre-populated by setup-uv-cached (per-job scoped group).
+# All `uv run` calls below use --no-sync so they never trigger a redundant sync
+# or the setup.py SPA build hook.  The adjust_relative_args helper and the
+# subdirectory-cd path are retained for local developer use where the tool may
+# be invoked from a subdirectory; they are not exercised in CI.
 
 TOOL_NAME="$1"
 shift  # Remove tool name from arguments

--- a/dev-tools/setup/run_tool.sh
+++ b/dev-tools/setup/run_tool.sh
@@ -105,12 +105,12 @@ run_tool() {
             adjusted_args=$(adjust_relative_args "$project_root" "$@")
             if [ -n "$adjusted_args" ]; then
                 # shellcheck disable=SC2086
-                (cd "$project_root" && uv run "${TOOL_NAME}" $adjusted_args)
+                (cd "$project_root" && uv run --no-sync "${TOOL_NAME}" $adjusted_args)
             else
-                (cd "$project_root" && uv run "${TOOL_NAME}")
+                (cd "$project_root" && uv run --no-sync "${TOOL_NAME}")
             fi
         else
-            uv run "${TOOL_NAME}" "$@"
+            uv run --no-sync "${TOOL_NAME}" "$@"
         fi
     elif [ -f ".venv/bin/${TOOL_NAME}" ] && venv_usable ".venv"; then
         echo "Executing with venv..."
@@ -125,12 +125,12 @@ run_tool() {
                 adjusted_args=$(adjust_relative_args "$project_root" "$@")
                 if [ -n "$adjusted_args" ]; then
                     # shellcheck disable=SC2086
-                    (cd "$project_root" && uv run python -m "${TOOL_NAME}" $adjusted_args)
+                    (cd "$project_root" && uv run --no-sync python -m "${TOOL_NAME}" $adjusted_args)
                 else
-                    (cd "$project_root" && uv run python -m "${TOOL_NAME}")
+                    (cd "$project_root" && uv run --no-sync python -m "${TOOL_NAME}")
                 fi
             else
-                uv run python -m "${TOOL_NAME}" "$@"
+                uv run --no-sync python -m "${TOOL_NAME}" "$@"
             fi
         else
             python3 -m "${TOOL_NAME}" "$@"

--- a/makefiles/ci.mk
+++ b/makefiles/ci.mk
@@ -4,12 +4,12 @@
 # Individual code quality targets (with tool names)
 ci-quality-ruff: dev-install  ## Run Ruff formatting and linting check (basic rules only)
 	@echo "Running Ruff formatting and linting check (basic rules only)..."
-	@uv run ruff check --select W,F,I --ignore E501 --quiet .
-	@uv run ruff format --check --quiet .
+	@uv run --no-sync ruff check --select W,F,I --ignore E501 --quiet .
+	@uv run --no-sync ruff format --check --quiet .
 
 ci-quality-ruff-optional:  ## Run Ruff extended linting (warnings only)
 	@echo "Running Ruff extended linting..."
-	uv run ruff check --select=E501,N,UP,B,PL,C90,RUF . || true
+	uv run --no-sync ruff check --select=E501,N,UP,B,PL,C90,RUF . || true
 
 ci-quality-radon:  ## Run radon complexity analysis
 	@echo "Running radon complexity analysis..."
@@ -28,19 +28,19 @@ ci-quality-full: ci-quality-ruff ci-quality-ruff-optional ci-quality-pyright  ##
 # Individual architecture quality targets (with tool names)
 ci-arch-cqrs:  ## Run CQRS pattern validation
 	@echo "Running CQRS pattern validation..."
-	./dev-tools/quality/validate_cqrs.py
+	uv run --no-sync python ./dev-tools/quality/validate_cqrs.py
 
 ci-arch-clean:  ## Run Clean Architecture dependency validation
 	@echo "Running Clean Architecture validation..."
-	./dev-tools/quality/check_architecture.py
+	uv run --no-sync python ./dev-tools/quality/check_architecture.py
 
 ci-arch-imports: dev-install  ## Run import validation
 	@echo "Running import validation..."
-	uv run python ./dev-tools/quality/validate_imports.py
+	uv run --no-sync python ./dev-tools/quality/validate_imports.py
 
 ci-arch-file-sizes:  ## Check file size compliance
 	@echo "Running file size checks..."
-	./dev-tools/quality/dev_tools_runner.py check-file-sizes --warn-only
+	uv run --no-sync python ./dev-tools/quality/dev_tools_runner.py check-file-sizes --warn-only
 
 ci-arch-lint-imports: dev-install  ## Run import-linter layer-boundary contracts
 	@echo "Running import-linter layer-boundary checks..."

--- a/makefiles/ci.mk
+++ b/makefiles/ci.mk
@@ -2,7 +2,9 @@
 
 # @SECTION CI Quality Checks
 # Individual code quality targets (with tool names)
-ci-quality-ruff: dev-install  ## Run Ruff formatting and linting check (basic rules only)
+ci-quality-ruff:  ## Run Ruff formatting and linting check (basic rules only)
+	@# In CI the venv is pre-populated by setup-uv-cached (group: lint).
+	@# Local fresh-checkout: run `make dev-install` first.
 	@echo "Running Ruff formatting and linting check (basic rules only)..."
 	@uv run --no-sync ruff check --select W,F,I --ignore E501 --quiet .
 	@uv run --no-sync ruff format --check --quiet .
@@ -34,7 +36,9 @@ ci-arch-clean:  ## Run Clean Architecture dependency validation
 	@echo "Running Clean Architecture validation..."
 	uv run --no-sync python ./dev-tools/quality/check_architecture.py
 
-ci-arch-imports: dev-install  ## Run import validation
+ci-arch-imports:  ## Run import validation
+	@# In CI the venv is pre-populated by setup-uv-cached (group: arch).
+	@# Local fresh-checkout: run `make dev-install` first.
 	@echo "Running import validation..."
 	uv run --no-sync python ./dev-tools/quality/validate_imports.py
 
@@ -42,7 +46,9 @@ ci-arch-file-sizes:  ## Check file size compliance
 	@echo "Running file size checks..."
 	uv run --no-sync python ./dev-tools/quality/dev_tools_runner.py check-file-sizes --warn-only
 
-ci-arch-lint-imports: dev-install  ## Run import-linter layer-boundary contracts
+ci-arch-lint-imports:  ## Run import-linter layer-boundary contracts
+	@# In CI the venv is pre-populated by setup-uv-cached (group: arch).
+	@# Local fresh-checkout: run `make dev-install` first.
 	@echo "Running import-linter layer-boundary checks..."
 	$(call run-tool,lint-imports,)
 
@@ -188,8 +194,10 @@ ci-tests-ui-smoke:  ## Boot embedded UI + curl each page + shut down (matches ci
 	@./dev-tools/ci/run_ui_smoke.sh
 
 ci-check-python-version-drift:  ## Assert that workflow fallback strings match .project.yml python.versions
+	@# pyyaml is available via the project's core [dependencies]; uv run --no-sync
+	@# uses the venv pre-populated by setup-uv-cached (group: arch) in CI.
 	@echo "Checking Python version drift between .project.yml and workflow fallback strings..."
-	@python3 dev-tools/ci/check_python_version_drift.py
+	@uv run --no-sync python dev-tools/ci/check_python_version_drift.py
 
 ci-check:  ## Run comprehensive CI checks (matches GitHub Actions exactly)
 	@echo "Running comprehensive CI checks that match GitHub Actions pipeline..."

--- a/makefiles/dev.mk
+++ b/makefiles/dev.mk
@@ -60,7 +60,7 @@ test-report: dev-install  ## Generate comprehensive test report (PRESERVE: used 
 	./dev-tools/testing/run_tests.py --all --coverage --junit-xml=test-results-combined.xml --cov-xml=coverage-combined.xml --html-coverage --maxfail=1 --timeout=60
 
 system-tests: dev-install  ## Run system integration tests (real AWS)
-	@uv run python -m pytest tests/providers/aws/live/test_onaws.py -v -m manual_aws --no-cov --tb=long
+	@uv run --no-sync python -m pytest tests/providers/aws/live/test_onaws.py -v -m manual_aws --no-cov --tb=long
 
 # Backward compatibility aliases (direct calls to avoid loops)
 test-unit: dev-install
@@ -109,14 +109,14 @@ _HALF_CPU := $(shell python3 -c 'import os; print(max(1, (os.cpu_count() or 2) /
 PYTEST_WORKERS ?= $(_HALF_CPU)
 
 test-no-live: dev-install  ## Run all tests except live cloud suites (pre-PR check)
-	@uv run pytest --no-cov -q -ra -n $(PYTEST_WORKERS) --ignore=tests/providers/aws/live
+	@uv run --no-sync pytest --no-cov -q -ra -n $(PYTEST_WORKERS) --ignore=tests/providers/aws/live
 
 test-providers: dev-install  ## Run all provider tests except live
-	@uv run pytest --no-cov -q -ra -n $(PYTEST_WORKERS) tests/providers --ignore=tests/providers/aws/live
+	@uv run --no-sync pytest --no-cov -q -ra -n $(PYTEST_WORKERS) tests/providers --ignore=tests/providers/aws/live
 
 
 test-architecture: dev-install  ## Run architecture compliance tests
-	@uv run pytest --no-cov -q -ra -n $(PYTEST_WORKERS) tests/unit/architecture tests/unit/test_architectural_compliance.py
+	@uv run --no-sync pytest --no-cov -q -ra -n $(PYTEST_WORKERS) tests/unit/architecture tests/unit/test_architectural_compliance.py
 
 # Dummy targets removed (consolidated in quality.mk)
 

--- a/makefiles/providers.mk
+++ b/makefiles/providers.mk
@@ -33,34 +33,37 @@ endef
 define _provider_targets
 test-providers-$(1)-unit: dev-install  ## Run $(1) provider unit tests
 	@if [ -d tests/providers/$(1)/unit ]; then \
-	  uv run pytest --no-cov -q -ra $(call _workers_flag,$(1)) tests/providers/$(1)/unit; \
+	  uv run --no-sync pytest --no-cov -q -ra $(call _workers_flag,$(1)) tests/providers/$(1)/unit; \
 	else \
 	  echo "no unit tests for $(1)"; \
 	fi
 
 test-providers-$(1)-mocked: dev-install  ## Run $(1) provider mocked tests (in-process API mock)
 	@if [ -d tests/providers/$(1)/mocked ]; then \
-	  uv run pytest --no-cov -q -ra $(call _workers_flag,$(1)) tests/providers/$(1)/mocked; \
+	  uv run --no-sync pytest --no-cov -q -ra $(call _workers_flag,$(1)) tests/providers/$(1)/mocked; \
 	else \
 	  echo "no mocked tests for $(1)"; \
 	fi
 
 test-providers-$(1)-contract: dev-install  ## Run $(1) provider contract tests
 	@if [ -d tests/providers/$(1)/contract ]; then \
-	  uv run pytest --no-cov -q -ra $(call _workers_flag,$(1)) tests/providers/$(1)/contract; \
+	  uv run --no-sync pytest --no-cov -q -ra $(call _workers_flag,$(1)) tests/providers/$(1)/contract; \
 	else \
 	  echo "no contract tests for $(1)"; \
 	fi
 
+# Live tests must sync the provider extra (--extra installs the cloud SDK).
+# ORB_SKIP_UI_BUILD=1 prevents setup.py's build_ui.sh hook from firing during
+# that extra-sync without stripping the --extra flag.
 test-providers-$(1)-live: dev-install  ## Run $(1) provider live tests (real cloud / cluster)
 	@if [ -d tests/providers/$(1)/live ]; then \
-	  uv run --extra $$(or $$(EXTRAS_$(1)),$(1)) pytest --no-cov -q -ra $(call _workers_flag,$(1)) $$(or $$(LIVE_GATE_$(1)),--run-$(1)) tests/providers/$(1)/live; \
+	  ORB_SKIP_UI_BUILD=1 uv run --extra $$(or $$(EXTRAS_$(1)),$(1)) pytest --no-cov -q -ra $(call _workers_flag,$(1)) $$(or $$(LIVE_GATE_$(1)),--run-$(1)) tests/providers/$(1)/live; \
 	else \
 	  echo "no live tests for $(1)"; \
 	fi
 
 test-providers-$(1): dev-install  ## Run all non-live $(1) provider tests
-	@uv run pytest --no-cov -q -ra $(call _workers_flag,$(1)) tests/providers/$(1) --ignore=tests/providers/$(1)/live
+	@uv run --no-sync pytest --no-cov -q -ra $(call _workers_flag,$(1)) tests/providers/$(1) --ignore=tests/providers/$(1)/live
 
 endef
 

--- a/makefiles/quality.mk
+++ b/makefiles/quality.mk
@@ -42,7 +42,8 @@ quality-check-fix: dev-install
 quality-check-files: dev-install
 	@./dev-tools/quality/quality_dispatcher.py files $(FILES)
 
-format-fix: dev-install  # CRITICAL: Used by ci.yml
+format-fix:  # CRITICAL: Used by ci.yml — venv pre-populated by setup-uv-cached (group: lint)
+	@# Local fresh-checkout: run `make dev-install` first.
 	@./dev-tools/quality/quality_dispatcher.py fix
 
 lint-optional: dev-install

--- a/makefiles/quality.mk
+++ b/makefiles/quality.mk
@@ -9,14 +9,14 @@ format: dev-install  ## Format code (usage: make format [fix])
 	@if echo "$(MAKECMDGOALS)" | grep -q "fix"; then \
 		./dev-tools/quality/quality_dispatcher.py fix; \
 	else \
-		uv run ruff format --check --quiet .; \
+		uv run --no-sync ruff format --check --quiet .; \
 	fi
 
 lint: dev-install  ## Lint code (usage: make lint [optional])
 	@if echo "$(MAKECMDGOALS)" | grep -q "optional"; then \
-		uv run ruff check --select=N,UP,B,PL,C90,RUF --quiet . || true; \
+		uv run --no-sync ruff check --select=N,UP,B,PL,C90,RUF --quiet . || true; \
 	else \
-		uv run ruff check --quiet .; \
+		uv run --no-sync ruff check --quiet .; \
 	fi
 
 validate: lint ci-tests-unit  ## Run all validation checks
@@ -141,7 +141,7 @@ validate-workflow-syntax: dev-install  ## Validate GitHub Actions workflow YAML 
 	@echo "Validating workflow files..."
 	# Use 'uv run' because this script imports PyYAML (third-party package)
 	# Other dev-tools scripts use only standard library so work with shebang
-	uv run ./dev-tools/quality/validate_workflows.py
+	uv run --no-sync ./dev-tools/quality/validate_workflows.py
 
 validate-workflow-logic: dev-install  ## Validate GitHub Actions workflows with actionlint
 	@echo "Validating workflows with actionlint..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,17 +303,51 @@ dev = [
 # Use: `uv sync --group dev` or `uv sync --group ci`
 # The [project.optional-dependencies] ci/dev sections above are pip shims
 # that mirror these lists for `pip install -e ".[dev]"` compatibility.
+#
+# Per-job groups (Phase 2 scoping):
+#   lint      — ruff + pathspec (lint-ruff, auto-format jobs)
+#   typecheck — pyright + type stubs (lint-pyright job)
+#   arch      — import-linter (arch-validation job; pyyaml via project deps)
+#   test      — pytest stack + all test dependencies (all test legs)
+#   docs      — mkdocs stack (docs job)
+#   security  — bandit/safety/pip-audit/cyclonedx (security-bandit/safety jobs)
+#   build     — build + wheel (build-and-package job)
+#
+# Umbrella groups (keep local dev + --all-groups unchanged):
+#   ci        — includes all sub-groups above (same resolved set as before)
+#   dev       — includes ci + local-dev tools
 # ---------------------------------------------------------------------------
-# CI Dependencies: What CI needs to test, lint, and build docs
-ci = [
-    # Code Quality Tools (ruff replaces black/isort/flake8/pylint)
+
+# --- per-job sub-groups ---
+
+lint = [
     "ruff>=0.1.0",
     "pathspec>=0.11.0",  # For gitignore pattern matching in dev-tools
-    "pyright>=1.1.408,<2.0.0",
-    "bandit>=1.7.5,<2.0.0",
-    "bandit-sarif-formatter>=1.1.1,<2.0.0",
-    "import-linter>=2.0,<3.0.0",  # Architecture layer-boundary enforcement
+]
 
+typecheck = [
+    "pyright>=1.1.408,<2.0.0",
+    # pyright type-checks the whole src/orb tree, so it needs every runtime
+    # dependency the code imports (fastapi, kubernetes, alembic, opentelemetry,
+    # rich, jinja2, starlette, prometheus-client, click, ...) importable — not
+    # just type stubs.  Pull the full runtime via the `all` extra; this group is
+    # synced standalone (--no-default-groups --group typecheck) so `all`'s ui
+    # extra does not clash with the ci/dev groups.
+    "orb-py[all]",
+    # Type stubs (augment the runtime packages above)
+    "types-PyYAML>=6.0.12.12,<7.0.0",
+    "types-python-dateutil>=2.8.19.14,<3.0.0",
+    "kubernetes-stubs-elephant-fork>=36.0.2,<37.0.0",
+    # For pyproject.toml parsing in dev scripts (Python < 3.11)
+    "tomli>=2.0.0,<3.0.0",
+]
+
+arch = [
+    "import-linter>=2.0,<3.0.0",  # Architecture layer-boundary enforcement
+    # pyyaml is available via project [dependencies] (always installed with the project)
+]
+
+test = [
     # Testing Framework
     "pytest>=7.4.3,<10.0.0",
     "pytest-cov>=4.1.0,<8.0.0",
@@ -325,26 +359,20 @@ ci = [
     "pytest-html>=4.1.1,<5.0.0",
     "pytest-benchmark>=5.1.0,<6.0.0",
     "coverage>=7.3.2,<8.0.0",
-
     # Test dependencies for API and template tests
     "fastapi>=0.128.0",
     "httpx>=0.27.0",  # Required by FastAPI TestClient
     "jinja2>=3.1.0",
-
     # AWS Testing
     "moto[all]>=5.1.19,<6.0.0",
     "responses>=0.24.0,<1.0.0",
     "requests-mock>=1.11.0,<2.0.0",
-    # Security overrides for vulnerable dependencies
+    # Security overrides for vulnerable transitive deps pulled in by test tooling
     "joserfc>=1.6.1",
     "werkzeug>=3.1.6",
     # Security override for safety's vulnerable nltk dependency (GHSA-7p94-766c-hgjp)
     "nltk>=3.9.3",
-
     # k8s-legacy extra deps — required for tests/integration/k8s_legacy/
-    # The [k8s-legacy] optional extra gates the shim on `kubernetes`; listing
-    # them here ensures the integration test job installs them via --all-groups
-    # without relying solely on --all-extras (which the cached env may skip).
     "kubernetes",
     "watchdog",
     "tenacity",
@@ -352,11 +380,8 @@ ci = [
     "uvicorn>=0.24.0",
     "prometheus-client>=0.17.0",
     "alembic>=1.13",
-
-    # OpenTelemetry stack — installed in CI so pyright resolves the guarded
-    # optional imports in bootstrap/telemetry.py and the observability tests
-    # exercise the real SDK path (the [monitoring] extra is not synced by
-    # --all-groups, which only pulls dependency-groups, not extras).
+    # OpenTelemetry stack — so pyright resolves guarded optional imports and
+    # observability tests exercise the real SDK path
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-prometheus>=0.64b0,<1.0",
     "opentelemetry-instrumentation-fastapi>=0.41b0,<1.0",
@@ -365,31 +390,11 @@ ci = [
     "opentelemetry-instrumentation-click>=0.64b0,<1.0",
     "opentelemetry-instrumentation-system-metrics>=0.64b0,<1.0",
     "opentelemetry-instrumentation-logging>=0.64b0,<1.0",
-
     # k8s HTTP-level mock server (test-only, not shipped with the package)
     "kmock>=0.7",
+]
 
-    # Essential Type Stubs
-    "types-PyYAML>=6.0.12.12,<7.0.0",
-    "types-python-dateutil>=2.8.19.14,<3.0.0",
-    "kubernetes-stubs-elephant-fork>=36.0.2,<37.0.0",
-
-    # Build Tools
-    "tomli>=2.0.0,<3.0.0",  # For pyproject.toml parsing in dev scripts (Python < 3.11)
-
-    # Security Scanning
-    "safety>=3.7.0,<4.0.0",
-    "pip-audit>=2.6.1,<3.0.0",
-    "semgrep>=1.45.0,<2.0.0",
-    "cyclonedx-bom>=4.0.0,<8.0.0",
-    # Security override for safety's vulnerable peewee dependency
-    "peewee>=3.18.3",
-    # Security override for safety's vulnerable marshmallow dependency (CVE-2025-68480)
-    "marshmallow>=4.1.2",
-    # Security override for lxml (CVE-2026-41066) — transitive via cyclonedx-bom + pip-audit
-    "lxml>=6.1.0",
-
-    # Documentation
+docs = [
     "mkdocs>=1.5.0,<2.0.0",
     "mkdocs-material>=9.1.0,<10.0.0",
     "mkdocstrings>=0.22.0,<2.0.0",
@@ -398,10 +403,40 @@ ci = [
     "mkdocs-literate-nav>=0.6.0,<1.0.0",
     "mkdocs-section-index>=0.3.0,<1.0.0",
     "mike>=1.1.0,<3.0.0",
+]
 
-    # Build and Packaging
+security = [
+    "bandit>=1.7.5,<2.0.0",
+    "bandit-sarif-formatter>=1.1.1,<2.0.0",
+    "safety>=3.7.0,<4.0.0",
+    "pip-audit>=2.6.1,<3.0.0",
+    "cyclonedx-bom>=4.0.0,<8.0.0",
+    # Security overrides for safety's vulnerable transitive deps
+    "peewee>=3.18.3",
+    "marshmallow>=4.1.2",
+    # Security override for lxml (CVE-2026-41066) — transitive via cyclonedx-bom + pip-audit
+    "lxml>=6.1.0",
+    # semgrep is intentionally excluded: the workflow pins and installs its own
+    # version via pip (semgrep==<pinned>) to avoid version drift with this group.
+]
+
+build = [
     "build>=1.0.3,<2.0.0",
     "wheel>=0.41.3,<1.0.0",
+]
+
+# --- umbrella groups (preserve --all-groups / local dev-install behaviour) ---
+
+# CI Dependencies: umbrella that includes all per-job sub-groups.
+# Resolved package set is identical to the former flat ci group.
+ci = [
+    {include-group = "lint"},
+    {include-group = "typecheck"},
+    {include-group = "arch"},
+    {include-group = "test"},
+    {include-group = "docs"},
+    {include-group = "security"},
+    {include-group = "build"},
 ]
 
 # Dev Dependencies: Additional dev tools (includes all CI deps)

--- a/uv.lock
+++ b/uv.lock
@@ -3505,6 +3505,13 @@ ui = [
 ]
 
 [package.dev-dependencies]
+arch = [
+    { name = "import-linter" },
+]
+build = [
+    { name = "build" },
+    { name = "wheel" },
+]
 ci = [
     { name = "alembic" },
     { name = "bandit" },
@@ -3540,6 +3547,7 @@ ci = [
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-instrumentation-system-metrics" },
     { name = "opentelemetry-sdk" },
+    { name = "orb-py", extra = ["all"], marker = "extra == 'group-6-orb-py-ci' or (extra == 'extra-6-orb-py-ui' and extra == 'group-6-orb-py-dev')" },
     { name = "pathspec" },
     { name = "peewee" },
     { name = "pg8000" },
@@ -3560,7 +3568,6 @@ ci = [
     { name = "responses" },
     { name = "ruff" },
     { name = "safety" },
-    { name = "semgrep" },
     { name = "tenacity" },
     { name = "tomli" },
     { name = "types-python-dateutil" },
@@ -3611,6 +3618,7 @@ dev = [
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-instrumentation-system-metrics" },
     { name = "opentelemetry-sdk" },
+    { name = "orb-py", extra = ["all"], marker = "extra == 'group-6-orb-py-ci' or extra == 'group-6-orb-py-dev' or extra != 'extra-6-orb-py-ui'" },
     { name = "pathspec" },
     { name = "peewee" },
     { name = "pg8000" },
@@ -3637,7 +3645,6 @@ dev = [
     { name = "responses" },
     { name = "ruff" },
     { name = "safety" },
-    { name = "semgrep" },
     { name = "tenacity" },
     { name = "tomli" },
     { name = "twine" },
@@ -3648,6 +3655,76 @@ dev = [
     { name = "watchdog" },
     { name = "werkzeug" },
     { name = "wheel" },
+]
+docs = [
+    { name = "mike" },
+    { name = "mkdocs" },
+    { name = "mkdocs-gen-files" },
+    { name = "mkdocs-literate-nav" },
+    { name = "mkdocs-material" },
+    { name = "mkdocs-section-index" },
+    { name = "mkdocstrings" },
+    { name = "mkdocstrings-python" },
+]
+lint = [
+    { name = "pathspec" },
+    { name = "ruff" },
+]
+security = [
+    { name = "bandit" },
+    { name = "bandit-sarif-formatter" },
+    { name = "cyclonedx-bom" },
+    { name = "lxml" },
+    { name = "marshmallow" },
+    { name = "peewee" },
+    { name = "pip-audit" },
+    { name = "safety" },
+]
+test = [
+    { name = "alembic" },
+    { name = "coverage" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "joserfc" },
+    { name = "kmock" },
+    { name = "kubernetes" },
+    { name = "moto", extra = ["all"] },
+    { name = "nltk" },
+    { name = "opentelemetry-exporter-prometheus" },
+    { name = "opentelemetry-instrumentation-botocore" },
+    { name = "opentelemetry-instrumentation-click" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-logging" },
+    { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "opentelemetry-instrumentation-system-metrics" },
+    { name = "opentelemetry-sdk" },
+    { name = "pg8000" },
+    { name = "prometheus-client" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-cov" },
+    { name = "pytest-env", version = "1.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-orb-py-ui' and extra == 'group-6-orb-py-ci') or (extra == 'extra-6-orb-py-ui' and extra == 'group-6-orb-py-dev')" },
+    { name = "pytest-env", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-orb-py-ui' and extra == 'group-6-orb-py-ci') or (extra == 'extra-6-orb-py-ui' and extra == 'group-6-orb-py-dev')" },
+    { name = "pytest-html" },
+    { name = "pytest-mock" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+    { name = "requests-mock" },
+    { name = "responses" },
+    { name = "tenacity" },
+    { name = "uvicorn" },
+    { name = "watchdog" },
+    { name = "werkzeug" },
+]
+typecheck = [
+    { name = "kubernetes-stubs-elephant-fork" },
+    { name = "orb-py", extra = ["all"] },
+    { name = "pyright" },
+    { name = "tomli" },
+    { name = "types-python-dateutil" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -3784,6 +3861,11 @@ requires-dist = [
 provides-extras = ["sql", "aws", "k8s", "all-providers", "k8s-legacy", "ui", "cli", "api", "otel", "monitoring", "monitoring-aws", "all", "test-aws", "test-k8s", "ci", "dev"]
 
 [package.metadata.requires-dev]
+arch = [{ name = "import-linter", specifier = ">=2.0,<3.0.0" }]
+build = [
+    { name = "build", specifier = ">=1.0.3,<2.0.0" },
+    { name = "wheel", specifier = ">=0.41.3,<1.0.0" },
+]
 ci = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "bandit", specifier = ">=1.7.5,<2.0.0" },
@@ -3819,6 +3901,7 @@ ci = [
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.41b0,<1.0" },
     { name = "opentelemetry-instrumentation-system-metrics", specifier = ">=0.64b0,<1.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
+    { name = "orb-py", extras = ["all"] },
     { name = "pathspec", specifier = ">=0.11.0" },
     { name = "peewee", specifier = ">=3.18.3" },
     { name = "pg8000" },
@@ -3838,7 +3921,6 @@ ci = [
     { name = "responses", specifier = ">=0.24.0,<1.0.0" },
     { name = "ruff", specifier = ">=0.1.0" },
     { name = "safety", specifier = ">=3.7.0,<4.0.0" },
-    { name = "semgrep", specifier = ">=1.45.0,<2.0.0" },
     { name = "tenacity" },
     { name = "tomli", specifier = ">=2.0.0,<3.0.0" },
     { name = "types-python-dateutil", specifier = ">=2.8.19.14,<3.0.0" },
@@ -3889,6 +3971,7 @@ dev = [
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.41b0,<1.0" },
     { name = "opentelemetry-instrumentation-system-metrics", specifier = ">=0.64b0,<1.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
+    { name = "orb-py", extras = ["all"] },
     { name = "pathspec", specifier = ">=0.11.0" },
     { name = "peewee", specifier = ">=3.18.3" },
     { name = "pg8000" },
@@ -3914,7 +3997,6 @@ dev = [
     { name = "responses", specifier = ">=0.24.0,<1.0.0" },
     { name = "ruff", specifier = ">=0.1.0" },
     { name = "safety", specifier = ">=3.7.0,<4.0.0" },
-    { name = "semgrep", specifier = ">=1.45.0,<2.0.0" },
     { name = "tenacity" },
     { name = "tomli", specifier = ">=2.0.0,<3.0.0" },
     { name = "twine", specifier = ">=4.0.0" },
@@ -3925,6 +4007,75 @@ dev = [
     { name = "watchdog" },
     { name = "werkzeug", specifier = ">=3.1.6" },
     { name = "wheel", specifier = ">=0.41.3,<1.0.0" },
+]
+docs = [
+    { name = "mike", specifier = ">=1.1.0,<3.0.0" },
+    { name = "mkdocs", specifier = ">=1.5.0,<2.0.0" },
+    { name = "mkdocs-gen-files", specifier = ">=0.5.0,<1.0.0" },
+    { name = "mkdocs-literate-nav", specifier = ">=0.6.0,<1.0.0" },
+    { name = "mkdocs-material", specifier = ">=9.1.0,<10.0.0" },
+    { name = "mkdocs-section-index", specifier = ">=0.3.0,<1.0.0" },
+    { name = "mkdocstrings", specifier = ">=0.22.0,<2.0.0" },
+    { name = "mkdocstrings-python", specifier = ">=1.1.0,<3.0.0" },
+]
+lint = [
+    { name = "pathspec", specifier = ">=0.11.0" },
+    { name = "ruff", specifier = ">=0.1.0" },
+]
+security = [
+    { name = "bandit", specifier = ">=1.7.5,<2.0.0" },
+    { name = "bandit-sarif-formatter", specifier = ">=1.1.1,<2.0.0" },
+    { name = "cyclonedx-bom", specifier = ">=4.0.0,<8.0.0" },
+    { name = "lxml", specifier = ">=6.1.0" },
+    { name = "marshmallow", specifier = ">=4.1.2" },
+    { name = "peewee", specifier = ">=3.18.3" },
+    { name = "pip-audit", specifier = ">=2.6.1,<3.0.0" },
+    { name = "safety", specifier = ">=3.7.0,<4.0.0" },
+]
+test = [
+    { name = "alembic", specifier = ">=1.13" },
+    { name = "coverage", specifier = ">=7.3.2,<8.0.0" },
+    { name = "fastapi", specifier = ">=0.128.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "jinja2", specifier = ">=3.1.0" },
+    { name = "joserfc", specifier = ">=1.6.1" },
+    { name = "kmock", specifier = ">=0.7" },
+    { name = "kubernetes" },
+    { name = "moto", extras = ["all"], specifier = ">=5.1.19,<6.0.0" },
+    { name = "nltk", specifier = ">=3.9.3" },
+    { name = "opentelemetry-exporter-prometheus", specifier = ">=0.64b0,<1.0" },
+    { name = "opentelemetry-instrumentation-botocore", specifier = ">=0.64b0,<1.0" },
+    { name = "opentelemetry-instrumentation-click", specifier = ">=0.64b0,<1.0" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.41b0,<1.0" },
+    { name = "opentelemetry-instrumentation-logging", specifier = ">=0.64b0,<1.0" },
+    { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.41b0,<1.0" },
+    { name = "opentelemetry-instrumentation-system-metrics", specifier = ">=0.64b0,<1.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
+    { name = "pg8000" },
+    { name = "prometheus-client", specifier = ">=0.17.0" },
+    { name = "pytest", specifier = ">=7.4.3,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21.1,<2.0.0" },
+    { name = "pytest-benchmark", specifier = ">=5.1.0,<6.0.0" },
+    { name = "pytest-cov", specifier = ">=4.1.0,<8.0.0" },
+    { name = "pytest-env", specifier = ">=1.1.1,<2.0.0" },
+    { name = "pytest-html", specifier = ">=4.1.1,<5.0.0" },
+    { name = "pytest-mock", specifier = ">=3.12.0,<4.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.2.0,<3.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.3.1,<4.0.0" },
+    { name = "requests-mock", specifier = ">=1.11.0,<2.0.0" },
+    { name = "responses", specifier = ">=0.24.0,<1.0.0" },
+    { name = "tenacity" },
+    { name = "uvicorn", specifier = ">=0.24.0" },
+    { name = "watchdog" },
+    { name = "werkzeug", specifier = ">=3.1.6" },
+]
+typecheck = [
+    { name = "kubernetes-stubs-elephant-fork", specifier = ">=36.0.2,<37.0.0" },
+    { name = "orb-py", extras = ["all"] },
+    { name = "pyright", specifier = ">=1.1.408,<2.0.0" },
+    { name = "tomli", specifier = ">=2.0.0,<3.0.0" },
+    { name = "types-python-dateutil", specifier = ">=2.8.19.14,<3.0.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.12,<7.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Speeds up and hardens CI dependency installation. Previously every CI job installed the full ~300-package development environment (`uv sync --all-groups`) — even a single-tool lint job — and the dependency cache never actually populated (it saved an empty `.venv`). This scopes each job to only the packages it needs and makes the cache work.

- **Per-job dependency scoping (PEP 735 groups):** the monolithic `ci` group is decomposed into orthogonal groups — `lint`, `typecheck`, `arch`, `test`, `docs`, `security`, `build` — with `ci`/`dev` redefined as umbrella `{include-group=…}` references, so `pip install`, `--all-groups`, and local dev resolve the **identical** package set as before (verified against the lockfile: 303 packages unchanged). Each CI job runs `uv sync --frozen --no-default-groups --group <its-group>`, installing ~35–130 packages instead of ~300. (The `typecheck` group pulls the full runtime via `[all]` because pyright type-checks the whole tree and needs every import resolvable.)
- **Working dependency cache:** `cache-management.yml` now populates the venv on a cache miss before saving; the key is per-group (`deps-py3.12-<group>-<lock hash>`). Each job also syncs-on-miss, so correctness never depends on the prime.
- **Security jobs use the cache:** the security workflow previously never primed/restored and cold-installed on every run; it now shares the mechanism, scoped to `security`. (semgrep is installed by the workflow at a pinned version, so it's kept out of the shared env to avoid drift.)
- **`uv run --no-sync` in CI:** bare `uv run` auto-syncs (rebuilding the package + firing the UI build hook); `--no-sync` uses the installed venv. Live-provider tests keep their sync (they need `--extra`) but skip the UI build.
- **Defensive UI-build skip** at the CI workflow env level; dropped redundant `dev-install` prerequisites from CI-only make targets (local fresh-checkout still works).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
<!-- Link any related issues here using #issue-number -->
Fixes #

## How Has This Been Tested?
<!-- Describe the tests you ran and how -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

- `uv lock` resolves the identical 303-package set as `main` (umbrella groups preserve local/release behavior).
- `uv sync --frozen --no-default-groups --group lint` installs ~35 packages (vs 300+); `--all-groups` still resolves the full set.
- `uv sync --group typecheck` + `pyright` → 0 errors (runtime deps resolvable).
- `uv run --no-sync ruff` / `make ci-arch-cqrs` run fast with no project rebuild.
- actionlint clean on all 21 workflows.

## Test Configuration
* Python version: 3.12 (CI); resolves for 3.10–3.14
* OS: ubuntu-latest
* AWS region: n/a
* Dependencies changed: dependency-group structure only; resolved package set unchanged

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md file

## Security Considerations
<!-- Describe any security implications of your changes -->
- [x] No security implications

Dependency scoping + caching + invocation only; the resolved dependency set is unchanged and no permissions are modified.

## Reviewers
@finos/open-resource-broker-maintainers
