### PR TITLE
ci(arch): enforce import-linter layer contracts and standardize config deprecation

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -254,7 +254,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        check: [cqrs, clean, imports, file-sizes]
+        check: [cqrs, clean, imports, lint-imports, file-sizes]
         include:
           - check: cqrs
             description: "CQRS Pattern Validation"
@@ -262,6 +262,8 @@ jobs:
             description: "Clean Architecture Dependencies"
           - check: imports
             description: "Import Validation"
+          - check: lint-imports
+            description: "Import-Linter Layer Contracts"
           - check: file-sizes
             description: "File Size Compliance"
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,11 +191,13 @@ make ci-quality-ruff
 # or: uv run ruff check src/
 
 # 3. Architecture checks (must pass — enforced in CI)
-make ci-arch-clean    # Clean Architecture layer boundaries
-make ci-arch-cqrs     # CQRS pattern compliance
-make ci-arch-imports  # Import validation
+make ci-arch-clean        # Clean Architecture layer boundaries
+make ci-arch-cqrs         # CQRS pattern compliance
+make ci-arch-imports      # Import validation
+make ci-arch-lint-imports # import-linter layer-boundary contracts
 # or: uv run ./dev-tools/scripts/check_architecture.py
 #     uv run ./dev-tools/scripts/validate_cqrs.py
+#     uv run lint-imports
 
 # 4. Unit tests (must pass — enforced in CI)
 make ci-tests-unit
@@ -204,6 +206,31 @@ make ci-tests-unit
 # Run everything in one shot
 make ci-check
 ```
+
+### Layer-Boundary Contracts (import-linter)
+
+Clean Architecture layering is enforced statically by
+[import-linter](https://import-linter.readthedocs.io/). The contracts live in
+`.importlinter` at the repo root and are checked in CI (the `lint-imports` leg
+of the architecture-validation matrix) and locally via
+`make ci-arch-lint-imports`.
+
+Three `forbidden` contracts guard the dependency direction:
+
+- **Domain layer is clean** — `orb.domain` must not import from
+  `orb.application`, `orb.infrastructure`, `orb.interface`, `orb.providers`,
+  `orb.monitoring`, `orb.cli`, or `argparse`. The domain holds pure business
+  logic and stays free of outer layers and CLI frameworks.
+- **Application does not import infrastructure concretes** — `orb.application`
+  must not import `orb.infrastructure`, `orb.providers`, or `orb.monitoring`.
+  Handlers depend on abstract ports only; concretes are wired via DI.
+- **Infrastructure does not import upward** — `orb.infrastructure` must not
+  import `orb.interface` or `orb.cli`.
+
+The contracts are currently **green with zero violations** — the tree already
+satisfies them. Treat any new failure as a real layering regression: fix the
+offending import (invert the dependency, move the shared type to a lower layer,
+or inject via a port) rather than relaxing the contract.
 
 ### Formatting and Linting
 

--- a/src/orb/config/loader.py
+++ b/src/orb/config/loader.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar
 
@@ -121,24 +120,26 @@ class ConfigurationLoader:
             else:
                 get_config_logger().warning("User configuration file not found: %s", config_path)
 
-        # Warn if deprecated storage.dynamodb_strategy key is present
+        # Warn if deprecated storage.dynamodb_strategy key is present.
+        # This is an operator-facing config-key deprecation detected while loading
+        # a config dict at startup, so it must emit a logger.warning (not
+        # warnings.warn, which is filtered by ``filterwarnings`` in production and
+        # CI and never reaches operators). See docs/root/developer_guide/deprecation.md
+        # (Pattern 2).
         if isinstance(config, dict) and "dynamodb_strategy" in config.get("storage", {}):
-            warnings.warn(
-                "storage.dynamodb_strategy in config root is deprecated since ORB 2.x. "
-                "Move it to provider.providers[N].config.storage.dynamodb. "
-                "This key will be removed in ORB 3.0.",
-                DeprecationWarning,
-                stacklevel=2,
+            get_config_logger().warning(
+                "Config key 'storage.dynamodb_strategy' is deprecated since ORB 2.x "
+                "and will be removed in ORB 3.0; move it under "
+                "provider.providers[N].config.storage.dynamodb."
             )
 
-        # Warn if deprecated performance.batch_sizes key is present
+        # Warn if deprecated performance.batch_sizes key is present (operator-facing
+        # config-key deprecation — see the note above and deprecation.md Pattern 2).
         if isinstance(config, dict) and "batch_sizes" in config.get("performance", {}):
-            warnings.warn(
-                "performance.batch_sizes is deprecated since ORB 2.x. "
-                "Move it to provider.providers[N].config.batch_sizes. "
-                "This key will be removed in ORB 3.0.",
-                DeprecationWarning,
-                stacklevel=2,
+            get_config_logger().warning(
+                "Config key 'performance.batch_sizes' is deprecated since ORB 2.x "
+                "and will be removed in ORB 3.0; move it under "
+                "provider.providers[N].config.batch_sizes."
             )
 
         # Override with environment variables (highest precedence)

--- a/tests/unit/config/test_storage_deprecation_warning.py
+++ b/tests/unit/config/test_storage_deprecation_warning.py
@@ -1,12 +1,20 @@
-"""Unit tests for storage.dynamodb_strategy deprecation warning."""
+"""Unit tests for operator-facing config-key deprecation warnings.
+
+These config-key deprecations are detected while loading a config dict at
+startup, so per the house deprecation standard (Pattern 2 in
+``docs/root/developer_guide/deprecation.md``) they are emitted via
+``logger.warning`` — not ``warnings.warn(DeprecationWarning)``, which is
+filtered by ``filterwarnings`` in production and CI and never reaches
+operators.  Tests therefore assert against ``caplog``.
+"""
 
 import json
-import warnings
+import logging
 
 
 class TestStorageDeprecationWarning:
-    def test_old_format_emits_deprecation_warning(self, tmp_path):
-        """Loading a config with storage.dynamodb_strategy emits DeprecationWarning."""
+    def test_old_format_emits_deprecation_log_warning(self, tmp_path, caplog):
+        """Loading a config with storage.dynamodb_strategy logs a deprecation warning."""
         from orb.config.loader import ConfigurationLoader
 
         config = {
@@ -23,21 +31,19 @@ class TestStorageDeprecationWarning:
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps(config))
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with caplog.at_level(logging.WARNING, logger="orb.config.loader"):
             ConfigurationLoader.load(config_path=str(config_file))
 
-        deprecation_warnings = [
-            w
-            for w in caught
-            if issubclass(w.category, DeprecationWarning)
-            and "storage.dynamodb_strategy" in str(w.message)
+        matching = [
+            r
+            for r in caplog.records
+            if "storage.dynamodb_strategy" in r.getMessage() and "deprecated" in r.getMessage()
         ]
-        assert len(deprecation_warnings) >= 1
-        assert "deprecated" in str(deprecation_warnings[0].message)
+        assert len(matching) >= 1
+        assert matching[0].levelno == logging.WARNING
 
-    def test_new_format_no_deprecation_warning(self, tmp_path):
-        """Loading a config with new structure emits no DeprecationWarning."""
+    def test_new_format_no_deprecation_log_warning(self, tmp_path, caplog):
+        """Loading a config with new structure logs no deprecation warning."""
         from orb.config.loader import ConfigurationLoader
 
         config = {
@@ -66,17 +72,11 @@ class TestStorageDeprecationWarning:
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps(config))
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with caplog.at_level(logging.WARNING, logger="orb.config.loader"):
             ConfigurationLoader.load(config_path=str(config_file))
 
-        deprecation_warnings = [
-            w
-            for w in caught
-            if issubclass(w.category, DeprecationWarning)
-            and "storage.dynamodb_strategy" in str(w.message)
-        ]
-        assert len(deprecation_warnings) == 0
+        matching = [r for r in caplog.records if "storage.dynamodb_strategy" in r.getMessage()]
+        assert len(matching) == 0
 
     def test_old_format_still_loads_correctly(self, tmp_path):
         """Old format config still loads without error — deprecation does not break functionality."""
@@ -96,14 +96,12 @@ class TestStorageDeprecationWarning:
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps(config))
 
-        with warnings.catch_warnings(record=True):
-            warnings.simplefilter("always")
-            result = ConfigurationLoader.load(config_path=str(config_file))
+        result = ConfigurationLoader.load(config_path=str(config_file))
 
         assert result["storage"]["dynamodb_strategy"]["region"] == "eu-west-1"
 
-    def test_warning_uses_deprecation_warning_category(self, tmp_path):
-        """Warning must use DeprecationWarning category, not UserWarning or logger."""
+    def test_warning_message_names_replacement_and_removal_horizon(self, tmp_path, caplog):
+        """The deprecation message must name the replacement and the removal version."""
         from orb.config.loader import ConfigurationLoader
 
         config = {
@@ -119,11 +117,59 @@ class TestStorageDeprecationWarning:
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps(config))
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with caplog.at_level(logging.WARNING, logger="orb.config.loader"):
             ConfigurationLoader.load(config_path=str(config_file))
 
-        dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert len(dep_warnings) >= 1
-        # Must not be a plain UserWarning
-        assert not any(w.category is UserWarning for w in dep_warnings)
+        matching = [r for r in caplog.records if "storage.dynamodb_strategy" in r.getMessage()]
+        assert len(matching) >= 1
+        message = matching[0].getMessage()
+        assert "ORB 3.0" in message
+        assert "provider.providers" in message
+
+
+class TestBatchSizesDeprecationWarning:
+    def test_old_format_emits_deprecation_log_warning(self, tmp_path, caplog):
+        """Loading a config with performance.batch_sizes logs a deprecation warning."""
+        from orb.config.loader import ConfigurationLoader
+
+        config = {
+            "version": "2.0.0",
+            "storage": {"strategy": "json"},
+            "performance": {
+                "batch_sizes": {
+                    "provisioning": 10,
+                    "termination": 5,
+                },
+            },
+        }
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        with caplog.at_level(logging.WARNING, logger="orb.config.loader"):
+            ConfigurationLoader.load(config_path=str(config_file))
+
+        matching = [
+            r
+            for r in caplog.records
+            if "performance.batch_sizes" in r.getMessage() and "deprecated" in r.getMessage()
+        ]
+        assert len(matching) >= 1
+        assert matching[0].levelno == logging.WARNING
+        assert "ORB 3.0" in matching[0].getMessage()
+
+    def test_new_format_no_deprecation_log_warning(self, tmp_path, caplog):
+        """A config without performance.batch_sizes logs no batch_sizes deprecation warning."""
+        from orb.config.loader import ConfigurationLoader
+
+        config = {
+            "version": "2.0.0",
+            "storage": {"strategy": "json"},
+        }
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        with caplog.at_level(logging.WARNING, logger="orb.config.loader"):
+            ConfigurationLoader.load(config_path=str(config_file))
+
+        matching = [r for r in caplog.records if "performance.batch_sizes" in r.getMessage()]
+        assert len(matching) == 0


### PR DESCRIPTION
## Description

Additive architecture/quality guardrails — no runtime behavior change beyond one config-deprecation log fix.

- **Import-linter in CI**: the repo already carried `.importlinter` (3 layer contracts: domain-is-clean, application-no-infra-concretes, infrastructure-no-upward — currently 3 kept / 0 broken) and a `ci-arch-lint-imports` make target, but it was not wired into the CI matrix. Added `lint-imports` as a leg in the arch-validation matrix in `ci-quality.yml`, and documented the contracts + "fix the import, don't relax the contract" policy in `CONTRIBUTING.md`. New layer-boundary violations now fail CI.
- **Config deprecation standardization**: the operator-facing `storage.dynamodb_strategy` / `performance.batch_sizes` config-key deprecations in `loader.py` used `warnings.warn(DeprecationWarning)`, which the project's `filterwarnings` config suppresses in prod/CI so operators never see it. Converted to `logger.warning`, per `docs/root/developer_guide/deprecation.md` (Pattern 2: operator-facing → logger).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup or refactor
- [ ] Dependencies update
- [x] CI/CD or build process changes

## How Has This Been Tested?
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

`lint-imports` runs clean (3 kept, 0 broken). The storage-deprecation test suite passes (6 tests) and asserts the `logger.warning` path. YAML validated; ruff clean on the touched Python file.

## Test Configuration
* Python version: 3.12
* OS: macOS / Linux CI
* AWS region: n/a
* Dependencies changed: none (import-linter/grimp already present)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Performance Impact
- [x] No significant performance impact
- [ ] Performance improved
- [ ] Performance degraded (explain why it's necessary)

## Dependencies
None.

## Deployment Notes
CI now enforces import-linter layer contracts; a PR introducing a new domain→infra (etc.) import will fail the arch-validation leg.
