### PR TITLE
fix(docker): clear setuptools CVEs failing the container Trivy gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
         ca-certificates=20250419 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --no-cache-dir --upgrade pip setuptools wheel
+    pip install --no-cache-dir --upgrade pip "setuptools>=78.1.1" wheel
 ARG BUILD_DATE
 ARG VERSION=dev
 ARG VCS_REF
@@ -62,6 +62,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY dist/*.whl /tmp/
 RUN WHEEL=$(ls /tmp/*.whl) \
     && uv pip install --no-cache "${WHEEL}[all]" \
+    && uv pip install --no-cache --upgrade "setuptools>=78.1.1" \
     && rm -f /tmp/*.whl
 
 # Copy only runtime files needed


### PR DESCRIPTION
## Description
Clears the CRITICAL/HIGH CVEs that fail the container Trivy gate on the release pipeline's default-Python (3.14) image, so `prod-containers` and its downstream manifest/signing jobs complete.

Root-caused the 9 unsuppressed findings from the v1.8.3 release scan:

- **3 `setuptools` HIGH CVEs (RCE / ReDoS / path-traversal)** — CVE-2024-6345, CVE-2022-40897, CVE-2025-47273. The base Python already upgraded setuptools, but the runtime venv at `/opt/venv` is created by `uv venv` and is isolated from the base interpreter's site-packages — Trivy scans both, and the venv had no explicitly-patched setuptools. **Fixed** by installing `setuptools>=78.1.1` (clears all three) into the venv, plus making the base-image constraint explicit. No suppression.
- **6 Debian trixie OS CVEs** — sqlite/zlib/openldap/perl/glibc/pam. Verified against the Debian Security Tracker: all are already fixed in the package versions shipped by the current `python:3.14-slim` base (which the Dockerfile's `apt-get update && apt-get upgrade -y` keeps current); the failing scan had a stale Trivy vulnerability DB. No `.trivyignore` entries added — suppressing already-fixed CVEs would be wrong.

No new suppressions; the fix is a real dependency upgrade.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

- Local `trivy image --severity CRITICAL,HIGH --ignorefile .trivyignore` on the built 3.14 image → 0 CRITICAL/HIGH (setuptools 83.0.0 present in both base site-packages and `/opt/venv`).
- Each of the 6 OS CVEs cross-checked against the Debian Security Tracker for a fixed trixie package version.
- `actionlint .github/workflows/*.yml` → 0 errors (workflows unchanged).

## Test Configuration
* Python version: 3.10–3.14 container matrix
* OS: Debian 13.6 (trixie) base
* AWS region: n/a
* Dependencies changed: setuptools pinned `>=78.1.1` in the container image only

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md file

## Security Considerations
- [x] Security improved

Removes three HIGH setuptools vulnerabilities (including an RCE) from the published container's runtime environment by upgrading to a patched version. The container CVE gate remains a blocking CRITICAL/HIGH check.

## Reviewers
@finos/open-resource-broker-maintainers
