### PR TITLE
fix(release): decouple release-artifact signing from container build success

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -90,6 +90,10 @@ jobs:
     # prod-pypi, and github-assets.
     if: github.event_name == 'release'
     strategy:
+      # Each python-version variant scans, builds, and signs independently.
+      # fail-fast: false ensures that one variant's CVE gate failure does not
+      # cancel the other variants — each arch is self-contained.
+      fail-fast: false
       matrix:
         python-version: ${{ fromJSON(needs.config.outputs.python-versions) }}
 
@@ -491,7 +495,12 @@ jobs:
 
   github-assets:
     name: Upload GitHub Release Assets
-    needs: [config, build-wheel, prod-containers, prod-pypi]
+    # prod-containers intentionally removed from needs: wheel signing + GH release
+    # asset upload must run on every release independent of container health.
+    # A container base-image CVE (Trivy gate) must not prevent the Python
+    # wheel/sdist from being signed and published.  prod-manifests (which
+    # legitimately needs the pushed images) retains its prod-containers dep.
+    needs: [config, build-wheel, prod-pypi]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Only upload assets and create gh release upload on a real GitHub Release.

--- a/.trivyignore
+++ b/.trivyignore
@@ -22,3 +22,49 @@ htmlcov/**
 # security scanner). No fixed version available upstream as of 2026-06-17. Not
 # present in runtime install. Re-evaluate when nltk publishes a patched release.
 CVE-2026-54293
+
+# ── Debian 13 (trixie) OS-package CVEs with no upstream fix as of 2026-07-16 ─────
+#
+# All findings below are in the python:3.X-slim base image (Debian 13.6 for 3.14,
+# Debian 13.4 for older variants). The Dockerfile already runs `apt-get upgrade -y`
+# so every available Debian patch is applied at build time. The CVEs below are
+# suppressed because Debian has not yet published a fixed package version (status:
+# "affected" or "fix_deferred", Fixed Version column is empty in Trivy output).
+# Re-evaluate each on every release — remove this entry as soon as a fixed
+# Debian package is available.
+#
+# util-linux / bsdutils / libblkid1 / libuuid1 / libmount1 / libsmartcols1 /
+# liblastlog2-2 / login / mount — CVE-2026-53615 (HIGH)
+# Integer overflow in libblkid/src/partitions/dos.c. No fixed package in Debian 13.
+CVE-2026-53615
+#
+# ncurses (libncursesw6 / libtinfo6 / ncurses-base / ncurses-bin) — CVE-2025-69720 (HIGH)
+# Buffer overflow in ncurses that may lead to arbitrary code execution.
+# No fixed package in Debian 13 as of 2026-07-16.
+CVE-2025-69720
+#
+# gzip — CVE-2026-41992 (HIGH)
+# Global buffer overflow in LZH decompression. No fixed package in Debian 13.
+CVE-2026-41992
+#
+# libacl1 — CVE-2026-54369 (HIGH)
+# Symlink traversal privilege escalation via libacl functions.
+# No fixed package in Debian 13.
+CVE-2026-54369
+#
+# perl-base — CVE-2026-13221, CVE-2026-8376 (CRITICAL), CVE-2026-57432 (HIGH),
+#             CVE-2026-48962 (HIGH)
+# Multiple perl vulnerabilities (incorrect regex, heap buffer overflow on 32-bit,
+# integer overflow, arbitrary code execution via output glob).
+# No fixed package in Debian 13; status: "affected".
+CVE-2026-13221
+CVE-2026-8376
+CVE-2026-57432
+CVE-2026-48962
+#
+# perl-base — CVE-2026-42496, CVE-2026-42497, CVE-2026-9538 (HIGH/CRITICAL)
+# perl-Archive-Tar / perl-IO-Compress path traversal, arbitrary file modification,
+# DoS via crafted tar headers. No fixed package in Debian 13; status: "fix_deferred".
+CVE-2026-42496
+CVE-2026-42497
+CVE-2026-9538


### PR DESCRIPTION
## Description
Fixes the production release pipeline so release-artifact signing runs on every release, independent of container-build health, and unblocks the container Trivy gate.

**Root cause (observed on v1.8.1):** the `github-assets` job — which generates the Sigstore build-provenance attestation for the wheel/sdist and uploads them (plus the `.intoto.jsonl`) to the GitHub Release — had `needs: [..., prod-containers, ...]`. A container Trivy gate failure (unfixable Debian OS CVEs on the python image) failed `prod-containers`, which is fail-fast, cancelling the whole matrix and **skipping `github-assets` entirely**. Result: v1.8.1 shipped with no release-asset provenance and no signed containers, even though the wheel built and published to PyPI fine.

Changes:
- **Decouple signing from containers:** `github-assets` now `needs: [config, build-wheel, prod-pypi]` — it does not consume any `prod-containers` output, so a container CVE can no longer prevent the Python artifacts from being signed and attached to the release. `prod-manifests` retains its `prod-containers` dependency (it legitimately needs the pushed images).
- **Container matrix `fail-fast: false`:** one Python variant's gate failure no longer cancels the other variants — each builds, scans, and signs independently.
- **Unblock the Trivy gate:** the CRITICAL/HIGH findings on `python:3.14-slim` (Debian 13.6) are all upstream-unfixed (`affected` / `fix_deferred`); the Dockerfile already runs `apt-get upgrade`, so no base-image bump can clear them. They are suppressed in `.trivyignore` with per-CVE attribution, following the pattern already established in the repo for a prior unfixable CVE. The gate still blocks on any fixable CRITICAL/HIGH.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

- `actionlint .github/workflows/prod-release.yml` → 0 errors.
- Dependency graph reviewed: `github-assets` has no `needs.prod-containers.*` references; `prod-manifests`/`container-cleanup` chains unchanged.
- Local `trivy image` scan of the built image with the new `.trivyignore` → 0 remaining CRITICAL/HIGH, exit 0.

Full end-to-end validation only occurs on a real tagged release (release-only jobs).

## Test Configuration
* Python version: n/a (workflow change)
* OS: ubuntu-latest
* AWS region: n/a
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md file

## Security Considerations
- [x] Security improved

Ensures every release's Python artifacts carry Sigstore build-provenance attestations regardless of container-scan outcome (previously a container CVE could silently skip all release signing). Suppressed CVEs are OS-level, upstream-unfixed, and individually attributed; the gate still blocks fixable CRITICAL/HIGH.

## Reviewers
@finos/open-resource-broker-maintainers
