### PR TITLE
fix(release): repair SBOM generation, Trivy gate suppression, and a test-order flake

### DIFF
--- a/.github/workflows/dev-containers.yml
+++ b/.github/workflows/dev-containers.yml
@@ -250,6 +250,7 @@ jobs:
         output: 'trivy-results-py${{ matrix.python-version }}.sarif'
         exit-code: '0'
         severity: ${{ env.SCAN_LEVEL == 'full' && 'CRITICAL,HIGH,MEDIUM' || 'CRITICAL,HIGH' }}
+        trivyignores: .trivyignore
 
     - name: Upload Trivy scan results
       uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -168,6 +168,9 @@ jobs:
       # exit-code: '1' blocks the push if CRITICAL or HIGH CVEs are found.
       # This is the security gate: the image is not pushed to GHCR until it
       # passes.  SCAN_LEVEL == 'full' only on the default Python matrix entry.
+      # trivyignores honours the suppression file for known unfixable base-image
+      # CVEs (e.g. Debian CVEs in the Python slim images) so the gate only fires
+      # on actionable findings.
       if: env.SCAN_LEVEL == 'full'
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
       with:
@@ -176,6 +179,7 @@ jobs:
         output: 'trivy-results-py${{ matrix.python-version }}.sarif'
         exit-code: '1'
         severity: 'CRITICAL,HIGH'
+        trivyignores: .trivyignore
 
     - name: Build and push container image
       id: build
@@ -250,6 +254,7 @@ jobs:
         output: 'trivy-results-py${{ matrix.python-version }}.sarif'
         exit-code: '0'
         severity: 'CRITICAL,HIGH'
+        trivyignores: .trivyignore
 
     - name: Upload Trivy scan results
       uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -112,6 +112,7 @@ jobs:
           scan-ref: '.'
           format: 'sarif'
           output: 'trivy-fs-results.sarif'
+          trivyignores: .trivyignore
 
       - name: Upload Trivy filesystem scan results
         if: inputs.scan-type == 'trivy-fs' && always()

--- a/dev-tools/setup/install_dev_tools.py
+++ b/dev-tools/setup/install_dev_tools.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Development Tools Installation Script
 

--- a/makefiles/quality.mk
+++ b/makefiles/quality.mk
@@ -69,14 +69,14 @@ hadolint-check-container: dev-install  ## Check Dockerfile with hadolint in cont
 	./dev-tools/ci/run_dev_checks.sh all
 
 install-dev-tools: dev-install  ## Install all development tools
-	./dev-tools/setup/install_dev_tools.py
+	$(PYTHON) ./dev-tools/setup/install_dev_tools.py
 
 install-dev-tools-required: dev-install  ## Install only required development tools
-	./dev-tools/setup/install_dev_tools.py --required-only
+	$(PYTHON) ./dev-tools/setup/install_dev_tools.py --required-only
 
 install-dev-tools-dry-run: dev-install  ## Show what development tools would be installed
 	@echo "Checking what development tools would be installed..."
-	./dev-tools/setup/install_dev_tools.py --dry-run
+	$(PYTHON) ./dev-tools/setup/install_dev_tools.py --dry-run
 
 clean-whitespace:  ## Clean whitespace in blank lines from all files
 	@echo "Cleaning whitespace in blank lines..."
@@ -95,8 +95,8 @@ security: dev-install  ## Run security checks (usage: make security [quick] [all
 sbom-generate: dev-install ## Generate Software Bill of Materials (SBOM)
 	@echo "Generating SBOM files..."
 	@echo "Ensuring required tools are installed..."
-	./dev-tools/setup/install_dev_tools.py --tool syft
-	./dev-tools/setup/install_dev_tools.py --tool pip-audit
+	$(PYTHON) ./dev-tools/setup/install_dev_tools.py --tool syft
+	$(PYTHON) ./dev-tools/setup/install_dev_tools.py --tool pip-audit
 	@echo "Generating Python dependency SBOM..."
 	# pip-audit exits 1 when it finds CVEs (routine) or on a network blip.
 	# We still want the output file; || true keeps the recipe non-failing.
@@ -147,13 +147,13 @@ validate-workflow-syntax: dev-install  ## Validate GitHub Actions workflow YAML 
 validate-workflow-logic: dev-install  ## Validate GitHub Actions workflows with actionlint
 	@echo "Validating workflows with actionlint..."
 	@echo "Ensuring actionlint is installed..."
-	./dev-tools/setup/install_dev_tools.py --tool actionlint
+	$(PYTHON) ./dev-tools/setup/install_dev_tools.py --tool actionlint
 	./dev-tools/quality/validate_actionlint.py
 
 validate-shell-scripts: dev-install  ## Validate shell scripts with shellcheck
 	@echo "Validating shell scripts with shellcheck..."
 	@echo "Ensuring shellcheck is installed..."
-	./dev-tools/setup/install_dev_tools.py --tool shellcheck
+	$(PYTHON) ./dev-tools/setup/install_dev_tools.py --tool shellcheck
 	./dev-tools/quality/validate_shell_scripts.py
 
 validate-all-workflows: validate-workflow-syntax validate-workflow-logic  ## Run all workflow validation checks

--- a/tests/unit/providers/test_cli_early_bootstrap_ordering.py
+++ b/tests/unit/providers/test_cli_early_bootstrap_ordering.py
@@ -17,6 +17,14 @@ from unittest.mock import patch
 
 def test_register_all_provider_cli_specs_calls_discover_first(monkeypatch) -> None:
     """register_all_provider_cli_specs calls discover_provider_plugins before iterating."""
+    # Import the module before patching so sys.modules holds the canonical object.
+    # A prior test may evict `orb.providers.registration` from sys.modules; if
+    # monkeypatch.setattr runs while the module is absent it patches a stale
+    # package-attribute object (the `orb.providers.registration` binding left on the
+    # orb.providers package), while the subsequent `import` statement re-imports a
+    # fresh copy — two different objects, so the patch is invisible at call time.
+    import orb.providers.registration as reg_mod
+
     call_log: list[str] = []
 
     def _fake_discover(*args, **kwargs):
@@ -26,8 +34,6 @@ def test_register_all_provider_cli_specs_calls_discover_first(monkeypatch) -> No
     monkeypatch.setattr("orb.providers.registration.discover_provider_plugins", _fake_discover)
     # Start with an empty provider list to ensure discover is truly first
     monkeypatch.setattr("orb.providers.registration._REGISTERED_PROVIDERS", [])
-
-    import orb.providers.registration as reg_mod
 
     reg_mod.register_all_provider_cli_specs()
 
@@ -39,6 +45,11 @@ def test_register_all_provider_cli_specs_calls_discover_first(monkeypatch) -> No
 
 def test_register_all_defaults_loaders_calls_discover_first(monkeypatch) -> None:
     """register_all_defaults_loaders calls discover_provider_plugins before iterating."""
+    # Import before patching for the same reason as the cli-specs test above:
+    # ensures sys.modules holds the live module so monkeypatch and the
+    # registration call operate on the same object regardless of suite order.
+    import orb.providers.registration as reg_mod
+
     call_log: list[str] = []
 
     def _fake_discover(*args, **kwargs):
@@ -47,8 +58,6 @@ def test_register_all_defaults_loaders_calls_discover_first(monkeypatch) -> None
 
     monkeypatch.setattr("orb.providers.registration.discover_provider_plugins", _fake_discover)
     monkeypatch.setattr("orb.providers.registration._REGISTERED_PROVIDERS", [])
-
-    import orb.providers.registration as reg_mod
 
     reg_mod.register_all_defaults_loaders()
 

--- a/uv.lock
+++ b/uv.lock
@@ -3204,7 +3204,7 @@ wheels = [
 
 [[package]]
 name = "orb-py"
-version = "1.8.1"
+version = "1.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Description
Fixes three post-merge failures that surfaced after the provider-centralization and release-signing work landed. Together they caused v1.8.2 to ship without a signed GitHub Release (no `.intoto.jsonl`) and a scheduled CI failure.

- **SBOM generation ran a Python script through `sh`.** `make sbom-generate` invoked `./dev-tools/setup/install_dev_tools.py` as a bare path; with no shebang and no exec handling, make spawned it via `/bin/sh`, which choked on the module docstring (`import: not found`, `Syntax error`). The step failed, so the downstream provenance attestation + release-asset upload never ran — the release-signing gap. Fixed by invoking via `$(PYTHON)` (matching the pattern already used elsewhere) for all `install_dev_tools.py` calls, plus a `#!/usr/bin/env python3` shebang as defence-in-depth.
- **Container Trivy gate ignored `.trivyignore`.** The gate step had no `trivyignores:` input, so the documented, unfixable Debian-13 base-image CVE suppressions were not applied and the python3.14 container gate failed (blocking manifests and failing the release). Added `trivyignores: .trivyignore` to the gate step (and the advisory/fs scan steps for consistency). Gate severity and exit-code are unchanged — it still blocks fixable CRITICAL/HIGH.
- **Order-dependent test flake.** `test_register_all_provider_cli_specs_calls_discover_first` passed in isolation but failed in the full suite: a prior test evicts `orb.providers.registration` from `sys.modules`, so the test's `monkeypatch.setattr` patched a stale module object while the test body re-imported a fresh one. Fixed by importing the module before patching so both operate on the canonical object. Production code is unchanged and correct (discovery is genuinely called first).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

- `python3 ./dev-tools/setup/install_dev_tools.py --tool syft --dry-run` → runs as Python (no sh syntax error).
- `pytest tests/unit/test_no_provider_install.py tests/unit/providers/test_cli_early_bootstrap_ordering.py` → 7 passed (previously 1 failed); `pytest tests/unit/providers` → 373 passed, no regressions.
- `pyright src/` → 0 errors; ruff (W/F/I + format) → clean; `actionlint .github/workflows/*.yml` → 0 errors.
- Full end-to-end signing only exercises on a real tagged release; the next release will pick up the fixed pipeline.

## Test Configuration
* Python version: 3.12 local; resolves 3.10–3.14
* OS: macOS / ubuntu-latest
* AWS region: n/a
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md file

## Security Considerations
- [x] Security improved

Restores signed GitHub Release assets (build-provenance `.intoto.jsonl`) on every release by unblocking the SBOM+attestation path, and makes the container CVE gate honor its documented suppression file without weakening the CRITICAL/HIGH block.

## Reviewers
@finos/open-resource-broker-maintainers
