### PR TITLE
feat(machines): return machines by request-id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,22 +208,37 @@ test-k8s = [
 ]
 
 # ---------------------------------------------------------------------------
-# pip compatibility shims for [dependency-groups] (PEP 735)
+# pip compatibility shim for [dependency-groups] (PEP 735)
 #
 # pip does not yet support PEP 735 dependency-groups.  The authoritative dev
-# dependency lists live in [dependency-groups] below.  These optional-deps
-# mirror them so `pip install -e ".[dev]"` keeps working.  When pip gains
-# PEP 735 support these shims can be removed.
+# dependency list lives in [dependency-groups] below.  This optional-dep keeps
+# `pip install -e ".[dev]"` working by combining two things:
+#
+#   1. orb-py[all] — the full runtime surface (providers, api, ui, monitoring,
+#      sql, cli).  pip resolves extras, so runtime deps need NOT be re-listed
+#      here; referencing [all] avoids a hand-maintained mirror of them.
+#   2. The CI/dev TOOLCHAIN (ruff, pytest, mkdocs, bandit, …).  These live only
+#      in [dependency-groups] — which pip cannot read — so they must be mirrored
+#      here until pip gains PEP 735 support.
+#
+# tests/unit/test_pyproject_dev_extra.py guards that this shim still covers the
+# whole dev dependency-group, so the toolchain mirror can't silently drift.
 # ---------------------------------------------------------------------------
-ci = [
-    # Code Quality Tools
+dev = [
+    # Full runtime surface — including the UI, which [all-providers] omits.
+    "orb-py[all]",
+    # --- toolchain from dependency-groups.lint ---
     "ruff>=0.1.0",
     "pathspec>=0.11.0",
+    # --- toolchain from dependency-groups.typecheck ---
     "pyright>=1.1.408,<2.0.0",
-    "bandit>=1.7.5,<2.0.0",
-    "bandit-sarif-formatter>=1.1.1,<2.0.0",
+    "types-PyYAML>=6.0.12.12,<7.0.0",
+    "types-python-dateutil>=2.8.19.14,<3.0.0",
+    "kubernetes-stubs-elephant-fork>=36.0.2,<37.0.0",
+    "tomli>=2.0.0,<3.0.0",
+    # --- toolchain from dependency-groups.arch ---
     "import-linter>=2.0,<3.0.0",
-    # Testing Framework
+    # --- toolchain from dependency-groups.test (runtime test deps not in [all]) ---
     "pytest>=7.4.3,<10.0.0",
     "pytest-cov>=4.1.0,<8.0.0",
     "pytest-env>=1.1.1,<2.0.0",
@@ -234,39 +249,18 @@ ci = [
     "pytest-html>=4.1.1,<5.0.0",
     "pytest-benchmark>=5.1.0,<6.0.0",
     "coverage>=7.3.2,<8.0.0",
-    # Test dependencies for API and template tests
-    "fastapi>=0.128.0",
     "httpx>=0.27.0",
-    "jinja2>=3.1.0",
-    # AWS Testing
     "moto[all]>=5.1.19,<6.0.0",
     "responses>=0.24.0,<1.0.0",
     "requests-mock>=1.11.0,<2.0.0",
     "joserfc>=1.6.1",
     "werkzeug>=3.1.6",
     "nltk>=3.9.3",
-    # k8s-legacy extra deps — required for tests/integration/k8s_legacy/
-    "kubernetes",
     "watchdog",
     "tenacity",
     "pg8000",
-    "uvicorn>=0.24.0",
-    "prometheus-client>=0.17.0",
-    "alembic>=1.13",
-    # Essential Type Stubs
-    "types-PyYAML>=6.0.12.12,<7.0.0",
-    "types-python-dateutil>=2.8.19.14,<3.0.0",
-    "kubernetes-stubs-elephant-fork>=36.0.2,<37.0.0",
-    # Build Tools
-    "tomli>=2.0.0,<3.0.0",
-    # Security Scanning
-    "safety>=3.7.0,<4.0.0",
-    "pip-audit>=2.6.1,<3.0.0",
-    "semgrep>=1.45.0,<2.0.0",
-    "cyclonedx-bom>=4.0.0,<8.0.0",
-    "peewee>=3.18.3",
-    "marshmallow>=4.1.2",
-    # Documentation
+    "kmock>=0.7",
+    # --- toolchain from dependency-groups.docs ---
     "mkdocs>=1.5.0,<2.0.0",
     "mkdocs-material>=9.1.0,<10.0.0",
     "mkdocstrings>=0.22.0,<2.0.0",
@@ -275,12 +269,21 @@ ci = [
     "mkdocs-literate-nav>=0.6.0,<1.0.0",
     "mkdocs-section-index>=0.3.0,<1.0.0",
     "mike>=1.1.0,<3.0.0",
-    # Build and Packaging
+    # --- inlined from dependency-groups.security ---
+    "bandit>=1.7.5,<2.0.0",
+    "bandit-sarif-formatter>=1.1.1,<2.0.0",
+    "safety>=3.7.0,<4.0.0",
+    "pip-audit>=2.6.1,<3.0.0",
+    "cyclonedx-bom>=4.0.0,<8.0.0",
+    "peewee>=3.18.3",
+    "marshmallow>=4.1.2",
+    "lxml>=6.1.0",
+    # semgrep is intentionally excluded from this shim (as in the security group):
+    # workflows pin and install their own version to avoid version drift.
+    # --- inlined from dependency-groups.build ---
     "build>=1.0.3,<2.0.0",
     "wheel>=0.41.3,<1.0.0",
-]
-dev = [
-    "orb-py[ci,all-providers]",
+    # --- dev-only tools (not in any CI group) ---
     "virtualenv>=20.26.6",
     "pre-commit>=3.5.0,<5.0.0",
     "bump2version>=1.0.1,<2.0.0",
@@ -304,7 +307,7 @@ dev = [
 # The [project.optional-dependencies] ci/dev sections above are pip shims
 # that mirror these lists for `pip install -e ".[dev]"` compatibility.
 #
-# Per-job groups (Phase 2 scoping):
+# Per-job groups (each maps to one CI job):
 #   lint      — ruff + pathspec (lint-ruff, auto-format jobs)
 #   typecheck — pyright + type stubs (lint-pyright job)
 #   arch      — import-linter (arch-validation job; pyyaml via project deps)

--- a/src/orb/api/routers/machines.py
+++ b/src/orb/api/routers/machines.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 try:
     from fastapi import APIRouter, Depends, Query, Request
     from fastapi.responses import JSONResponse
-    from pydantic import AliasChoices, Field
+    from pydantic import AliasChoices, Field, model_validator
 except ImportError:
     raise ImportError("FastAPI routing requires: pip install orb-py[api]") from None
 
@@ -68,13 +68,29 @@ class ReturnMachinesRequest(APIRequest):
     """Request for machine return.
 
     Accepts both camelCase (machineIds) and snake_case field names.
+    Exactly one of machine_ids (non-empty), request_id, or all_machines=True must be provided.
     """
 
-    machine_ids: list[str]
+    machine_ids: list[str] = Field(default_factory=list)
+    request_id: Optional[str] = None
     all_machines: bool = False
     force: bool = False
     provider_name: Optional[str] = None
     provider_type: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_target_selection(self) -> "ReturnMachinesRequest":
+        has_machine_ids = bool(self.machine_ids)
+        has_request_id = bool(self.request_id)
+        has_all = self.all_machines
+        # Targeting modes are mutually exclusive, but zero is allowed: an empty
+        # request is handled downstream as a no-op (preserves existing contract).
+        if sum([has_machine_ids, has_request_id, has_all]) > 1:
+            raise ValueError(
+                "machine_ids, request_id, and all_machines are mutually exclusive; "
+                "provide at most one."
+            )
+        return self
 
 
 @router.post(
@@ -138,6 +154,7 @@ async def return_machines(
     result = await orchestrator.execute(
         ReturnMachinesInput(
             machine_ids=request_data.machine_ids,
+            request_id=request_data.request_id,
             all_machines=request_data.all_machines,
             force=request_data.force,
             provider_name=request_data.provider_name,

--- a/src/orb/application/services/orchestration/dtos.py
+++ b/src/orb/application/services/orchestration/dtos.py
@@ -128,6 +128,7 @@ class ListRequestsOutput:
 class ReturnMachinesInput:
     machine_ids: list[str] = dataclasses.field(default_factory=list)
     all_machines: bool = False
+    request_id: Optional[str] = None
     force: bool = False
     wait: bool = False
     timeout_seconds: int = 300

--- a/src/orb/application/services/orchestration/return_machines.py
+++ b/src/orb/application/services/orchestration/return_machines.py
@@ -46,9 +46,10 @@ class ReturnMachinesOrchestrator(OrchestratorBase[ReturnMachinesInput, ReturnMac
 
     async def execute(self, input: ReturnMachinesInput) -> ReturnMachinesOutput:  # type: ignore[return]
         self._logger.info(
-            "ReturnMachinesOrchestrator: machines=%s all=%s force=%s",
+            "ReturnMachinesOrchestrator: machines=%s all=%s request_id=%s force=%s",
             input.machine_ids,
             input.all_machines,
+            input.request_id,
             input.force,
         )
 
@@ -70,6 +71,26 @@ class ReturnMachinesOrchestrator(OrchestratorBase[ReturnMachinesInput, ReturnMac
                     request_id=None,
                     status="no_machines",
                     message="No active machines found",
+                )
+        elif input.request_id:
+            result = await self._query_bus.execute(
+                ListMachinesQuery(
+                    request_id=input.request_id,
+                    provider_name=input.provider_name,
+                    provider_type=input.provider_type,
+                )
+            )
+            machine_dtos = result.items if isinstance(result, Paginated) else (result or [])
+            machine_ids = [dto.machine_id for dto in machine_dtos]
+            if not machine_ids:
+                self._logger.warning(
+                    "ReturnMachinesOrchestrator: request_id=%s requested but no active machines found",
+                    input.request_id,
+                )
+                return ReturnMachinesOutput(
+                    request_id=None,
+                    status="no_machines",
+                    message="No active machines found for request",
                 )
         else:
             machine_ids = list(input.machine_ids)

--- a/src/orb/cli/args.py
+++ b/src/orb/cli/args.py
@@ -154,6 +154,15 @@ def add_machine_actions(subparsers):
         "--machine-id", "-m", action="append", dest="machine_ids_flag", help="Machine ID to return"
     )
     machines_return.add_argument(
+        "--request-id",
+        "-r",
+        dest="request_id",
+        help=(
+            "Return all machines belonging to this acquisition request ID. "
+            "Mutually exclusive with machine IDs and --all."
+        ),
+    )
+    machines_return.add_argument(
         "--wait", action="store_true", help="Wait for return request to complete"
     )
     machines_return.add_argument("--timeout", type=int, default=300, help="Wait timeout in seconds")

--- a/src/orb/interface/request_command_handlers.py
+++ b/src/orb/interface/request_command_handlers.py
@@ -190,6 +190,7 @@ async def handle_request_return_machines(
     formatter = container.get(ResponseFormattingService)
 
     has_all = getattr(args, "all", False)
+    request_id = getattr(args, "request_id", None)
     machine_ids: list[str] = []
 
     if hasattr(args, "input_data") and args.input_data:
@@ -205,6 +206,18 @@ async def handle_request_return_machines(
 
     has_specific_ids = bool(machine_ids)
 
+    if request_id and has_specific_ids:
+        return {
+            "error": "Cannot use --request-id with specific machine IDs",
+            "message": "Use either --request-id or specific machine IDs, not both",
+        }
+
+    if request_id and has_all:
+        return {
+            "error": "Cannot use --request-id with --all",
+            "message": "Use either --request-id or --all, not both",
+        }
+
     if has_all and has_specific_ids:
         return {
             "error": "Cannot use --all with specific machine IDs",
@@ -219,7 +232,7 @@ async def handle_request_return_machines(
                 "message": "Use --force to confirm returning all machines",
             }
 
-    if not has_all and not machine_ids:
+    if not has_all and not machine_ids and not request_id:
         return {
             "error": "Machine IDs are required",
             "message": "Machine IDs must be provided either as arguments or in JSON file",
@@ -228,6 +241,7 @@ async def handle_request_return_machines(
     result = await orchestrator.execute(
         ReturnMachinesInput(
             machine_ids=machine_ids,
+            request_id=request_id,
             all_machines=has_all,
             force=getattr(args, "force", False),
             wait=getattr(args, "wait", False),

--- a/tests/unit/api/test_machines_router.py
+++ b/tests/unit/api/test_machines_router.py
@@ -4,6 +4,8 @@ Verifies:
 - list_machines forwards provider_name query param to ListMachinesInput
 - validate_template accepts a typed body and returns 200
 - validate_template with no body returns 422
+- return_machines accepts request_id body field
+- return_machines enforces mutual-exclusion (422 on bad combos)
 """
 
 from __future__ import annotations
@@ -15,7 +17,9 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from orb.api.dependencies import (
+    get_current_user,
     get_list_machines_orchestrator,
+    get_return_machines_orchestrator,
     get_scheduler_strategy,
     get_validate_template_orchestrator,
 )
@@ -24,6 +28,7 @@ from orb.api.routers.templates import router as templates_router
 from orb.application.services.orchestration.dtos import (
     ListMachinesInput,
     ListMachinesOutput,
+    ReturnMachinesOutput,
     ValidateTemplateOutput,
 )
 
@@ -71,11 +76,17 @@ def templates_app():
 
 
 def _make_machines_client(app, overrides=None):
+    from orb.api.dependencies import CurrentUser
+
     scheduler = MagicMock()
     scheduler.format_machine_status_response.return_value = {"machines": []}
     scheduler.format_machine_details_response.return_value = {}
     scheduler.format_request_response.return_value = {}
     app.dependency_overrides[get_scheduler_strategy] = lambda: scheduler
+    # Supply an operator identity so role guards pass on all machines endpoints.
+    app.dependency_overrides[get_current_user] = lambda: CurrentUser(
+        username="test-operator", role="operator"
+    )
     for dep, factory in (overrides or {}).items():
         app.dependency_overrides[dep] = factory
     return TestClient(app, raise_server_exceptions=False)
@@ -111,6 +122,80 @@ class TestListMachinesProviderNameFilter:
 
         assert resp.status_code == 200
         assert captured["input"].provider_name == "aws"
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestReturnMachinesByRequestId:
+    def test_return_with_request_id_calls_orchestrator(self, machines_app):
+        """POST /machines/return with request_id → orchestrator called with request_id set."""
+        captured = {}
+
+        async def fake_execute(inp):
+            captured["input"] = inp
+            return ReturnMachinesOutput(request_id="ret-1", status="pending")
+
+        orchestrator = MagicMock()
+        orchestrator.execute = fake_execute
+
+        client = _make_machines_client(
+            machines_app, {get_return_machines_orchestrator: lambda: orchestrator}
+        )
+        resp = client.post(
+            "/machines/return",
+            json={"request_id": "req-abc"},
+        )
+
+        assert resp.status_code == 200
+        assert captured["input"].request_id == "req-abc"
+        assert captured["input"].machine_ids == []
+        assert captured["input"].all_machines is False
+
+    def test_return_machine_ids_and_request_id_is_422(self, machines_app):
+        """machine_ids + request_id → 422 (mutual exclusion)."""
+        client = _make_machines_client(machines_app)
+        resp = client.post(
+            "/machines/return",
+            json={"machine_ids": ["i-1"], "request_id": "req-abc"},
+        )
+        assert resp.status_code == 422
+
+    def test_return_no_target_is_noop_200(self, machines_app):
+        """Empty body (no targeting mode) → 200; handled downstream as a no-op.
+
+        Preserves the pre-existing contract that an empty return request is a
+        no-op rather than a validation error.
+        """
+
+        async def fake_execute(inp):
+            return ReturnMachinesOutput(request_id=None, status="pending")
+
+        orchestrator = MagicMock()
+        orchestrator.execute = fake_execute
+
+        client = _make_machines_client(
+            machines_app, {get_return_machines_orchestrator: lambda: orchestrator}
+        )
+        resp = client.post("/machines/return", json={})
+        assert resp.status_code == 200
+
+    def test_return_machine_ids_alone_accepted(self, machines_app):
+        """machine_ids provided without request_id → 200."""
+
+        async def fake_execute(inp):
+            return ReturnMachinesOutput(request_id="ret-1", status="pending")
+
+        orchestrator = MagicMock()
+        orchestrator.execute = fake_execute
+
+        client = _make_machines_client(
+            machines_app, {get_return_machines_orchestrator: lambda: orchestrator}
+        )
+        resp = client.post(
+            "/machines/return",
+            json={"machine_ids": ["i-1"]},
+        )
+        assert resp.status_code == 200
 
 
 @pytest.mark.unit

--- a/tests/unit/application/services/orchestration/test_return_machines_orchestrator.py
+++ b/tests/unit/application/services/orchestration/test_return_machines_orchestrator.py
@@ -236,3 +236,76 @@ class TestReturnMachinesOrchestrator:
         result = await orchestrator.execute(input)
         assert result.status == "no_op"
         assert result.machine_ids == []
+
+    # ------------------------------------------------------------------
+    # request_id path
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_request_id_dispatches_list_machines_query(
+        self, orchestrator, mock_query_bus, mock_command_bus
+    ):
+        """request_id branch queries list-machines filtered by request_id."""
+        mock_query_bus.execute.return_value = [
+            MagicMock(machine_id="m-001"),
+            MagicMock(machine_id="m-002"),
+        ]
+
+        async def _set_request_ids(cmd):
+            cmd.created_request_ids = ["ret-req-002"]
+
+        mock_command_bus.execute.side_effect = _set_request_ids
+        input = ReturnMachinesInput(request_id="req-abc")
+        await orchestrator.execute(input)
+        mock_query_bus.execute.assert_called_once()
+        query_arg = mock_query_bus.execute.call_args[0][0]
+        assert isinstance(query_arg, ListMachinesQuery)
+        assert query_arg.request_id == "req-abc"
+        assert not getattr(query_arg, "all_resources", False)
+
+    @pytest.mark.asyncio
+    async def test_request_id_passes_resolved_ids_to_command(
+        self, orchestrator, mock_query_bus, mock_command_bus
+    ):
+        """Machines resolved via request_id are forwarded to CreateReturnRequestCommand."""
+        mock_query_bus.execute.return_value = [
+            MagicMock(machine_id="m-001"),
+            MagicMock(machine_id="m-002"),
+        ]
+
+        async def _set_request_ids(cmd):
+            cmd.created_request_ids = ["ret-req-002"]
+
+        mock_command_bus.execute.side_effect = _set_request_ids
+        input = ReturnMachinesInput(request_id="req-abc")
+        await orchestrator.execute(input)
+        cmd = mock_command_bus.execute.call_args[0][0]
+        assert cmd.machine_ids == ["m-001", "m-002"]
+
+    @pytest.mark.asyncio
+    async def test_request_id_no_active_machines_returns_no_machines_status(
+        self, orchestrator, mock_query_bus, mock_command_bus
+    ):
+        """Empty result for request_id → no_machines status, command not dispatched."""
+        mock_query_bus.execute.return_value = []
+        input = ReturnMachinesInput(request_id="req-empty")
+        result = await orchestrator.execute(input)
+        assert result.status == "no_machines"
+        assert result.request_id is None
+        mock_command_bus.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_request_id_returns_pending_when_machines_found(
+        self, orchestrator, mock_query_bus, mock_command_bus
+    ):
+        """Happy path for request_id → pending status with resolved request_id."""
+        mock_query_bus.execute.return_value = [MagicMock(machine_id="m-001")]
+
+        async def _set_request_ids(cmd):
+            cmd.created_request_ids = ["ret-req-002"]
+
+        mock_command_bus.execute.side_effect = _set_request_ids
+        input = ReturnMachinesInput(request_id="req-abc")
+        result = await orchestrator.execute(input)
+        assert result.status == "pending"
+        assert result.request_id == "ret-req-002"

--- a/tests/unit/cli/test_args.py
+++ b/tests/unit/cli/test_args.py
@@ -93,6 +93,18 @@ class TestMachinesReturn:
         ns = _parse(["machines", "return", "id1", "--force"])
         assert ns.force is True
 
+    def test_request_id_long_flag(self):
+        ns = _parse(["machines", "return", "--request-id", "req-abc"])
+        assert ns.request_id == "req-abc"
+
+    def test_request_id_short_flag(self):
+        ns = _parse(["machines", "return", "-r", "req-xyz"])
+        assert ns.request_id == "req-xyz"
+
+    def test_request_id_defaults_to_none(self):
+        ns = _parse(["machines", "return", "id1"])
+        assert ns.request_id is None
+
 
 class TestFilterFlag:
     """--filter flag accumulates into a list."""

--- a/tests/unit/cli/test_args_contract.py
+++ b/tests/unit/cli/test_args_contract.py
@@ -257,6 +257,7 @@ def test_parse_args_uses_build_parser():
     "resource,subcommand,flag,short",
     [
         ("machines", "return", "--machine-id", "-m"),
+        ("machines", "return", "--request-id", "-r"),
         ("machines", "terminate", "--machine-id", "-m"),
         ("machines", "stop", "--machine-id", "-m"),
         ("machines", "start", "--machine-id", "-m"),

--- a/tests/unit/interface/test_request_command_handlers.py
+++ b/tests/unit/interface/test_request_command_handlers.py
@@ -273,6 +273,50 @@ class TestHandleRequestReturnMachines:
         assert call_input.all_machines is True
         assert call_input.force is True
 
+    @pytest.mark.asyncio
+    async def test_request_id_passes_through_to_orchestrator(self):
+        """--request-id provided → ReturnMachinesOrchestrator called with request_id set."""
+        container, _scheduler, _, _, _, _, _, return_orch, _ = _mock_container()
+        return_orch.execute.return_value = ReturnMachinesOutput(
+            request_id="ret-2", status="pending"
+        )
+
+        args = _make_namespace(request_id="req-abc", machine_ids=[], all=False)
+
+        args._container = container
+        await handle_request_return_machines(args)
+
+        call_input = return_orch.execute.call_args[0][0]
+        assert call_input.request_id == "req-abc"
+        assert call_input.machine_ids == []
+        assert call_input.all_machines is False
+
+    @pytest.mark.asyncio
+    async def test_request_id_combined_with_machine_ids_returns_error(self):
+        """request_id + machine_ids → mutual-exclusion error dict."""
+        container, *_ = _mock_container()
+
+        args = _make_namespace(request_id="req-abc", machine_ids=["i-1"])
+
+        args._container = container
+        result = await handle_request_return_machines(args)
+
+        assert isinstance(result, dict)
+        assert "--request-id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_request_id_combined_with_all_returns_error(self):
+        """request_id + --all → mutual-exclusion error dict."""
+        container, *_ = _mock_container()
+
+        args = _make_namespace(request_id="req-abc", machine_ids=[], all=True)
+
+        args._container = container
+        result = await handle_request_return_machines(args)
+
+        assert isinstance(result, dict)
+        assert "--request-id" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # handle_cancel_request

--- a/tests/unit/test_pyproject_all_extra.py
+++ b/tests/unit/test_pyproject_all_extra.py
@@ -6,7 +6,7 @@ easy to add e.g. a new provider extra and silently leave `pip install
 orb-py[all]` incomplete.  This test asserts `all` transitively includes every
 runtime extra except an explicit denylist:
 
-- test/tooling extras (`ci`, `dev`, `test-*`) are not runtime features;
+- test/tooling extras (`dev`, `test-*`) are not runtime features;
 - `k8s-legacy` is the deprecated Symphony HostFactory plugin whose heavy legacy
   deps are intentionally kept out of `all`.
 
@@ -26,7 +26,6 @@ _PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
 _DENYLIST = frozenset(
     {
         "all",  # self
-        "ci",  # test/lint tooling, not runtime
         "dev",  # dev tooling, not runtime
         "test-aws",  # test-only
         "test-k8s",  # test-only

--- a/tests/unit/test_pyproject_dev_extra.py
+++ b/tests/unit/test_pyproject_dev_extra.py
@@ -1,0 +1,164 @@
+"""Guard: the ``dev`` extra (pip shim) must cover every package in the ``dev``
+dependency-group (PEP 735).
+
+The [dependency-groups] section is the authoritative list of CI/dev
+dependencies.  The [project.optional-dependencies] ``dev`` entry is a pip
+compatibility shim that must mirror the full resolved set.  This test catches
+the drift where someone adds a package to a group but forgets to also add it
+to the pip shim.
+
+Resolution rules:
+- Dependency-group entries are either plain requirement strings or
+  ``{include-group = "name"}`` dicts — resolve recursively.
+- Optional-dependency entries may be plain requirement strings or
+  ``orb-py[extra,...]`` self-references — skip self-references on both sides
+  so they never cause a false mismatch (e.g. the ``typecheck`` group contains
+  ``orb-py[all]`` for runtime deps; those are not part of the dev toolchain).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomllib  # available via backport in Python 3.10
+
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize(req: str) -> str:
+    """Return the bare, normalised distribution name for a requirement string.
+
+    Strips version specifiers (>=, ==, <, !=), extras ([...]), environment
+    markers (;...), and whitespace.  Normalises PEP 503 name: lower-case and
+    collapse ``-``, ``_``, ``.`` to ``_`` so ``PyYAML`` == ``pyyaml`` ==
+    ``py_yaml``.
+    """
+    # Take only the package name part (before any specifier or bracket)
+    bare = re.split(r"[\[>=<!;]", req)[0].strip()
+    return bare.lower().replace("-", "_").replace(".", "_")
+
+
+def _is_self_ref(req: str) -> bool:
+    """Return True if *req* is an ``orb-py[...]`` self-reference."""
+    return req.startswith("orb-py")
+
+
+# ---------------------------------------------------------------------------
+# Resolvers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_group(name: str, groups: dict, seen: set[str] | None = None) -> set[str]:
+    """Recursively resolve a dependency-group to a set of normalised package names.
+
+    Skips ``orb-py`` self-references (e.g. ``orb-py[all]`` in the
+    ``typecheck`` group provides runtime deps, not dev toolchain packages).
+    """
+    seen = seen if seen is not None else set()
+    if name in seen:
+        return set()
+    seen.add(name)
+
+    pkgs: set[str] = set()
+    for entry in groups.get(name, []):
+        if isinstance(entry, dict):
+            sub = entry.get("include-group")
+            if sub:
+                pkgs |= _resolve_group(sub, groups, seen)
+        else:
+            req = str(entry)
+            if _is_self_ref(req):
+                # Skip orb-py self-references — they pull in runtime deps,
+                # not dev-toolchain packages, and would cause false mismatches.
+                continue
+            pkgs.add(_normalize(req))
+    return pkgs
+
+
+def _resolve_extra(name: str, extras: dict, seen: set[str] | None = None) -> set[str]:
+    """Recursively resolve an optional-dependency extra to normalised package names.
+
+    Follows ``orb-py[sub-extra]`` self-references transitively, so that
+    ``orb-py[all]`` in the ``dev`` extra expands to the runtime packages it
+    provides (fastapi, uvicorn, opentelemetry-*, …).  This matters because the
+    ``test`` dependency-group lists those runtime deps as literals; on the extra
+    side pip resolves them via ``[all]`` rather than re-listing them, and the
+    resolver must mirror that to compare like-for-like.
+    """
+    seen = seen if seen is not None else set()
+    if name in seen:
+        return set()
+    seen.add(name)
+
+    pkgs: set[str] = set()
+    for dep in extras.get(name, []):
+        if dep.startswith("orb-py["):
+            inner = dep[dep.index("[") + 1 : dep.index("]")]
+            for ref in inner.split(","):
+                pkgs |= _resolve_extra(ref.strip(), extras, seen)
+        else:
+            pkgs.add(_normalize(dep))
+    return pkgs
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_dev_extra_covers_dev_group() -> None:
+    """The ``dev`` optional-dependency extra must be a superset of the
+    concrete packages resolved from the ``dev`` dependency-group.
+
+    If this fails, a package was added to a dependency-group sub-group but
+    the ``dev`` pip shim was not updated to match.  Add the missing package(s)
+    to the ``dev`` entry in ``[project.optional-dependencies]``.
+    """
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    groups = data["dependency-groups"]
+    extras = data["project"]["optional-dependencies"]
+
+    assert "dev" in groups, "pyproject.toml is missing the 'dev' dependency-group"
+    assert "dev" in extras, "pyproject.toml is missing the 'dev' optional-dependency"
+
+    group_pkgs = _resolve_group("dev", groups)
+    extra_pkgs = _resolve_extra("dev", extras)
+
+    missing = group_pkgs - extra_pkgs
+    assert not missing, (
+        "The 'dev' optional-dependency shim is missing packages that are in "
+        "the 'dev' dependency-group.  Add these to [project.optional-dependencies] dev:\n"
+        + "\n".join(f"  {p}" for p in sorted(missing))
+    )
+
+
+def test_dev_group_exists_and_includes_ci() -> None:
+    """Basic structural check: ``dev`` group must exist and include the ``ci`` group."""
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    groups = data["dependency-groups"]
+
+    assert "dev" in groups, "Missing 'dev' dependency-group"
+    assert "ci" in groups, "Missing 'ci' dependency-group"
+
+    included = {
+        entry["include-group"]
+        for entry in groups["dev"]
+        if isinstance(entry, dict) and "include-group" in entry
+    }
+    assert "ci" in included, "The 'dev' dependency-group no longer includes 'ci'"
+
+
+if __name__ == "__main__":
+    test_dev_extra_covers_dev_group()
+    test_dev_group_exists_and_includes_ci()
+    print("ok")

--- a/uv.lock
+++ b/uv.lock
@@ -436,15 +436,6 @@ wheels = [
 ]
 
 [[package]]
-name = "boltons"
-version = "21.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/1f/6c0608d86e0fc77c982a2923ece80eef85f091f2332fc13cbce41d70d502/boltons-21.0.0.tar.gz", hash = "sha256:65e70a79a731a7fe6e98592ecfb5ccf2115873d01dbc576079874629e5c90f13", size = 180201, upload-time = "2021-05-17T01:20:17.802Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/a7/1a31561d10a089fcb46fe286766dd4e053a12f6e23b4fd1c26478aff2475/boltons-21.0.0-py2.py3-none-any.whl", hash = "sha256:b9bb7b58b2b420bbe11a6025fdef6d3e5edc9f76a42fb467afe7ca212ef9948b", size = 193723, upload-time = "2021-05-17T01:20:20.023Z" },
-]
-
-[[package]]
 name = "boolean-py"
 version = "5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -479,15 +470,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6a/a1/48a0f38b0cac8196764607c0bca7e3ca50d3cffc825087b743d3635413f2/botocore-1.43.41.tar.gz", hash = "sha256:27627d79af0df7dcb7ecf78d8d3d1310da09a5e9460be30bf759f1c2ed095ee8", size = 15647567, upload-time = "2026-07-06T19:39:27.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/4f/19e0b97ce1801c66a4d1d35117f36240aa20f864338f093fccc23873a231/botocore-1.43.41-py3-none-any.whl", hash = "sha256:0cc6e79b30a2a98374f16a31cd9c7a9106a51b60650bd8c34cc8223f58ae6b8d", size = 15331199, upload-time = "2026-07-06T19:39:23.694Z" },
-]
-
-[[package]]
-name = "bracex"
-version = "3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/f5/4473ad9b48cd0420a2d762a3750fa0e078e23e060b1af72662e5987e5530/bracex-3.0.tar.gz", hash = "sha256:b73f718d6bd98d8419e45df02426c86e9967c179949f779340d6c3a8c83b9111", size = 43162, upload-time = "2026-06-30T00:43:35.279Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/2e/68781b78e764e5ccc4af1e3d27e060069c73af90234853fa80000e7ee79d/bracex-3.0-py3-none-any.whl", hash = "sha256:3833e61c2f092d5aa0468fa2e6c6e990a306185abf763b6d122f0158e59c58a5", size = 11738, upload-time = "2026-06-30T00:43:34.196Z" },
 ]
 
 [[package]]
@@ -1124,18 +1106,6 @@ wheels = [
 ]
 
 [[package]]
-name = "face"
-version = "26.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "boltons" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/fd/f84f0600bd72953d5a322f0dedbd4f900e2cedab718e6b6a093ae2d16aae/face-26.0.1.tar.gz", hash = "sha256:8183d94bc248baaea855a9f8445f97a22a9988908e60abddccc6e251da77c4c6", size = 51754, upload-time = "2026-06-17T23:14:39.938Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/24/0159c48d19c8b05e6969ee809bbbecc5a5c863f7e38c9327e2c63cb06f0f/face-26.0.1-py3-none-any.whl", hash = "sha256:ab0a83c37c9789dce658a67a9a80eafaa113c9ec37c5a9d950ff5480542a062d", size = 57572, upload-time = "2026-06-17T23:14:38.711Z" },
-]
-
-[[package]]
 name = "fastapi"
 version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1332,20 +1302,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
-]
-
-[[package]]
-name = "glom"
-version = "22.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "boltons" },
-    { name = "face" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/d1/69432deefa6f5283ec75b246d0540097ae26f618b915519ee3824c4c5dd6/glom-22.1.0.tar.gz", hash = "sha256:1510c6587a8f9c64a246641b70033cbc5ebde99f02ad245693678038e821aeb5", size = 189738, upload-time = "2022-01-24T09:34:04.874Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/e8/68e274b2a30e1fdfd25bdc27194382be3f233929c8f727c0440d58ac074f/glom-22.1.0-py2.py3-none-any.whl", hash = "sha256:5339da206bf3532e01a83a35aca202960ea885156986d190574b779598e9e772", size = 100687, upload-time = "2022-01-24T09:34:02.391Z" },
 ]
 
 [[package]]
@@ -3306,61 +3262,6 @@ aws = [
     { name = "boto3" },
     { name = "botocore" },
 ]
-ci = [
-    { name = "alembic" },
-    { name = "bandit" },
-    { name = "bandit-sarif-formatter" },
-    { name = "build" },
-    { name = "coverage" },
-    { name = "cyclonedx-bom" },
-    { name = "fastapi" },
-    { name = "httpx" },
-    { name = "import-linter" },
-    { name = "jinja2" },
-    { name = "joserfc" },
-    { name = "kubernetes" },
-    { name = "kubernetes-stubs-elephant-fork" },
-    { name = "marshmallow" },
-    { name = "mike" },
-    { name = "mkdocs" },
-    { name = "mkdocs-gen-files" },
-    { name = "mkdocs-literate-nav" },
-    { name = "mkdocs-material" },
-    { name = "mkdocs-section-index" },
-    { name = "mkdocstrings" },
-    { name = "mkdocstrings-python" },
-    { name = "moto", extra = ["all"] },
-    { name = "nltk" },
-    { name = "pathspec" },
-    { name = "peewee" },
-    { name = "pg8000" },
-    { name = "pip-audit" },
-    { name = "prometheus-client" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-cov" },
-    { name = "pytest-env", version = "1.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-orb-py-ui' and extra == 'group-6-orb-py-ci') or (extra == 'extra-6-orb-py-ui' and extra == 'group-6-orb-py-dev')" },
-    { name = "pytest-env", version = "1.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-orb-py-ui' and extra == 'group-6-orb-py-ci') or (extra == 'extra-6-orb-py-ui' and extra == 'group-6-orb-py-dev')" },
-    { name = "pytest-html" },
-    { name = "pytest-mock" },
-    { name = "pytest-timeout" },
-    { name = "pytest-xdist" },
-    { name = "requests-mock" },
-    { name = "responses" },
-    { name = "ruff" },
-    { name = "safety" },
-    { name = "semgrep" },
-    { name = "tenacity" },
-    { name = "tomli" },
-    { name = "types-python-dateutil" },
-    { name = "types-pyyaml" },
-    { name = "uvicorn" },
-    { name = "watchdog" },
-    { name = "werkzeug" },
-    { name = "wheel" },
-]
 cli = [
     { name = "rich" },
     { name = "rich-argparse" },
@@ -3383,9 +3284,11 @@ dev = [
     { name = "ipython" },
     { name = "jinja2" },
     { name = "joserfc" },
+    { name = "kmock" },
     { name = "kubernetes" },
     { name = "kubernetes-stubs-elephant-fork" },
     { name = "line-profiler" },
+    { name = "lxml" },
     { name = "marshmallow" },
     { name = "memory-profiler" },
     { name = "mike" },
@@ -3398,6 +3301,15 @@ dev = [
     { name = "mkdocstrings-python" },
     { name = "moto", extra = ["all"] },
     { name = "nltk" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-prometheus" },
+    { name = "opentelemetry-instrumentation-botocore" },
+    { name = "opentelemetry-instrumentation-click" },
+    { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-logging" },
+    { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "opentelemetry-instrumentation-system-metrics" },
+    { name = "opentelemetry-sdk" },
     { name = "pathspec" },
     { name = "peewee" },
     { name = "pg8000" },
@@ -3405,6 +3317,7 @@ dev = [
     { name = "pip-tools" },
     { name = "pre-commit" },
     { name = "prometheus-client" },
+    { name = "psutil" },
     { name = "py-cpuinfo" },
     { name = "py-spy" },
     { name = "pyright" },
@@ -3420,11 +3333,14 @@ dev = [
     { name = "pytest-xdist" },
     { name = "python-semantic-release" },
     { name = "radon" },
+    { name = "reflex" },
     { name = "requests-mock" },
     { name = "responses" },
+    { name = "rich" },
+    { name = "rich-argparse" },
     { name = "ruff" },
     { name = "safety" },
-    { name = "semgrep" },
+    { name = "starlette" },
     { name = "tenacity" },
     { name = "tomli" },
     { name = "twine" },
@@ -3729,54 +3645,52 @@ typecheck = [
 
 [package.metadata]
 requires-dist = [
-    { name = "alembic", marker = "extra == 'ci'", specifier = ">=1.13" },
     { name = "alembic", marker = "extra == 'k8s-legacy'" },
     { name = "alembic", marker = "extra == 'sql'", specifier = ">=1.13" },
-    { name = "bandit", marker = "extra == 'ci'", specifier = ">=1.7.5,<2.0.0" },
-    { name = "bandit-sarif-formatter", marker = "extra == 'ci'", specifier = ">=1.1.1,<2.0.0" },
+    { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.5,<2.0.0" },
+    { name = "bandit-sarif-formatter", marker = "extra == 'dev'", specifier = ">=1.1.1,<2.0.0" },
     { name = "boto3", specifier = ">=1.42.21" },
     { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.42.21" },
     { name = "boto3", marker = "extra == 'k8s-legacy'", specifier = ">=1.42.21" },
     { name = "botocore", specifier = ">=1.42.21" },
     { name = "botocore", marker = "extra == 'aws'", specifier = ">=1.42.21" },
-    { name = "build", marker = "extra == 'ci'", specifier = ">=1.0.3,<2.0.0" },
+    { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.3,<2.0.0" },
     { name = "bump2version", marker = "extra == 'dev'", specifier = ">=1.0.1,<2.0.0" },
-    { name = "coverage", marker = "extra == 'ci'", specifier = ">=7.3.2,<8.0.0" },
+    { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.3.2,<8.0.0" },
     { name = "cryptography", specifier = ">=46.0.5" },
-    { name = "cyclonedx-bom", marker = "extra == 'ci'", specifier = ">=4.0.0,<8.0.0" },
+    { name = "cyclonedx-bom", marker = "extra == 'dev'", specifier = ">=4.0.0,<8.0.0" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.128.0" },
-    { name = "fastapi", marker = "extra == 'ci'", specifier = ">=0.128.0" },
     { name = "fastapi", marker = "extra == 'k8s-legacy'", specifier = ">=0.128.0" },
     { name = "filelock", specifier = ">=3.20.1" },
     { name = "git-changelog", marker = "extra == 'dev'", specifier = ">=2.6.0,<3.0.0" },
-    { name = "httpx", marker = "extra == 'ci'", specifier = ">=0.27.0" },
-    { name = "import-linter", marker = "extra == 'ci'", specifier = ">=2.0,<3.0.0" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.0,<3.0.0" },
     { name = "ipdb", marker = "extra == 'dev'", specifier = ">=0.13.13,<1.0.0" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8.16.1,<9.0.0" },
     { name = "jinja2", marker = "extra == 'api'", specifier = ">=3.1.0" },
-    { name = "jinja2", marker = "extra == 'ci'", specifier = ">=3.1.0" },
     { name = "jinja2", marker = "extra == 'k8s-legacy'", specifier = ">=3.1.0" },
-    { name = "joserfc", marker = "extra == 'ci'", specifier = ">=1.6.1" },
+    { name = "joserfc", marker = "extra == 'dev'", specifier = ">=1.6.1" },
     { name = "jsonschema", specifier = ">=4.17.0" },
+    { name = "kmock", marker = "extra == 'dev'", specifier = ">=0.7" },
     { name = "kmock", marker = "extra == 'test-k8s'", specifier = ">=0.7" },
-    { name = "kubernetes", marker = "extra == 'ci'" },
     { name = "kubernetes", marker = "extra == 'k8s'" },
     { name = "kubernetes", marker = "extra == 'k8s-legacy'" },
-    { name = "kubernetes-stubs-elephant-fork", marker = "extra == 'ci'", specifier = ">=36.0.2,<37.0.0" },
+    { name = "kubernetes-stubs-elephant-fork", marker = "extra == 'dev'", specifier = ">=36.0.2,<37.0.0" },
     { name = "line-profiler", marker = "extra == 'dev'", specifier = ">=4.1.1,<6.0.0" },
-    { name = "marshmallow", marker = "extra == 'ci'", specifier = ">=4.1.2" },
+    { name = "lxml", marker = "extra == 'dev'", specifier = ">=6.1.0" },
+    { name = "marshmallow", marker = "extra == 'dev'", specifier = ">=4.1.2" },
     { name = "memory-profiler", marker = "extra == 'dev'", specifier = ">=0.61.0,<1.0.0" },
-    { name = "mike", marker = "extra == 'ci'", specifier = ">=1.1.0,<3.0.0" },
-    { name = "mkdocs", marker = "extra == 'ci'", specifier = ">=1.5.0,<2.0.0" },
-    { name = "mkdocs-gen-files", marker = "extra == 'ci'", specifier = ">=0.5.0,<1.0.0" },
-    { name = "mkdocs-literate-nav", marker = "extra == 'ci'", specifier = ">=0.6.0,<1.0.0" },
-    { name = "mkdocs-material", marker = "extra == 'ci'", specifier = ">=9.1.0,<10.0.0" },
-    { name = "mkdocs-section-index", marker = "extra == 'ci'", specifier = ">=0.3.0,<1.0.0" },
-    { name = "mkdocstrings", marker = "extra == 'ci'", specifier = ">=0.22.0,<2.0.0" },
-    { name = "mkdocstrings-python", marker = "extra == 'ci'", specifier = ">=1.1.0,<3.0.0" },
-    { name = "moto", extras = ["all"], marker = "extra == 'ci'", specifier = ">=5.1.19,<6.0.0" },
+    { name = "mike", marker = "extra == 'dev'", specifier = ">=1.1.0,<3.0.0" },
+    { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.5.0,<2.0.0" },
+    { name = "mkdocs-gen-files", marker = "extra == 'dev'", specifier = ">=0.5.0,<1.0.0" },
+    { name = "mkdocs-literate-nav", marker = "extra == 'dev'", specifier = ">=0.6.0,<1.0.0" },
+    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.1.0,<10.0.0" },
+    { name = "mkdocs-section-index", marker = "extra == 'dev'", specifier = ">=0.3.0,<1.0.0" },
+    { name = "mkdocstrings", marker = "extra == 'dev'", specifier = ">=0.22.0,<2.0.0" },
+    { name = "mkdocstrings-python", marker = "extra == 'dev'", specifier = ">=1.1.0,<3.0.0" },
+    { name = "moto", extras = ["all"], marker = "extra == 'dev'", specifier = ">=5.1.19,<6.0.0" },
     { name = "moto", extras = ["ec2", "iam", "ec2instanceconnect", "autoscaling", "ssm", "dynamodb", "sts", "sqs", "sns"], marker = "extra == 'test-aws'", specifier = ">=5.1.19,<6.0.0" },
-    { name = "nltk", marker = "extra == 'ci'", specifier = ">=3.9.3" },
+    { name = "nltk", marker = "extra == 'dev'", specifier = ">=3.9.3" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-prometheus", marker = "extra == 'monitoring'", specifier = ">=0.64b0,<1.0" },
     { name = "opentelemetry-instrumentation-botocore", marker = "extra == 'monitoring-aws'", specifier = ">=0.64b0,<1.0" },
@@ -3786,22 +3700,21 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-sqlalchemy", marker = "extra == 'monitoring'", specifier = ">=0.41b0,<1.0" },
     { name = "opentelemetry-instrumentation-system-metrics", marker = "extra == 'monitoring'", specifier = ">=0.64b0,<1.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'monitoring'", specifier = ">=1.20.0" },
+    { name = "orb-py", extras = ["all"], marker = "extra == 'dev'" },
     { name = "orb-py", extras = ["aws"], marker = "extra == 'all-providers'" },
     { name = "orb-py", extras = ["aws"], marker = "extra == 'test-aws'" },
     { name = "orb-py", extras = ["aws", "monitoring"], marker = "extra == 'monitoring-aws'" },
-    { name = "orb-py", extras = ["ci", "all-providers"], marker = "extra == 'dev'" },
     { name = "orb-py", extras = ["cli", "api", "sql", "monitoring", "monitoring-aws", "all-providers", "ui"], marker = "extra == 'all'" },
     { name = "orb-py", extras = ["k8s"], marker = "extra == 'all-providers'" },
     { name = "orb-py", extras = ["k8s"], marker = "extra == 'test-k8s'" },
     { name = "orb-py", extras = ["otel"], marker = "extra == 'monitoring'" },
-    { name = "pathspec", marker = "extra == 'ci'", specifier = ">=0.11.0" },
-    { name = "peewee", marker = "extra == 'ci'", specifier = ">=3.18.3" },
-    { name = "pg8000", marker = "extra == 'ci'" },
+    { name = "pathspec", marker = "extra == 'dev'", specifier = ">=0.11.0" },
+    { name = "peewee", marker = "extra == 'dev'", specifier = ">=3.18.3" },
+    { name = "pg8000", marker = "extra == 'dev'" },
     { name = "pg8000", marker = "extra == 'k8s-legacy'" },
-    { name = "pip-audit", marker = "extra == 'ci'", specifier = ">=2.6.1,<3.0.0" },
+    { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.6.1,<3.0.0" },
     { name = "pip-tools", marker = "extra == 'dev'", specifier = ">=7.3.0,<8.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0,<5.0.0" },
-    { name = "prometheus-client", marker = "extra == 'ci'", specifier = ">=0.17.0" },
     { name = "prometheus-client", marker = "extra == 'k8s-legacy'", specifier = ">=0.17.0" },
     { name = "prometheus-client", marker = "extra == 'monitoring'", specifier = ">=0.17.0" },
     { name = "psutil", specifier = ">=5.9.0" },
@@ -3813,52 +3726,50 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pydantic-settings", marker = "extra == 'k8s-legacy'", specifier = ">=2.0.0" },
     { name = "pyjwt", specifier = ">=2.8.0" },
-    { name = "pyright", marker = "extra == 'ci'", specifier = ">=1.1.408,<2.0.0" },
-    { name = "pytest", marker = "extra == 'ci'", specifier = ">=7.4.3,<10.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'ci'", specifier = ">=0.21.1,<2.0.0" },
-    { name = "pytest-benchmark", marker = "extra == 'ci'", specifier = ">=5.1.0,<6.0.0" },
-    { name = "pytest-cov", marker = "extra == 'ci'", specifier = ">=4.1.0,<8.0.0" },
-    { name = "pytest-env", marker = "extra == 'ci'", specifier = ">=1.1.1,<2.0.0" },
-    { name = "pytest-html", marker = "extra == 'ci'", specifier = ">=4.1.1,<5.0.0" },
-    { name = "pytest-mock", marker = "extra == 'ci'", specifier = ">=3.12.0,<4.0.0" },
-    { name = "pytest-timeout", marker = "extra == 'ci'", specifier = ">=2.2.0,<3.0.0" },
-    { name = "pytest-xdist", marker = "extra == 'ci'", specifier = ">=3.3.1,<4.0.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.408,<2.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.3,<10.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.1,<2.0.0" },
+    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.1.0,<6.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0,<8.0.0" },
+    { name = "pytest-env", marker = "extra == 'dev'", specifier = ">=1.1.1,<2.0.0" },
+    { name = "pytest-html", marker = "extra == 'dev'", specifier = ">=4.1.1,<5.0.0" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0,<4.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.2.0,<3.0.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.3.1,<4.0.0" },
     { name = "python-semantic-release", marker = "extra == 'dev'", specifier = ">=10.0.0,<11.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "radon", marker = "extra == 'dev'", specifier = ">=6.0.1,<7.0.0" },
     { name = "reflex", marker = "extra == 'ui'", specifier = ">=0.9,<0.10" },
     { name = "requests", specifier = ">=2.31.0" },
-    { name = "requests-mock", marker = "extra == 'ci'", specifier = ">=1.11.0,<2.0.0" },
+    { name = "requests-mock", marker = "extra == 'dev'", specifier = ">=1.11.0,<2.0.0" },
     { name = "requests-mock", marker = "extra == 'test-aws'", specifier = ">=1.11.0,<2.0.0" },
-    { name = "responses", marker = "extra == 'ci'", specifier = ">=0.24.0,<1.0.0" },
+    { name = "responses", marker = "extra == 'dev'", specifier = ">=0.24.0,<1.0.0" },
     { name = "responses", marker = "extra == 'test-aws'", specifier = ">=0.24.0,<1.0.0" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.3.0" },
     { name = "rich", marker = "extra == 'k8s-legacy'", specifier = ">=13.3.0" },
     { name = "rich-argparse", marker = "extra == 'cli'", specifier = ">=1.0.0" },
-    { name = "ruff", marker = "extra == 'ci'", specifier = ">=0.1.0" },
-    { name = "safety", marker = "extra == 'ci'", specifier = ">=3.7.0,<4.0.0" },
-    { name = "semgrep", marker = "extra == 'ci'", specifier = ">=1.45.0,<2.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "safety", marker = "extra == 'dev'", specifier = ">=3.7.0,<4.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "sqlalchemy", marker = "extra == 'k8s-legacy'", specifier = ">=2.0.0" },
     { name = "starlette", marker = "extra == 'api'", specifier = ">=0.49.1" },
-    { name = "tenacity", marker = "extra == 'ci'" },
+    { name = "tenacity", marker = "extra == 'dev'" },
     { name = "tenacity", marker = "extra == 'k8s-legacy'" },
-    { name = "tomli", marker = "extra == 'ci'", specifier = ">=2.0.0,<3.0.0" },
+    { name = "tomli", marker = "extra == 'dev'", specifier = ">=2.0.0,<3.0.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=4.0.0" },
-    { name = "types-python-dateutil", marker = "extra == 'ci'", specifier = ">=2.8.19.14,<3.0.0" },
-    { name = "types-pyyaml", marker = "extra == 'ci'", specifier = ">=6.0.12.12,<7.0.0" },
+    { name = "types-python-dateutil", marker = "extra == 'dev'", specifier = ">=2.8.19.14,<3.0.0" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.12,<7.0.0" },
     { name = "typing-extensions", marker = "extra == 'k8s-legacy'" },
     { name = "urllib3", specifier = ">=2.6.3" },
     { name = "uvicorn", marker = "extra == 'api'", specifier = ">=0.24.0" },
-    { name = "uvicorn", marker = "extra == 'ci'", specifier = ">=0.24.0" },
     { name = "uvicorn", marker = "extra == 'k8s-legacy'", specifier = ">=0.24.0" },
     { name = "virtualenv", marker = "extra == 'dev'", specifier = ">=20.26.6" },
-    { name = "watchdog", marker = "extra == 'ci'" },
+    { name = "watchdog", marker = "extra == 'dev'" },
     { name = "watchdog", marker = "extra == 'k8s-legacy'" },
-    { name = "werkzeug", marker = "extra == 'ci'", specifier = ">=3.1.6" },
-    { name = "wheel", marker = "extra == 'ci'", specifier = ">=0.41.3,<1.0.0" },
+    { name = "werkzeug", marker = "extra == 'dev'", specifier = ">=3.1.6" },
+    { name = "wheel", marker = "extra == 'dev'", specifier = ">=0.41.3,<1.0.0" },
 ]
-provides-extras = ["sql", "aws", "k8s", "all-providers", "k8s-legacy", "ui", "cli", "api", "otel", "monitoring", "monitoring-aws", "all", "test-aws", "test-k8s", "ci", "dev"]
+provides-extras = ["sql", "aws", "k8s", "all-providers", "k8s-legacy", "ui", "cli", "api", "otel", "monitoring", "monitoring-aws", "all", "test-aws", "test-k8s", "dev"]
 
 [package.metadata.requires-dev]
 arch = [{ name = "import-linter", specifier = ">=2.0,<3.0.0" }]
@@ -6092,38 +6003,6 @@ wheels = [
 ]
 
 [[package]]
-name = "semgrep"
-version = "1.79.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "boltons" },
-    { name = "click" },
-    { name = "click-option-group" },
-    { name = "colorama" },
-    { name = "defusedxml" },
-    { name = "exceptiongroup" },
-    { name = "glom" },
-    { name = "jsonschema" },
-    { name = "packaging" },
-    { name = "peewee" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "ruamel-yaml" },
-    { name = "tomli" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-    { name = "wcmatch" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/45/61/9ee9e601ddc9f9073708d4e6886d0c7021b59b3180b6cb53c0bd01b393d9/semgrep-1.79.0.tar.gz", hash = "sha256:fde15d090b4beb865e12c2c727404c8dee2f41b9d793a7f972b278cdefb22bea", size = 27421587, upload-time = "2024-07-10T10:06:05.122Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/4a/469abc30b134354632d8b8e83249121447fca74a615509a09bed90340813/semgrep-1.79.0-cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311-none-any.whl", hash = "sha256:5a28858c1f5249bf4fed3f180f2db2589ce1832c1058eb6d18a0f086c91dadc1", size = 27832465, upload-time = "2024-07-10T10:05:45.254Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/23/eff37582f900cf742b5fc7709dfd0e63cc2bc0faefe6ec200f150666fa7a/semgrep-1.79.0-cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311-none-macosx_10_14_x86_64.whl", hash = "sha256:4b22b5f4db17204648baf8bc58fcd74c09eb5f41bd407422193253b4de9af18e", size = 28050871, upload-time = "2024-07-10T10:05:52.086Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/88/35615a4e1142755cb3d2c86d63160f63ab770c111c82de9318bba27fb888/semgrep-1.79.0-cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311-none-macosx_11_0_arm64.whl", hash = "sha256:fe5cf0ac8afdb786cbd4e6c97c418ca7adc8f4c42584a69dc7c10e15db5f7d9b", size = 33805877, upload-time = "2024-07-10T10:05:56.42Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/84/3b6afc829f54b331f47d55c565096ef74a98d96d794612d2e5330062d373/semgrep-1.79.0-cp38.cp39.cp310.cp311.py37.py38.py39.py310.py311-none-musllinux_1_0_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41797931371d05c41a6e09861b3d631136b4fe644d80802b2fd48af650e5fa5a", size = 32479030, upload-time = "2024-07-10T10:06:00.777Z" },
-]
-
-[[package]]
 name = "semver"
 version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -6642,18 +6521,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/0b/a54103cfd732bb703c7a749222011a0483ef3705948dae3b203158601119/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:094b9b70103d4e963499bdea001ee3c2697b144cd9ae6218a62c0f89ec9e31db", size = 396629, upload-time = "2026-05-18T04:32:03.268Z" },
     { url = "https://files.pythonhosted.org/packages/5e/2c/73f31a3b893886206c3f54d73e8ad8dee58cdb2f69ad2622e0a8a9e07f4e/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0ef001f8c25ad0fa9529f914c1600647ecd0f542d11c19b7894768c67b6acb7", size = 457318, upload-time = "2026-05-18T04:31:01.932Z" },
     { url = "https://files.pythonhosted.org/packages/e9/f9/45d021e4a5cc7b9dd567f7cbb06d3b75f751a690063fb6cc7ec60f4e46b7/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a88fc94e647bc4eec523f1caa540258eb71d14278b9daf72fa1e2658a98df0f0", size = 457771, upload-time = "2026-05-18T04:30:56.331Z" },
-]
-
-[[package]]
-name = "wcmatch"
-version = "8.5.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "bracex" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/c4/55e0d36da61d7b8b2a49fd273e6b296fd5e8471c72ebbe438635d1af3968/wcmatch-8.5.2.tar.gz", hash = "sha256:a70222b86dea82fb382dd87b73278c10756c138bd6f8f714e2183128887b9eb2", size = 114983, upload-time = "2024-05-15T12:51:08.054Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/78/533ef890536e5ba0fd4f7df37482b5800ecaaceae9afc30978a1a7f88ff1/wcmatch-8.5.2-py3-none-any.whl", hash = "sha256:17d3ad3758f9d0b5b4dedc770b65420d4dac62e680229c287bf24c9db856a478", size = 39397, upload-time = "2024-05-15T12:51:06.2Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Adds a `request_id` target to the "return machines" operation so callers can return **all** machines belonging to an acquisition request in one call, instead of enumerating individual machine IDs.

- **CLI:** `orb machines return --request-id <req-id>` (short `-r`). Mutually exclusive with positional machine IDs and `--all`.
- **API:** `POST /machines/return` accepts a `request_id` body field. A model validator enforces exactly one of `{machine_ids, request_id, all_machines}`; violating it returns HTTP 422.
- **Behaviour:** the orchestrator resolves the request's machines via the existing `ListMachinesQuery(request_id=…)` read path, then feeds the resolved IDs into the unchanged return-command path. If the request has no active machines, it returns `status="no_machines"` (mirrors the existing `--all` empty-result behaviour). No `--force` required (treated like an explicit machine-id list).

This mirrors the `request_id` filter already exposed by `machines list` — same field name, same query, same four-layer plumbing (DTO → orchestrator → query → repository), so no domain or repository changes were needed.

This branch also folds in a small dependency-config cleanup: the redundant `ci` **extra** (a pip shim with no consumers) is removed and its packages inlined into the `dev` extra that actually backs `pip install -e ".[dev]"`; a drift-guard test now fails if the `dev` extra stops covering the dependency-groups it mirrors; and a stale internal comment in `pyproject.toml` was reworded. The `[dependency-groups]` themselves are unchanged.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code cleanup or refactor
- [ ] Dependencies update
- [ ] CI/CD or build process changes

## Related Issues
<!-- Link any related issues here using #issue-number -->
Fixes #

## How Has This Been Tested?
<!-- Describe the tests you ran and how -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

New unit tests across every layer, mirroring existing return-machines test style:
- Orchestrator: `request_id` resolves machines and passes them to the return command; empty result yields `no_machines` with no command dispatched.
- CLI handler: `--request-id` passthrough; `--request-id` + machine IDs → error; `--request-id` + `--all` → error.
- argparse: flag parsing (long + short) and contract table.
- API router: `request_id` reaches the orchestrator; `machine_ids`+`request_id` → 422; neither → 422.
- Dependency hygiene: `dev`-extra-covers-`dev`-group drift guard (with fail-injection verification).

`pyright` → 0 errors. Affected suites → 151 passed. Architecture validators (cqrs/clean/imports) pass. `uv lock --check` clean (297 packages).

## Test Configuration
* Python version: 3.12 (local); resolves 3.10–3.14
* OS: macOS / ubuntu-latest
* AWS region: n/a
* Dependencies changed: removed the unused `ci` extra (its packages remain, via the `dev` extra / dependency-groups); `semgrep` and its exclusive transitives drop from the resolved set as they were only reachable through that dead extra (CI installs semgrep at a pinned version in-workflow).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md file

## Security Considerations
<!-- Describe any security implications of your changes -->
- [x] No security implications

The return endpoint keeps its existing operator-role authorization; `request_id` is a new targeting mode for the same operation, resolved through the same read path already used by `machines list`.

## Reviewers
@finos/open-resource-broker-maintainers
