### PR TITLE
feat(k8s): AWS parity — config-driven resilience, HTTP proxy, metrics, strategy decomposition

### DIFF
--- a/src/orb/providers/k8s/auth/in_cluster.py
+++ b/src/orb/providers/k8s/auth/in_cluster.py
@@ -58,6 +58,12 @@ def _redact_proxy_url(url: str) -> str:
     Logging the raw URL at DEBUG level would expose credentials in log files.
     This helper strips the userinfo from the netloc so the host/port are still
     visible for diagnostics without leaking secrets.
+
+    ``urllib.parse`` only populates ``username``/``password`` when it finds a
+    scheme and network-location component.  A scheme-less but credentialed
+    value such as ``user:pass@proxy:3128`` parses entirely into ``path`` with
+    ``username`` unset, so we additionally detect a userinfo ``@`` segment in
+    the authority portion by hand and redact it.
     """
     try:
         parsed = urllib.parse.urlparse(url)
@@ -69,9 +75,34 @@ def _redact_proxy_url(url: str) -> str:
             redacted_netloc = f"***@{redacted_netloc}"
             parsed = parsed._replace(netloc=redacted_netloc)
             return urllib.parse.urlunparse(parsed)
+        return _redact_schemeless_userinfo(url)
     except Exception:  # pragma: no cover — malformed URLs passed through
         pass
     return url
+
+
+def _redact_schemeless_userinfo(url: str) -> str:
+    """Redact a ``user:pass@host`` userinfo segment that ``urlparse`` missed.
+
+    Handles scheme-less values (``user:pass@proxy:3128``) as well as values
+    whose scheme was recognised but whose userinfo urllib still declined to
+    split.  Only the authority portion (up to the first ``/``) is inspected so
+    an ``@`` inside a path is never mistaken for credentials.
+    """
+    scheme_sep = "://"
+    prefix = ""
+    remainder = url
+    sep_idx = url.find(scheme_sep)
+    if sep_idx != -1:
+        prefix = url[: sep_idx + len(scheme_sep)]
+        remainder = url[sep_idx + len(scheme_sep) :]
+
+    authority, sep, rest = remainder.partition("/")
+    at_idx = authority.rfind("@")
+    if at_idx == -1:
+        return url
+    host_part = authority[at_idx + 1 :]
+    return f"{prefix}***@{host_part}{sep}{rest}"
 
 
 # ---------------------------------------------------------------------------
@@ -79,13 +110,21 @@ def _redact_proxy_url(url: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_proxy_url() -> Optional[str]:
+def _resolve_proxy_url(config_proxy_url: Optional[str] = None) -> Optional[str]:
     """Return the proxy URL to use for apiserver connections, or ``None``.
 
-    Preference order: ``HTTPS_PROXY`` → ``https_proxy`` → ``HTTP_PROXY`` →
-    ``http_proxy``.  HTTPS variants are checked first because the Kubernetes
-    apiserver always serves TLS.
+    When *config_proxy_url* is supplied (from :class:`K8sProviderConfig`) it
+    takes precedence over the environment — explicit provider configuration
+    always wins over ambient env vars.
+
+    Otherwise the preference order is ``HTTPS_PROXY`` → ``https_proxy`` →
+    ``HTTP_PROXY`` → ``http_proxy``.  HTTPS variants are checked first because
+    the Kubernetes apiserver always serves TLS.
     """
+    if config_proxy_url is not None:
+        stripped = config_proxy_url.strip()
+        if stripped:
+            return stripped
     for var in ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"):
         value = os.environ.get(var, "").strip()
         if value:
@@ -93,8 +132,16 @@ def _resolve_proxy_url() -> Optional[str]:
     return None
 
 
-def _resolve_no_proxy() -> Optional[str]:
-    """Return the ``NO_PROXY`` exclusion list, or ``None`` when unset."""
+def _resolve_no_proxy(config_no_proxy: Optional[str] = None) -> Optional[str]:
+    """Return the ``NO_PROXY`` exclusion list, or ``None`` when unset.
+
+    A *config_no_proxy* value from :class:`K8sProviderConfig` takes precedence
+    over the ``NO_PROXY`` / ``no_proxy`` environment variables.
+    """
+    if config_no_proxy is not None:
+        stripped = config_no_proxy.strip()
+        if stripped:
+            return stripped
     for var in ("NO_PROXY", "no_proxy"):
         value = os.environ.get(var, "").strip()
         if value:
@@ -102,27 +149,37 @@ def _resolve_no_proxy() -> Optional[str]:
     return None
 
 
-def _apply_proxy_to_default_configuration(logger: Optional[LoggingPort]) -> None:
+def _apply_proxy_to_default_configuration(
+    logger: Optional[LoggingPort],
+    config_proxy_url: Optional[str] = None,
+    config_no_proxy: Optional[str] = None,
+) -> None:
     """Patch the kubernetes global default Configuration with proxy settings.
 
     This is called *after* ``load_incluster_config`` so the loaded credentials
-    are already in place.  We read the proxy env vars, apply them to a copy of
-    the active default Configuration, then promote the patched copy back as the
-    new default.
+    are already in place.  We resolve the proxy settings (config values take
+    precedence over env vars), apply them to a copy of the active default
+    Configuration, then promote the patched copy back as the new default.
 
-    When no proxy env vars are set this function is a no-op.
+    When neither a config value nor a proxy env var is set this function is a
+    no-op.
 
     Args:
         logger: Optional :class:`LoggingPort` for DEBUG messages.  When
             ``None`` proxy wiring is still applied silently.
+        config_proxy_url: Explicit proxy URL from :class:`K8sProviderConfig`.
+            Takes precedence over the proxy environment variables.
+        config_no_proxy: Explicit ``no_proxy`` exclusion list from
+            :class:`K8sProviderConfig`.  Takes precedence over the
+            ``NO_PROXY`` / ``no_proxy`` environment variables.
     """
     try:
         from kubernetes.client import Configuration  # type: ignore[reportAttributeAccessIssue]
     except ImportError:  # pragma: no cover — kubernetes extra not installed
         return
 
-    proxy_url = _resolve_proxy_url()
-    no_proxy = _resolve_no_proxy()
+    proxy_url = _resolve_proxy_url(config_proxy_url)
+    no_proxy = _resolve_no_proxy(config_no_proxy)
 
     if proxy_url is None and no_proxy is None:
         return
@@ -163,19 +220,33 @@ def is_in_cluster(sentinel: Path | None = None) -> bool:
         return False
 
 
-def load_in_cluster_config(logger: Optional[LoggingPort] = None) -> None:
+def load_in_cluster_config(
+    logger: Optional[LoggingPort] = None,
+    proxy_url: Optional[str] = None,
+    no_proxy: Optional[str] = None,
+) -> None:
     """Bootstrap the global ``kubernetes`` client config from in-cluster secrets.
 
-    After loading the service-account credentials, the function wires any HTTP
-    proxy configured in ``HTTPS_PROXY`` / ``https_proxy`` (preferred) or
-    ``HTTP_PROXY`` / ``http_proxy`` into ``kubernetes.client.Configuration.proxy``.
-    ``NO_PROXY`` / ``no_proxy`` is honoured via ``Configuration.no_proxy``.
-    When no proxy env vars are set this step is a no-op.
+    After loading the service-account credentials, the function wires an HTTP
+    proxy into ``kubernetes.client.Configuration.proxy``.  When *proxy_url* is
+    supplied (from :class:`K8sProviderConfig`) it takes precedence; otherwise
+    the loader falls back to ``HTTPS_PROXY`` / ``https_proxy`` (preferred) or
+    ``HTTP_PROXY`` / ``http_proxy``.  The exclusion list is taken from
+    *no_proxy* (config) or the ``NO_PROXY`` / ``no_proxy`` environment
+    variables and wired into ``Configuration.no_proxy``.  When neither a config
+    value nor a proxy env var is set this step is a no-op.
 
     Args:
         logger: Optional :class:`LoggingPort` for DEBUG messages about proxy
             wiring.  Proxy is applied regardless of whether a logger is
             provided.
+        proxy_url: Explicit proxy URL from :class:`K8sProviderConfig`.  Takes
+            precedence over the proxy environment variables.  ``None`` falls
+            back to the environment.
+        no_proxy: Explicit ``no_proxy`` exclusion list from
+            :class:`K8sProviderConfig`.  Takes precedence over the ``NO_PROXY``
+            / ``no_proxy`` environment variables.  ``None`` falls back to the
+            environment.
 
     Raises:
         K8sAuthError: If the kubernetes SDK is not installed, or the
@@ -194,8 +265,8 @@ def load_in_cluster_config(logger: Optional[LoggingPort] = None) -> None:
     except Exception as exc:
         raise K8sAuthError(f"Failed to load in-cluster config: {exc}") from exc
 
-    # Wire HTTP proxy from environment into the loaded configuration.
-    _apply_proxy_to_default_configuration(logger)
+    # Wire HTTP proxy (config value or environment) into the loaded configuration.
+    _apply_proxy_to_default_configuration(logger, proxy_url, no_proxy)
 
 
 class InClusterAuthAdapter:
@@ -211,10 +282,25 @@ class InClusterAuthAdapter:
             trigger a refresh.  Defaults to 55 minutes (3300 s), which
             provides a comfortable margin before the token is rotated at
             80 % of its default 3600-second lifetime.
+        logger: Optional :class:`LoggingPort` forwarded to
+            ``load_in_cluster_config`` for proxy-wiring DEBUG messages.
+        proxy_url: Explicit proxy URL from :class:`K8sProviderConfig`.  Carried
+            across every (re)load so token refreshes re-apply the same proxy.
+        no_proxy: Explicit ``no_proxy`` exclusion list from
+            :class:`K8sProviderConfig`, carried across every (re)load.
     """
 
-    def __init__(self, token_refresh_seconds: int = _DEFAULT_TOKEN_REFRESH_SECONDS) -> None:
+    def __init__(
+        self,
+        token_refresh_seconds: int = _DEFAULT_TOKEN_REFRESH_SECONDS,
+        logger: Optional[LoggingPort] = None,
+        proxy_url: Optional[str] = None,
+        no_proxy: Optional[str] = None,
+    ) -> None:
         self._token_refresh_seconds = token_refresh_seconds
+        self._logger = logger
+        self._proxy_url = proxy_url
+        self._no_proxy = no_proxy
         self._last_loaded_at: Optional[float] = None
 
     # ------------------------------------------------------------------
@@ -223,7 +309,11 @@ class InClusterAuthAdapter:
 
     def load(self) -> None:
         """Bootstrap the global kubernetes client config and record the timestamp."""
-        load_in_cluster_config()
+        load_in_cluster_config(
+            logger=self._logger,
+            proxy_url=self._proxy_url,
+            no_proxy=self._no_proxy,
+        )
         self._last_loaded_at = time.monotonic()
 
     # ------------------------------------------------------------------
@@ -249,7 +339,11 @@ class InClusterAuthAdapter:
         if age < self._token_refresh_seconds:
             return False
 
-        load_in_cluster_config()
+        load_in_cluster_config(
+            logger=self._logger,
+            proxy_url=self._proxy_url,
+            no_proxy=self._no_proxy,
+        )
         self._last_loaded_at = time.monotonic()
         return True
 

--- a/src/orb/providers/k8s/auth/kubeconfig.py
+++ b/src/orb/providers/k8s/auth/kubeconfig.py
@@ -60,6 +60,12 @@ def _redact_proxy_url(url: str) -> str:
 
     ``HTTPS_PROXY`` values often take the form ``http://user:pass@proxy:port``.
     Logging the raw URL at DEBUG level would expose credentials in log files.
+
+    ``urllib.parse`` only populates ``username``/``password`` when it finds a
+    scheme and network-location component.  A scheme-less but credentialed
+    value such as ``user:pass@proxy:3128`` parses entirely into ``path`` with
+    ``username`` unset, so we additionally detect a userinfo ``@`` segment in
+    the authority portion by hand and redact it.
     """
     try:
         parsed = urllib.parse.urlparse(url)
@@ -70,9 +76,34 @@ def _redact_proxy_url(url: str) -> str:
             redacted_netloc = f"***@{redacted_netloc}"
             parsed = parsed._replace(netloc=redacted_netloc)
             return urllib.parse.urlunparse(parsed)
+        return _redact_schemeless_userinfo(url)
     except Exception:  # pragma: no cover — malformed URLs passed through
         pass
     return url
+
+
+def _redact_schemeless_userinfo(url: str) -> str:
+    """Redact a ``user:pass@host`` userinfo segment that ``urlparse`` missed.
+
+    Handles scheme-less values (``user:pass@proxy:3128``) as well as values
+    whose scheme was recognised but whose userinfo urllib still declined to
+    split.  Only the authority portion (up to the first ``/``) is inspected so
+    an ``@`` inside a path is never mistaken for credentials.
+    """
+    scheme_sep = "://"
+    prefix = ""
+    remainder = url
+    sep_idx = url.find(scheme_sep)
+    if sep_idx != -1:
+        prefix = url[: sep_idx + len(scheme_sep)]
+        remainder = url[sep_idx + len(scheme_sep) :]
+
+    authority, sep, rest = remainder.partition("/")
+    at_idx = authority.rfind("@")
+    if at_idx == -1:
+        return url
+    host_part = authority[at_idx + 1 :]
+    return f"{prefix}***@{host_part}{sep}{rest}"
 
 
 # ---------------------------------------------------------------------------
@@ -80,13 +111,21 @@ def _redact_proxy_url(url: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_proxy_url() -> Optional[str]:
+def _resolve_proxy_url(config_proxy_url: Optional[str] = None) -> Optional[str]:
     """Return the proxy URL to use for apiserver connections, or ``None``.
 
-    Preference order: ``HTTPS_PROXY`` → ``https_proxy`` → ``HTTP_PROXY`` →
-    ``http_proxy``.  HTTPS variants are checked first because the Kubernetes
-    apiserver always serves TLS.
+    When *config_proxy_url* is supplied (from :class:`K8sProviderConfig`) it
+    takes precedence over the environment — explicit provider configuration
+    always wins over ambient env vars.
+
+    Otherwise the preference order is ``HTTPS_PROXY`` → ``https_proxy`` →
+    ``HTTP_PROXY`` → ``http_proxy``.  HTTPS variants are checked first because
+    the Kubernetes apiserver always serves TLS.
     """
+    if config_proxy_url is not None:
+        stripped = config_proxy_url.strip()
+        if stripped:
+            return stripped
     for var in ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"):
         value = os.environ.get(var, "").strip()
         if value:
@@ -94,8 +133,16 @@ def _resolve_proxy_url() -> Optional[str]:
     return None
 
 
-def _resolve_no_proxy() -> Optional[str]:
-    """Return the ``NO_PROXY`` exclusion list, or ``None`` when unset."""
+def _resolve_no_proxy(config_no_proxy: Optional[str] = None) -> Optional[str]:
+    """Return the ``NO_PROXY`` exclusion list, or ``None`` when unset.
+
+    A *config_no_proxy* value from :class:`K8sProviderConfig` takes precedence
+    over the ``NO_PROXY`` / ``no_proxy`` environment variables.
+    """
+    if config_no_proxy is not None:
+        stripped = config_no_proxy.strip()
+        if stripped:
+            return stripped
     for var in ("NO_PROXY", "no_proxy"):
         value = os.environ.get(var, "").strip()
         if value:
@@ -103,27 +150,37 @@ def _resolve_no_proxy() -> Optional[str]:
     return None
 
 
-def _apply_proxy_to_default_configuration(logger: Optional[LoggingPort]) -> None:
+def _apply_proxy_to_default_configuration(
+    logger: Optional[LoggingPort],
+    config_proxy_url: Optional[str] = None,
+    config_no_proxy: Optional[str] = None,
+) -> None:
     """Patch the kubernetes global default Configuration with proxy settings.
 
     This is called *after* ``load_kube_config`` so the loaded credentials are
-    already in place.  We read the proxy env vars, apply them to a copy of the
-    active default Configuration, then promote the patched copy back as the new
-    default.
+    already in place.  We resolve the proxy settings (config values take
+    precedence over env vars), apply them to a copy of the active default
+    Configuration, then promote the patched copy back as the new default.
 
-    When no proxy env vars are set this function is a no-op.
+    When neither a config value nor a proxy env var is set this function is a
+    no-op.
 
     Args:
         logger: Optional :class:`LoggingPort` for DEBUG messages.  When
             ``None`` proxy wiring is still applied silently.
+        config_proxy_url: Explicit proxy URL from :class:`K8sProviderConfig`.
+            Takes precedence over the proxy environment variables.
+        config_no_proxy: Explicit ``no_proxy`` exclusion list from
+            :class:`K8sProviderConfig`.  Takes precedence over the
+            ``NO_PROXY`` / ``no_proxy`` environment variables.
     """
     try:
         from kubernetes.client import Configuration  # type: ignore[reportAttributeAccessIssue]
     except ImportError:  # pragma: no cover — kubernetes extra not installed
         return
 
-    proxy_url = _resolve_proxy_url()
-    no_proxy = _resolve_no_proxy()
+    proxy_url = _resolve_proxy_url(config_proxy_url)
+    no_proxy = _resolve_no_proxy(config_no_proxy)
 
     if proxy_url is None and no_proxy is None:
         return
@@ -273,6 +330,8 @@ def load_kubeconfig(
     config_file: Optional[str] = None,
     context: Optional[str] = None,
     logger: Optional[LoggingPort] = None,
+    proxy_url: Optional[str] = None,
+    no_proxy: Optional[str] = None,
 ) -> None:
     """Bootstrap the global ``kubernetes`` client config from a kubeconfig file.
 
@@ -283,10 +342,13 @@ def load_kubeconfig(
        blocked unless ``ORB_K8S_ALLOW_UNKNOWN_EXEC_PLUGIN=1`` is set.
     2. Sanitises error messages from the SDK so that raw exception text
        (which may embed file contents) is not forwarded to callers.
-    3. Wires any HTTP proxy configured in ``HTTPS_PROXY`` / ``https_proxy``
-       (preferred) or ``HTTP_PROXY`` / ``http_proxy`` into
-       ``kubernetes.client.Configuration.proxy``.  ``NO_PROXY`` / ``no_proxy``
-       is honoured via ``Configuration.no_proxy``.
+    3. Wires an HTTP proxy into ``kubernetes.client.Configuration.proxy``.
+       When *proxy_url* is supplied (from :class:`K8sProviderConfig`) it takes
+       precedence; otherwise the loader falls back to ``HTTPS_PROXY`` /
+       ``https_proxy`` (preferred) or ``HTTP_PROXY`` / ``http_proxy``.  The
+       exclusion list is taken from *no_proxy* (config) or the ``NO_PROXY`` /
+       ``no_proxy`` environment variables and wired into
+       ``Configuration.no_proxy``.
 
     Args:
         config_file: Path to the kubeconfig file.  When ``None`` the
@@ -297,6 +359,13 @@ def load_kubeconfig(
         logger: Optional :class:`LoggingPort` for WARNING-level messages
             about allowed-but-unknown exec plugins and DEBUG-level messages
             about proxy wiring.
+        proxy_url: Explicit proxy URL from :class:`K8sProviderConfig`.  Takes
+            precedence over the proxy environment variables.  ``None`` falls
+            back to the environment.
+        no_proxy: Explicit ``no_proxy`` exclusion list from
+            :class:`K8sProviderConfig`.  Takes precedence over the ``NO_PROXY``
+            / ``no_proxy`` environment variables.  ``None`` falls back to the
+            environment.
 
     Raises:
         K8sAuthError: If the kubernetes SDK is not installed, an unknown
@@ -321,5 +390,6 @@ def load_kubeconfig(
     except Exception as exc:
         raise K8sAuthError(_sanitise_load_error(exc, config_file)) from exc
 
-    # Step 3 — wire HTTP proxy from environment into the loaded configuration.
-    _apply_proxy_to_default_configuration(logger)
+    # Step 3 — wire HTTP proxy (config value or environment) into the loaded
+    # configuration.
+    _apply_proxy_to_default_configuration(logger, proxy_url, no_proxy)

--- a/src/orb/providers/k8s/configuration/config.py
+++ b/src/orb/providers/k8s/configuration/config.py
@@ -8,6 +8,7 @@ integrates with the configuration loader and the provider settings registry.
 from __future__ import annotations
 
 import contextlib
+import urllib.parse
 from pathlib import Path
 from typing import Any, Optional
 
@@ -170,7 +171,7 @@ class K8sNamingConfig(BaseModel):
         return v
 
     @model_validator(mode="after")
-    def _validate_budget(self) -> "K8sNamingConfig":
+    def _validate_budget(self) -> K8sNamingConfig:
         """Ensure prefix+uuid_chars fit within every per-kind length budget.
 
         Deployment is almost always the tightest constraint because its
@@ -288,6 +289,31 @@ class K8sProviderConfig(BaseSettings, BaseProviderConfig):  # type: ignore[misc]
             "When ``None`` (default) the provider auto-detects in-cluster mode via "
             "the /var/run/secrets/kubernetes.io sentinel.  Explicit True/False "
             "short-circuits detection."
+        ),
+    )
+
+    # HTTP proxy for apiserver connections
+    proxy_url: Optional[str] = Field(
+        None,
+        description=(
+            "HTTP/HTTPS proxy URL used for connections to the Kubernetes API "
+            "server.  When set, this value is wired into "
+            "``kubernetes.client.Configuration.proxy`` after the credentials are "
+            "loaded and takes precedence over the ``HTTPS_PROXY`` / ``HTTP_PROXY`` "
+            "environment variables.  When ``None`` (the default) the loaders fall "
+            "back to the standard proxy environment variables.  Accepts an "
+            "optional ``user:password@`` userinfo component; credentials are "
+            "redacted from any DEBUG log output."
+        ),
+    )
+    no_proxy: Optional[str] = Field(
+        None,
+        description=(
+            "Comma-separated exclusion list wired into "
+            "``kubernetes.client.Configuration.no_proxy``.  Hosts matching an "
+            "entry bypass ``proxy_url``.  When set this takes precedence over the "
+            "``NO_PROXY`` / ``no_proxy`` environment variables; when ``None`` the "
+            "loaders fall back to those environment variables."
         ),
     )
 
@@ -706,6 +732,35 @@ class K8sProviderConfig(BaseSettings, BaseProviderConfig):  # type: ignore[misc]
                 "pass None to omit it (the provider will use the current kubeconfig context)."
             )
         return v
+
+    @field_validator("proxy_url")
+    @classmethod
+    def _validate_proxy_url(cls, v: Optional[str]) -> Optional[str]:
+        """Reject an empty/whitespace ``proxy_url`` and require an http(s) scheme.
+
+        ``None`` passes through (proxy disabled / fall back to env vars).  A
+        supplied value must be a non-empty ``http://`` or ``https://`` URL with
+        a host component so an operator typo (e.g. a bare host without scheme)
+        fails fast at config-construction time rather than being silently
+        ignored by the SDK.
+        """
+        if v is None:
+            return v
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError(
+                "proxy_url must be a non-empty URL when supplied; "
+                "pass None to disable the explicit proxy and fall back to the "
+                "HTTPS_PROXY / HTTP_PROXY environment variables."
+            )
+        parsed = urllib.parse.urlparse(stripped)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            raise ValueError(
+                f"proxy_url {v!r} is not a valid proxy URL.  Expected an "
+                "'http://' or 'https://' URL with a host, e.g. "
+                "'http://proxy.corp.example:3128'."
+            )
+        return stripped
 
     @field_validator("kubeconfig_path")
     @classmethod

--- a/src/orb/providers/k8s/infrastructure/handlers/base_handler.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/base_handler.py
@@ -22,7 +22,7 @@ from orb.domain.base.provider_fulfilment import CheckHostsStatusResult, Provider
 from orb.domain.request.aggregate import Request
 from orb.domain.template.template_aggregate import Template
 from orb.infrastructure.di.injectable import injectable
-from orb.infrastructure.resilience import retry
+from orb.infrastructure.resilience import MaxRetriesExceededError
 from orb.providers.k8s.configuration.config import K8sProviderConfig
 from orb.providers.k8s.infrastructure.handlers.shared.label_stamper import (
     stamp_native_workload_body as _stamp_workload_body,
@@ -36,6 +36,7 @@ from orb.providers.k8s.infrastructure.handlers.shared.pod_state_translator impor
     instance_dict_for_state as _instance_dict_for_state,
 )
 from orb.providers.k8s.infrastructure.k8s_client import K8sClient
+from orb.providers.k8s.resilience.circuit_breaker import K8sCircuitBreaker
 from orb.providers.k8s.utilities.pod_spec import request_id_label_selector
 from orb.providers.k8s.utilities.pod_spec_audit import audit_pod_spec
 from orb.providers.k8s.utilities.pod_state import (
@@ -171,16 +172,24 @@ class K8sHandlerBase(ABC):
         time after the block completes (whether via normal return or exception).
         No-op when metrics are not wired.
 
+        Uses :func:`time.perf_counter` (the highest-resolution clock for
+        measuring elapsed durations) rather than :func:`time.monotonic` so the
+        latency measurement is decoupled from the ``monotonic``-based TTL-cache
+        bookkeeping in the status resolvers — a resolver may wrap its
+        controller GET in this context manager and separately consult
+        ``time.monotonic()`` for cache freshness without the two clocks
+        interfering.
+
         Usage::
 
             with self._timed_api_call("create_namespaced_pod"):
                 core_v1.create_namespaced_pod(...)
         """
-        t0 = time.monotonic()
+        t0 = time.perf_counter()
         try:
             yield
         finally:
-            elapsed = time.monotonic() - t0
+            elapsed = time.perf_counter() - t0
             self._record_apiserver_latency(operation=operation, seconds=elapsed)
 
     def _classify_and_record_api_exception(
@@ -188,7 +197,7 @@ class K8sHandlerBase(ABC):
         exc: BaseException,
         *,
         operation: str,
-    ) -> "K8sError":
+    ) -> K8sError:
         """Classify a raw ``ApiException`` into a typed K8sError and emit metrics.
 
         Call this at the API-call boundary after the retry budget is exhausted
@@ -225,16 +234,47 @@ class K8sHandlerBase(ABC):
             from kubernetes.client.exceptions import ApiException as _ApiException
 
             if isinstance(candidate, _ApiException):
-                status = int(getattr(candidate, "status", 0) or 0)
-                error_code = str(status) if status else "unknown"
-                self._record_api_error(operation=operation, error_code=error_code)
+                self._record_api_exception(exc, operation=operation)
                 return classify_api_exception(candidate, operation=operation)
         except ImportError:  # pragma: no cover — kubernetes extra absent
             pass
 
         # Not an ApiException — wrap in base K8sError.
-        self._record_api_error(operation=operation, error_code="unknown")
+        self._record_api_exception(exc, operation=operation)
         return K8sError(str(exc), error_source=f"kubernetes.{operation}")
+
+    def _record_api_exception(self, exc: BaseException, *, operation: str) -> None:
+        """Record ``orb_k8s_api_errors_total`` for a caught API-boundary exception.
+
+        Extracts the HTTP status code from a raw ``ApiException`` (unwrapping one
+        level of retry wrapping when present) and increments the error counter.
+        A ``429`` status additionally increments ``orb_k8s_api_throttles_total``
+        via :meth:`K8sMetrics.record_api_error`.  Non-``ApiException`` inputs are
+        bucketed under the ``"unknown"`` error code so read paths that swallow
+        the exception (status resolvers) still surface as failures on the
+        dashboards.
+
+        Unlike :meth:`_classify_and_record_api_exception` this does not construct
+        a typed :class:`K8sError`; it is intended for call sites that catch and
+        recover from the exception rather than re-raising a structured error.
+        """
+        error_code = "unknown"
+        # Unwrap one level of retry wrapping when present.
+        candidate: BaseException = exc
+        last_exception = getattr(exc, "last_exception", None)
+        if isinstance(last_exception, BaseException):
+            candidate = last_exception
+
+        try:
+            from kubernetes.client.exceptions import ApiException as _ApiException
+
+            if isinstance(candidate, _ApiException):
+                status = int(getattr(candidate, "status", 0) or 0)
+                error_code = str(status) if status else "unknown"
+        except ImportError:  # pragma: no cover — kubernetes extra absent
+            pass
+
+        self._record_api_error(operation=operation, error_code=error_code)
 
     @property
     def client(self) -> K8sClient:
@@ -471,29 +511,67 @@ class K8sHandlerBase(ABC):
         apiserver failure count reaches ``circuit_breaker_failure_threshold``
         the circuit opens and subsequent calls fast-fail with
         ``CircuitBreakerOpenError`` until the reset window expires.  This
-        prevents cascading retry storms during apiserver degradation.
+        prevents cascading retry storms during apiserver degradation.  The
+        breaker is a :class:`K8sCircuitBreaker` wired with the handler's
+        metrics recorder so ``orb_k8s_circuit_breaker_state`` reflects the
+        state of the breakers that actually protect the apiserver calls.
+
+        Metrics: every attempt beyond the first is a genuine retry from the
+        resilience layer, so ``orb_k8s_api_retries_total`` is incremented once
+        per re-invocation of ``operation`` (i.e. ``attempts - 1`` times).  The
+        counter therefore reflects the real retry/backoff path rather than a
+        caller-side estimate.  ``operation_name`` is used as the ``operation``
+        label; values outside :data:`API_OPERATIONS` bucket to ``"unknown"``.
         """
         service_key = f"kubernetes.{self.PROVIDER_API.lower()}"
 
-        @retry(
-            strategy="circuit_breaker",
-            service=service_key,
+        # Metrics-aware circuit breaker so the gauge that tracks these
+        # apiserver-protecting breakers is emitted from the production retry
+        # path.  Semantics are identical to the base CircuitBreakerStrategy;
+        # the subclass only layers the ``orb_k8s_circuit_breaker_state``
+        # emission on top of the shared, class-level circuit state.
+        breaker = K8sCircuitBreaker(
+            service_name=service_key,
             max_attempts=self._max_retries,
             base_delay=self._base_delay,
             max_delay=self._max_delay,
             failure_threshold=self._cb_failure_threshold,
             reset_timeout=self._cb_reset_timeout,
+            metrics=self._metrics,
         )
-        def wrapped() -> T:
+
+        attempt = 0
+        while True:
+            # Every invocation after the first is a retry issued by the
+            # backoff loop — record it against the operation so
+            # ``orb_k8s_api_retries_total`` tracks the actual retry path.
+            if attempt > 0:
+                self._record_api_retry(operation=operation_name)
             self._logger.debug(
                 "Calling Kubernetes operation %s (args=%s kwargs=%s)",
                 operation_name,
                 args,
                 {k: v for k, v in kwargs.items() if k != "body"},
             )
-            return operation(*args, **kwargs)
+            try:
+                result = operation(*args, **kwargs)
+            except Exception as exc:
+                # ``should_retry`` updates the circuit state (and may raise
+                # ``CircuitBreakerOpenError`` when the circuit is open),
+                # emitting the state gauge on any transition.
+                if not breaker.should_retry(attempt, exc):
+                    if attempt >= self._max_retries:
+                        raise MaxRetriesExceededError(attempt + 1, exc) from exc
+                    raise
+                delay = breaker.get_delay(attempt)
+                breaker.on_retry(attempt, exc)
+                if delay > 0:
+                    time.sleep(delay)
+                attempt += 1
+                continue
 
-        return wrapped()
+            breaker.record_success()
+            return result
 
     # ------------------------------------------------------------------
     # Pod-state translation — shared between handlers and watcher

--- a/src/orb/providers/k8s/infrastructure/handlers/deployment_status.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/deployment_status.py
@@ -79,14 +79,16 @@ class DeploymentStatusResolver:
             # resource_version='0' serves from the apiserver reflector cache
             # (sub-ms, ~500 ms staleness) instead of reading from etcd.
             # Acceptable for status polls — not used on create/update paths.
-            response = handler.with_retry(
-                handler.client.core_v1.list_namespaced_pod,
-                namespace=namespace,
-                label_selector=selector,
-                resource_version="0",
-                operation_name="list_namespaced_pod",
-            )
+            with handler._timed_api_call("list_namespaced_pod"):
+                response = handler.with_retry(
+                    handler.client.core_v1.list_namespaced_pod,
+                    namespace=namespace,
+                    label_selector=selector,
+                    resource_version="0",
+                    operation_name="list_namespaced_pod",
+                )
         except Exception as exc:
+            handler._record_api_exception(exc, operation="list_namespaced_pod")
             handler._logger.error(
                 "list_namespaced_pod failed for deployment request %s: %s",
                 request.request_id,
@@ -194,12 +196,13 @@ class DeploymentStatusResolver:
         """
         handler = self._handler
         try:
-            deployment = handler.with_retry(
-                handler.client.apps_v1.read_namespaced_deployment,
-                name=deployment_name,
-                namespace=namespace,
-                operation_name="read_namespaced_deployment",
-            )
+            with handler._timed_api_call("read_namespaced_deployment"):
+                deployment = handler.with_retry(
+                    handler.client.apps_v1.read_namespaced_deployment,
+                    name=deployment_name,
+                    namespace=namespace,
+                    operation_name="read_namespaced_deployment",
+                )
         except Exception as exc:
             if handler.is_not_found(exc):
                 handler._logger.debug(
@@ -208,6 +211,7 @@ class DeploymentStatusResolver:
                     namespace,
                 )
                 return {}
+            handler._record_api_exception(exc, operation="read_namespaced_deployment")
             handler._logger.warning(
                 "read_namespaced_deployment failed (deployment=%s namespace=%s): %s",
                 deployment_name,

--- a/src/orb/providers/k8s/infrastructure/handlers/job_status.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/job_status.py
@@ -77,14 +77,16 @@ class JobStatusResolver:
             # resource_version='0' serves from the apiserver reflector cache
             # (sub-ms, ~500 ms staleness) instead of reading from etcd.
             # Acceptable for status polls — not used on create/update paths.
-            response = handler.with_retry(
-                handler.client.core_v1.list_namespaced_pod,
-                namespace=namespace,
-                label_selector=selector,
-                resource_version="0",
-                operation_name="list_namespaced_pod",
-            )
+            with handler._timed_api_call("list_namespaced_pod"):
+                response = handler.with_retry(
+                    handler.client.core_v1.list_namespaced_pod,
+                    namespace=namespace,
+                    label_selector=selector,
+                    resource_version="0",
+                    operation_name="list_namespaced_pod",
+                )
         except Exception as exc:
+            handler._record_api_exception(exc, operation="list_namespaced_pod")
             handler._logger.error(
                 "list_namespaced_pod failed for job request %s: %s",
                 request.request_id,
@@ -202,12 +204,13 @@ class JobStatusResolver:
         """
         handler = self._handler
         try:
-            job = handler.with_retry(
-                handler.client.batch_v1.read_namespaced_job,
-                name=job_name,
-                namespace=namespace,
-                operation_name="read_namespaced_job",
-            )
+            with handler._timed_api_call("read_namespaced_job"):
+                job = handler.with_retry(
+                    handler.client.batch_v1.read_namespaced_job,
+                    name=job_name,
+                    namespace=namespace,
+                    operation_name="read_namespaced_job",
+                )
         except Exception as exc:
             if handler.is_not_found(exc):
                 # Job not found is normal after release or before creation.
@@ -219,6 +222,7 @@ class JobStatusResolver:
                     namespace,
                 )
                 return {}
+            handler._record_api_exception(exc, operation="read_namespaced_job")
             handler._logger.warning(
                 "read_namespaced_job failed (job=%s namespace=%s): %s",
                 job_name,

--- a/src/orb/providers/k8s/infrastructure/handlers/pod_status.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/pod_status.py
@@ -79,11 +79,13 @@ class PodStatusResolver:
             list_kwargs["resource_version"] = "0"
 
         try:
-            response = handler.with_retry(
-                handler.client.core_v1.list_namespaced_pod,
-                **list_kwargs,
-            )
+            with handler._timed_api_call("list_namespaced_pod"):
+                response = handler.with_retry(
+                    handler.client.core_v1.list_namespaced_pod,
+                    **list_kwargs,
+                )
         except Exception as exc:
+            handler._record_api_exception(exc, operation="list_namespaced_pod")
             handler._logger.error(
                 "list_namespaced_pod failed for request %s: %s",
                 request.request_id,

--- a/src/orb/providers/k8s/infrastructure/handlers/statefulset_status.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/statefulset_status.py
@@ -79,14 +79,16 @@ class StatefulSetStatusResolver:
             # resource_version='0' serves from the apiserver reflector cache
             # (sub-ms, ~500 ms staleness) instead of reading from etcd.
             # Acceptable for status polls — not used on create/update paths.
-            response = handler.with_retry(
-                handler.client.core_v1.list_namespaced_pod,
-                namespace=namespace,
-                label_selector=selector,
-                resource_version="0",
-                operation_name="list_namespaced_pod",
-            )
+            with handler._timed_api_call("list_namespaced_pod"):
+                response = handler.with_retry(
+                    handler.client.core_v1.list_namespaced_pod,
+                    namespace=namespace,
+                    label_selector=selector,
+                    resource_version="0",
+                    operation_name="list_namespaced_pod",
+                )
         except Exception as exc:
+            handler._record_api_exception(exc, operation="list_namespaced_pod")
             handler._logger.error(
                 "list_namespaced_pod failed for statefulset request %s: %s",
                 request.request_id,
@@ -194,12 +196,13 @@ class StatefulSetStatusResolver:
         """
         handler = self._handler
         try:
-            statefulset = handler.with_retry(
-                handler.client.apps_v1.read_namespaced_stateful_set,
-                name=statefulset_name,
-                namespace=namespace,
-                operation_name="read_namespaced_stateful_set",
-            )
+            with handler._timed_api_call("read_namespaced_stateful_set"):
+                statefulset = handler.with_retry(
+                    handler.client.apps_v1.read_namespaced_stateful_set,
+                    name=statefulset_name,
+                    namespace=namespace,
+                    operation_name="read_namespaced_stateful_set",
+                )
         except Exception as exc:
             if handler.is_not_found(exc):
                 handler._logger.debug(
@@ -208,6 +211,7 @@ class StatefulSetStatusResolver:
                     namespace,
                 )
                 return {}
+            handler._record_api_exception(exc, operation="read_namespaced_stateful_set")
             handler._logger.warning(
                 "read_namespaced_stateful_set failed (statefulset=%s namespace=%s): %s",
                 statefulset_name,

--- a/src/orb/providers/k8s/infrastructure/instrumentation/metrics.py
+++ b/src/orb/providers/k8s/infrastructure/instrumentation/metrics.py
@@ -118,6 +118,7 @@ API_OPERATIONS: frozenset[str] = frozenset(
         # Job
         "create_namespaced_job",
         "delete_namespaced_job",
+        "read_namespaced_job",
         # Watcher / generic
         "list_watch",
         "unknown",
@@ -225,7 +226,7 @@ _METRIC_SPECS: tuple[tuple[str, str, str, list[str]], ...] = (
 )
 
 
-def _get_default_meter() -> "Meter":
+def _get_default_meter() -> Meter:
     """Return the global OTel Meter (no-op when SDK absent or disabled)."""
     try:
         from opentelemetry import metrics
@@ -302,7 +303,7 @@ class K8sMetrics:
 
     _init_lock: ClassVar[threading.Lock] = threading.Lock()
 
-    def __init__(self, meter: "Meter | None" = None) -> None:
+    def __init__(self, meter: Meter | None = None) -> None:
         """Initialise all metric instruments via *meter*.
 
         Args:

--- a/src/orb/providers/k8s/infrastructure/k8s_client.py
+++ b/src/orb/providers/k8s/infrastructure/k8s_client.py
@@ -94,7 +94,14 @@ class K8sClient:
             else {}
         )
         self._in_cluster_adapter: Optional[InClusterAuthAdapter] = (
-            InClusterAuthAdapter(**refresh_kwargs) if api_client is None else None
+            InClusterAuthAdapter(
+                logger=logger,
+                proxy_url=config.proxy_url,
+                no_proxy=config.no_proxy,
+                **refresh_kwargs,
+            )
+            if api_client is None
+            else None
         )
 
     # ------------------------------------------------------------------
@@ -124,7 +131,11 @@ class K8sClient:
                 if self._in_cluster_adapter is not None:
                     self._in_cluster_adapter.load()
                 else:
-                    load_in_cluster_config()
+                    load_in_cluster_config(
+                        logger=self._logger,
+                        proxy_url=self._config.proxy_url,
+                        no_proxy=self._config.no_proxy,
+                    )
             elif self._config.in_cluster is False:
                 self._logger.debug("Loading kubeconfig (in_cluster=False, forced).")
                 # In-cluster adapter not used for kubeconfig auth.
@@ -133,13 +144,19 @@ class K8sClient:
                     config_file=self._config.kubeconfig_path,
                     context=self._config.context,
                     logger=self._logger,
+                    proxy_url=self._config.proxy_url,
+                    no_proxy=self._config.no_proxy,
                 )
             elif is_in_cluster():
                 self._logger.debug("In-cluster sentinel present; loading in-cluster config.")
                 if self._in_cluster_adapter is not None:
                     self._in_cluster_adapter.load()
                 else:
-                    load_in_cluster_config()
+                    load_in_cluster_config(
+                        logger=self._logger,
+                        proxy_url=self._config.proxy_url,
+                        no_proxy=self._config.no_proxy,
+                    )
             else:
                 self._logger.debug(
                     "No in-cluster sentinel; loading kubeconfig (path=%s, context=%s).",
@@ -151,6 +168,8 @@ class K8sClient:
                     config_file=self._config.kubeconfig_path,
                     context=self._config.context,
                     logger=self._logger,
+                    proxy_url=self._config.proxy_url,
+                    no_proxy=self._config.no_proxy,
                 )
         except K8sAuthError:
             raise
@@ -214,7 +233,11 @@ class K8sClient:
                 try:
                     import time
 
-                    load_in_cluster_config()
+                    load_in_cluster_config(
+                        logger=self._logger,
+                        proxy_url=self._config.proxy_url,
+                        no_proxy=self._config.no_proxy,
+                    )
                     # Update the adapter's timestamp so the TTL window resets.
                     adapter._last_loaded_at = time.monotonic()
                 except K8sAuthError as auth_exc:

--- a/src/orb/providers/k8s/services/capability_service.py
+++ b/src/orb/providers/k8s/services/capability_service.py
@@ -334,5 +334,147 @@ class K8sCapabilityService:
             },
         }
 
+    @staticmethod
+    def get_ui_column_schema() -> list:
+        """Return k8s-specific UI column descriptors for machines, requests, and templates."""
+        from orb.application.dto.system import UIColumnDescriptor
+
+        return [
+            # ------------------------------------------------------------------
+            # machines — pod/workload-level columns
+            # ------------------------------------------------------------------
+            UIColumnDescriptor(
+                key="k8s_namespace",
+                path="provider_data.namespace",
+                label="Namespace",
+                kind="badge",
+                resource_type="machines",
+                provider="k8s",
+                sortable=True,
+                default_visible=True,
+            ),
+            UIColumnDescriptor(
+                key="k8s_node_name",
+                path="provider_data.node_name",
+                label="Node",
+                kind="text",
+                resource_type="machines",
+                provider="k8s",
+                sortable=True,
+                default_visible=True,
+            ),
+            UIColumnDescriptor(
+                key="k8s_phase",
+                path="provider_data.phase",
+                label="Phase",
+                kind="badge",
+                resource_type="machines",
+                provider="k8s",
+                badge_color_map={
+                    "Running": "green",
+                    "Pending": "orange",
+                    "Succeeded": "teal",
+                    "Failed": "red",
+                    "Unknown": "gray",
+                },
+                sortable=True,
+                default_visible=True,
+            ),
+            UIColumnDescriptor(
+                key="k8s_restart_count",
+                path="provider_data.restart_count",
+                label="Restarts",
+                kind="count",
+                resource_type="machines",
+                provider="k8s",
+                sortable=True,
+                default_visible=False,
+            ),
+            UIColumnDescriptor(
+                key="k8s_capacity_type",
+                path="provider_data.node_capacity_type",
+                label="Capacity Type",
+                kind="badge",
+                resource_type="machines",
+                provider="k8s",
+                badge_color_map={"spot": "orange", "on-demand": "blue", "on_demand": "blue"},
+                sortable=True,
+                default_visible=False,
+            ),
+            UIColumnDescriptor(
+                key="k8s_workload_kind",
+                path="provider_api",
+                label="Workload Kind",
+                kind="badge",
+                resource_type="machines",
+                provider="k8s",
+                badge_color_map={
+                    "Pod": "blue",
+                    "Deployment": "purple",
+                    "StatefulSet": "teal",
+                    "Job": "orange",
+                },
+                sortable=True,
+                default_visible=False,
+            ),
+            # ------------------------------------------------------------------
+            # requests — provider-level request columns
+            # ------------------------------------------------------------------
+            UIColumnDescriptor(
+                key="k8s_request_namespace",
+                path="provider_data.namespace",
+                label="Namespace",
+                kind="badge",
+                resource_type="requests",
+                provider="k8s",
+                sortable=True,
+                default_visible=True,
+            ),
+            UIColumnDescriptor(
+                key="k8s_request_provider_api",
+                path="provider_data.provider_api",
+                label="Workload Kind",
+                kind="badge",
+                resource_type="requests",
+                provider="k8s",
+                badge_color_map={
+                    "Pod": "blue",
+                    "Deployment": "purple",
+                    "StatefulSet": "teal",
+                    "Job": "orange",
+                },
+                default_visible=True,
+            ),
+            # ------------------------------------------------------------------
+            # templates — k8s template surface
+            # ------------------------------------------------------------------
+            UIColumnDescriptor(
+                key="k8s_template_provider_api",
+                path="provider_api",
+                label="Workload Kind",
+                kind="badge",
+                resource_type="templates",
+                provider="k8s",
+                badge_color_map={
+                    "Pod": "blue",
+                    "Deployment": "purple",
+                    "StatefulSet": "teal",
+                    "Job": "orange",
+                },
+                default_visible=True,
+                sortable=True,
+            ),
+            UIColumnDescriptor(
+                key="k8s_template_namespace",
+                path="namespace",
+                label="Namespace",
+                kind="text",
+                resource_type="templates",
+                provider="k8s",
+                default_visible=True,
+                sortable=True,
+            ),
+        ]
+
 
 __all__ = ["K8sCapabilityService"]

--- a/src/orb/providers/k8s/services/handler_registry.py
+++ b/src/orb/providers/k8s/services/handler_registry.py
@@ -123,6 +123,33 @@ class K8sHandlerRegistry:
             return self._api_aliases.get(raw, raw)
         return KubernetesProviderApi.POD.value
 
+    def _resilience_kwargs(self) -> dict[str, Any]:
+        """Map the provider config's circuit-breaker / retry knobs to handler kwargs.
+
+        ``K8sHandlerBase`` (and every concrete handler) accepts
+        ``max_retries`` / ``base_delay`` / ``max_delay`` positionally and
+        ``circuit_breaker_failure_threshold`` / ``circuit_breaker_reset_timeout``
+        as keyword-only args, then feeds them into :meth:`with_retry`.  The
+        provider config exposes the operator-facing spellings
+        (``retry_base_delay`` / ``retry_max_delay`` / ``max_retries`` /
+        ``circuit_breaker_*``); this helper bridges the two so the configured
+        values actually reach the handler's retry/circuit-breaker layer.
+
+        ``getattr`` with the K8sHandlerBase default is used so a config object
+        that predates these fields (or a hand-rolled test stub) still yields a
+        valid kwargs mapping rather than raising ``AttributeError``.
+        """
+        cfg = self._config
+        return {
+            "max_retries": getattr(cfg, "max_retries", 3),
+            "base_delay": getattr(cfg, "retry_base_delay", 1.0),
+            "max_delay": getattr(cfg, "retry_max_delay", 30.0),
+            "circuit_breaker_failure_threshold": getattr(
+                cfg, "circuit_breaker_failure_threshold", 5
+            ),
+            "circuit_breaker_reset_timeout": getattr(cfg, "circuit_breaker_reset_timeout", 60),
+        }
+
     def get_handler(self, provider_api: str) -> K8sHandlerBase:
         """Return (and lazily construct) the handler for ``provider_api``.
 
@@ -145,6 +172,13 @@ class K8sHandlerRegistry:
             else None
         )
 
+        # Circuit-breaker and retry knobs read from the provider config so the
+        # handler's ``with_retry`` uses operator-tuned resilience values instead
+        # of the K8sHandlerBase hardcoded defaults.  Threaded into both the
+        # built-in and plugin construction paths.  See
+        # ``K8sProviderConfig`` (circuit_breaker_* / max_retries / retry_*).
+        resilience_kwargs = self._resilience_kwargs()
+
         handler_class = self._handler_classes.get(provider_api)
         if handler_class is not None:
             handler = handler_class(
@@ -156,6 +190,7 @@ class K8sHandlerRegistry:
                 native_spec_service=native_spec_service,
                 node_state_cache=node_cache,
                 metrics=self._metrics_provider() if self._metrics_provider is not None else None,
+                **resilience_kwargs,
             )
             self._handlers[provider_api] = handler
             return handler
@@ -164,7 +199,8 @@ class K8sHandlerRegistry:
         # and ``docs/root/providers/k8s/plugin-authoring.md``.
         # Factories receive the full seven-kwarg surface so plugins that
         # consume ``native_spec_service`` or ``node_state_cache`` do not
-        # silently receive ``None``.
+        # silently receive ``None``, plus the resilience knobs so plugin
+        # handlers inherit the same operator-tuned retry/circuit-breaker values.
         factory = self._plugin_factories().get(provider_api)
         if factory is not None:
             handler = factory(
@@ -176,6 +212,7 @@ class K8sHandlerRegistry:
                 native_spec_service=native_spec_service,
                 node_state_cache=node_cache,
                 metrics=self._metrics_provider() if self._metrics_provider is not None else None,
+                **resilience_kwargs,
             )
             self._handlers[provider_api] = handler
             return handler

--- a/src/orb/providers/k8s/strategy/k8s_provider_adapter.py
+++ b/src/orb/providers/k8s/strategy/k8s_provider_adapter.py
@@ -116,7 +116,7 @@ class K8sResourceValidator:
             return False
         return True
 
-    def validate_launch_template(self, template: "Any") -> bool:  # type: ignore[override]
+    def validate_launch_template(self, template: Any) -> bool:  # type: ignore[override]
         """Not applicable for Kubernetes — always returns False."""
         return False
 

--- a/src/orb/providers/k8s/strategy/k8s_provider_strategy.py
+++ b/src/orb/providers/k8s/strategy/k8s_provider_strategy.py
@@ -21,8 +21,6 @@ factory can be a near drop-in.
 
 from __future__ import annotations
 
-import asyncio
-import threading
 import time
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
 
@@ -59,6 +57,15 @@ from orb.providers.k8s.services.instance_operation_service import (
 from orb.providers.k8s.services.start_stop_service import K8sStartStopService
 from orb.providers.k8s.services.template_validation_service import K8sTemplateValidationService
 from orb.providers.k8s.strategy.handler_registry import K8sHandlerRegistry
+from orb.providers.k8s.strategy.native_spec_resolver import K8sNativeSpecResolver
+from orb.providers.k8s.strategy.node_watch_lifecycle import K8sNodeWatchLifecycle
+from orb.providers.k8s.strategy.outcome_bridge import (
+    _all_instances_terminal,
+    _build_provider_result_data,
+    _outcome_to_provider_result,
+)
+from orb.providers.k8s.strategy.reconciliation_lifecycle import K8sReconciliationLifecycle
+from orb.providers.k8s.strategy.watch_lifecycle import K8sWatchManagerLifecycle
 from orb.providers.k8s.value_objects import KubernetesProviderApi
 from orb.providers.k8s.watch.events_watcher import K8sEventsWatcher, K8sNodeEventsCache
 from orb.providers.k8s.watch.multi_namespace import MultiNamespaceWatcher
@@ -67,6 +74,16 @@ from orb.providers.k8s.watch.node_watcher import K8sNodeWatcher
 from orb.providers.k8s.watch.pod_state_cache import PodStateCache
 
 _logger = get_logger(__name__)
+
+# Re-exported for backward compatibility: tests and callers import these
+# bridge helpers from this module.  The implementations now live in
+# ``outcome_bridge`` to keep the strategy shell focused on lifecycle.
+__all__ = [
+    "K8sProviderStrategy",
+    "_all_instances_terminal",
+    "_build_provider_result_data",
+    "_outcome_to_provider_result",
+]
 
 if TYPE_CHECKING:  # pragma: no cover — type-checking only
     from orb.domain.request.aggregate import Request
@@ -175,45 +192,54 @@ class K8sProviderStrategy(ProviderStrategy):
         self._provider_name = provider_name
         self._config_port = config_port
         self._kubernetes_client: Optional[K8sClient] = kubernetes_client
-        # Watch fan-out.  Constructed lazily by :meth:`initialize` when
-        # ``config.watch_enabled`` is True and no override has been
-        # provided.  Tests inject a stub via ``watch_manager``.
-        self._watch_manager: Optional[MultiNamespaceWatcher] = watch_manager
-        # Reconciliation wiring: startup reconciler + orphan GC.
         # ``known_request_ids`` is the storage closure the strategy hands
-        # to both — when the
-        # caller does not supply it the reconciler treats every managed
-        # pod as an orphan (safest signal) and the GC is wired to an
-        # empty set.  Tests can override both subsystems wholesale.
+        # to the reconciler + orphan GC — when the caller does not supply
+        # it the reconciler treats every managed pod as an orphan (safest
+        # signal) and the GC is wired to an empty set.
         self._known_request_ids_fn: Callable[[], Iterable[str]] = known_request_ids or (lambda: ())
-        self._startup_reconciler: Optional[StartupReconciler] = startup_reconciler
-        self._orphan_gc: Optional[OrphanGarbageCollector] = orphan_gc
-        self._last_reconciliation_report: Optional[ReconciliationReport] = None
-        # Node watching.  When ``node_watch_enabled=True`` (opt-in via
-        # K8sProviderConfig) the strategy starts a K8sNodeWatcher on the
-        # background thread and exposes the populated K8sNodeStateCache to
-        # handlers so per-instance status dicts carry node metadata.
-        # Tests inject both via the constructor kwargs to avoid real threads.
-        self._node_state_cache: K8sNodeStateCache = node_state_cache or K8sNodeStateCache()
-        self._node_watcher: Optional[K8sNodeWatcher] = node_watcher
-        # Events API watching.  When ``events_watch_enabled=True`` (opt-in via
-        # K8sProviderConfig) the strategy starts a K8sEventsWatcher on a
-        # background thread and populates K8sNodeEventsCache with Karpenter
-        # node-disruption events.  Tests inject both via constructor kwargs.
-        self._node_events_cache: K8sNodeEventsCache = node_events_cache or K8sNodeEventsCache()
-        self._events_watcher: Optional[K8sEventsWatcher] = events_watcher
+        # ------------------------------------------------------------------
+        # Lifecycle sub-services — mirror the AWS provider's delegation
+        # layout.  Each owns one cohesive background subsystem so the
+        # strategy shell stays a thin orchestrator.
+        # ------------------------------------------------------------------
+        # Watch fan-out (+ shared PodStateCache + metrics recorder).
+        self._watch_lifecycle = K8sWatchManagerLifecycle(
+            config=self._k8s_config,
+            logger=self._logger,
+            client_provider=lambda: self.kubernetes_client,
+            watch_manager=watch_manager,
+        )
+        # Startup reconciler + orphan GC.  Tests can override both
+        # subsystems wholesale via the constructor kwargs.
+        self._reconciliation_lifecycle = K8sReconciliationLifecycle(
+            config=self._k8s_config,
+            logger=self._logger,
+            client_provider=lambda: self.kubernetes_client,
+            watch_lifecycle=self._watch_lifecycle,
+            known_request_ids=self._known_request_ids_fn,
+            startup_reconciler=startup_reconciler,
+            orphan_gc=orphan_gc,
+        )
+        # Node watcher + events watcher (+ their shared caches).  Tests
+        # inject watchers/caches via constructor kwargs to avoid real
+        # threads.
+        self._node_watch_lifecycle = K8sNodeWatchLifecycle(
+            config=self._k8s_config,
+            logger=self._logger,
+            client_provider=lambda: self.kubernetes_client,
+            node_state_cache=node_state_cache,
+            node_watcher=node_watcher,
+            node_events_cache=node_events_cache,
+            events_watcher=events_watcher,
+        )
         # Native-spec escape hatch.  Resolved lazily on first handler
-        # construction.  ``None`` after resolution means the service is
-        # unavailable (jinja2 missing, injected service not provided, etc.)
-        # — handlers fall back to the typed builder path.  The injected
-        # ``native_spec_service`` is the raw ``NativeSpecService`` from the
-        # application layer; :meth:`_resolve_native_spec_service` wraps it
-        # in ``K8sNativeSpecService`` on first call.  There is no DI
-        # container fallback — callers that need native-spec support must
-        # supply the service via this constructor parameter.
-        self._injected_native_spec_service: Optional[Any] = native_spec_service
-        self._native_spec_service_resolved: bool = False
-        self._k8s_native_spec_service: Optional[Any] = None
+        # construction; owns the DI-container / config-port plumbing.
+        self._native_spec_resolver = K8sNativeSpecResolver(
+            config=self._k8s_config,
+            logger=self._logger,
+            config_port=self._config_port,
+            injected_native_spec_service=native_spec_service,
+        )
         # Infrastructure discovery service — constructed lazily by
         # :meth:`_get_discovery_service` on first use.
         self._discovery_service: Optional[K8sInfrastructureDiscoveryService] = None
@@ -244,11 +270,6 @@ class K8sProviderStrategy(ProviderStrategy):
         # a second invocation (e.g. uvicorn worker recycle) short-circuits
         # immediately to prevent double-reconciliation.
         self._daemon_services_started: bool = False
-        # Prometheus metrics — constructed lazily on first use so tests
-        # that never touch the metrics path do not pollute the global
-        # ``prometheus_client.REGISTRY``.  Disabled entirely when
-        # ``config.metrics_enabled=False``.
-        self._metrics: Optional[Any] = None
         # Handler registry — does the per-API handler factory wiring and
         # the typed acquire/return/status dispatch.  Wired with closures
         # over the strategy's lazy client, watcher, native-spec accessors
@@ -258,11 +279,11 @@ class K8sProviderStrategy(ProviderStrategy):
             config=self._k8s_config,
             logger=self._logger,
             client_provider=lambda: self.kubernetes_client,
-            watch_manager_provider=lambda: self._watch_manager,
+            watch_manager_provider=lambda: self._watch_lifecycle.watch_manager,
             plugin_factories=lambda: self._handler_factories,
             native_spec_service_provider=self._resolve_native_spec_service,
             handler_overrides=handler_overrides,
-            node_state_cache_provider=lambda: self._node_state_cache,
+            node_state_cache_provider=lambda: self._node_watch_lifecycle.node_state_cache,
             api_aliases=type(self)._API_ALIASES,
             metrics_provider=self._get_metrics,
         )
@@ -298,6 +319,64 @@ class K8sProviderStrategy(ProviderStrategy):
     def _handlers(self) -> dict[str, K8sHandlerBase]:
         """Handler cache view — preserved for test fixtures that pre-seed it."""
         return self._handler_registry.handlers
+
+    # ------------------------------------------------------------------
+    # Sub-service state delegation
+    #
+    # The background subsystems now live in dedicated lifecycle services,
+    # but the strategy's private attributes remain part of the contract
+    # relied on by fixtures and integration tests (which pre-seed / patch
+    # them directly).  These properties keep that surface intact while the
+    # implementation lives in the extracted services.
+    # ------------------------------------------------------------------
+
+    @property
+    def _watch_manager(self) -> Optional[MultiNamespaceWatcher]:
+        return self._watch_lifecycle.watch_manager
+
+    @_watch_manager.setter
+    def _watch_manager(self, value: Optional[MultiNamespaceWatcher]) -> None:
+        self._watch_lifecycle.watch_manager = value
+
+    @property
+    def _orphan_gc(self) -> Optional[OrphanGarbageCollector]:
+        return self._reconciliation_lifecycle.orphan_gc
+
+    @_orphan_gc.setter
+    def _orphan_gc(self, value: Optional[OrphanGarbageCollector]) -> None:
+        self._reconciliation_lifecycle.orphan_gc = value
+
+    @property
+    def _startup_reconciler(self) -> Optional[StartupReconciler]:
+        return self._reconciliation_lifecycle.startup_reconciler
+
+    @_startup_reconciler.setter
+    def _startup_reconciler(self, value: Optional[StartupReconciler]) -> None:
+        self._reconciliation_lifecycle.startup_reconciler = value
+
+    @property
+    def _node_watcher(self) -> Optional[K8sNodeWatcher]:
+        return self._node_watch_lifecycle.node_watcher
+
+    @_node_watcher.setter
+    def _node_watcher(self, value: Optional[K8sNodeWatcher]) -> None:
+        self._node_watch_lifecycle.node_watcher = value
+
+    @property
+    def _events_watcher(self) -> Optional[K8sEventsWatcher]:
+        return self._node_watch_lifecycle.events_watcher
+
+    @_events_watcher.setter
+    def _events_watcher(self, value: Optional[K8sEventsWatcher]) -> None:
+        self._node_watch_lifecycle.events_watcher = value
+
+    @property
+    def _node_state_cache(self) -> K8sNodeStateCache:
+        return self._node_watch_lifecycle.node_state_cache
+
+    @property
+    def _node_events_cache(self) -> K8sNodeEventsCache:
+        return self._node_watch_lifecycle.node_events_cache
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -377,18 +456,14 @@ class K8sProviderStrategy(ProviderStrategy):
             )
 
         try:
-            if self._node_watcher is not None:
-                self._node_watcher.stop()
-                self._node_watcher = None
+            self._node_watch_lifecycle.stop_node_watcher()
         except Exception as exc:
             self._logger.warning(
                 "Failed to stop Kubernetes node watcher during cleanup: %s", exc, exc_info=True
             )
 
         try:
-            if self._events_watcher is not None:
-                self._events_watcher.stop()
-                self._events_watcher = None
+            self._node_watch_lifecycle.stop_events_watcher()
         except Exception as exc:
             self._logger.warning(
                 "Failed to stop Kubernetes events watcher during cleanup: %s", exc, exc_info=True
@@ -417,126 +492,22 @@ class K8sProviderStrategy(ProviderStrategy):
     def _ensure_watch_manager(self) -> MultiNamespaceWatcher:
         """Lazily construct (but do NOT start) the watch fan-out.
 
-        Exposed so the startup reconciler can share the watcher's
-        :class:`PodStateCache`: the reconciler warms the cache before
-        the watcher spawns, then the watcher takes over.  The watcher
-        is only started later by :meth:`_maybe_start_watch_manager`
-        when an event loop is available.
+        Delegates to :class:`K8sWatchManagerLifecycle`.  Exposed so the
+        startup reconciler can share the watcher's :class:`PodStateCache`.
         """
-        if self._watch_manager is None:
-            self._watch_manager = MultiNamespaceWatcher(
-                kubernetes_client=self.kubernetes_client,
-                config=self._k8s_config,
-                logger=self._logger,
-                metrics=self._get_metrics(),
-            )
-        return self._watch_manager
+        return self._watch_lifecycle.ensure()
 
     def _maybe_start_watch_manager(self) -> None:
-        """Start the watch fleet when enabled by config and a loop is available.
-
-        The fleet runs as an asyncio task and therefore needs a running
-        event loop.  When ``initialize`` is called from a synchronous
-        context (e.g. CLI bootstrap) we skip startup and let the
-        cache-less fallback path serve reads.  Daemon / REST callers
-        typically run inside an event loop and pick up the watcher.
-        """
-        if not self._k8s_config.watch_enabled:
-            return
-        manager = self._ensure_watch_manager()
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            self._logger.debug(
-                "Skipping Kubernetes watcher startup: no running event loop "
-                "(cache-less fallback will serve reads)."
-            )
-            return
-        try:
-            # MultiNamespaceWatcher.start() is idempotent: it guards on
-            # ``self._started`` at entry and returns immediately on a
-            # second call.  A SIGTERM that interrupts between the
-            # subsystem calls in start_daemon_services() therefore does
-            # not leave duplicate watchers running — a retry simply
-            # no-ops on the already-started watcher.
-            manager.start()
-        except Exception as exc:
-            self._logger.warning("Failed to start Kubernetes watcher fleet: %s", exc, exc_info=True)
+        """Start the watch fleet when enabled by config and a loop is available."""
+        self._watch_lifecycle.maybe_start()
 
     def _stop_watch_manager_sync(self, *, shutdown_timeout: float = 10.0) -> None:
         """Stop the watch manager, blocking until all watchers exit or the timeout elapses.
 
-        Three paths depending on the calling context:
-
-        * **No running loop** — drives ``manager.stop()`` synchronously
-          via :func:`asyncio.run`.
-        * **Running loop, different thread** (e.g. signal handler) —
-          schedules the coroutine via
-          :func:`asyncio.run_coroutine_threadsafe` and calls
-          ``.result(timeout)`` to block until the watchers exit.  If the
-          timeout elapses a warning is logged but the caller is not raised.
-        * **Running loop, same thread** (event-loop-thread cleanup path) —
-          blocking via ``.result()`` would deadlock, so this path falls
-          back to fire-and-forget scheduling while logging a warning.
-          Callers that need guaranteed completion should use
-          ``await manager.stop()`` directly instead.
-
-        Args:
-            shutdown_timeout: Maximum seconds to wait for the watcher loop
-                to exit when called from a different thread.  Defaults to
-                ``10.0 s``.
+        Delegates to :class:`K8sWatchManagerLifecycle`; see it for the
+        three context-dependent shutdown paths.
         """
-        manager = self._watch_manager
-        if manager is None or not manager.is_started():
-            return
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop is None:
-            # No running event loop — drive the coroutine synchronously.
-            try:
-                asyncio.run(manager.stop())
-            except Exception as exc:
-                self._logger.debug(
-                    "Watch manager stop raised during cleanup: %s", exc, exc_info=True
-                )
-            return
-
-        # There is a running event loop.  Determine whether this call is
-        # arriving from the event-loop thread itself or from a foreign
-        # thread (e.g. a signal handler or a cleanup thread).
-        loop_thread_id: int | None = getattr(loop, "_thread_id", None)
-        on_loop_thread = (
-            loop_thread_id is not None and threading.current_thread().ident == loop_thread_id
-        )
-
-        if on_loop_thread:
-            # Blocking here would deadlock — the event loop cannot make
-            # progress while the current frame is suspended.  Schedule
-            # fire-and-forget and warn so operators know the watcher may
-            # not finish before the process exits.
-            self._logger.warning(
-                "Kubernetes watcher stop scheduled without awaiting completion "
-                "(cleanup called from the event-loop thread; "
-                "watchers may outlive this cleanup call)."
-            )
-            loop.create_task(manager.stop())
-            return
-
-        # Foreign thread with a running loop — block with timeout.
-        future = asyncio.run_coroutine_threadsafe(manager.stop(), loop)
-        try:
-            future.result(timeout=shutdown_timeout)
-        except TimeoutError:
-            self._logger.warning(
-                "Kubernetes watcher fleet did not stop within %.1fs; "
-                "proceeding with shutdown anyway.",
-                shutdown_timeout,
-            )
-        except Exception as exc:
-            self._logger.debug("Watch manager stop raised during cleanup: %s", exc, exc_info=True)
+        self._watch_lifecycle.stop_sync(shutdown_timeout=shutdown_timeout)
 
     # ------------------------------------------------------------------
     # Reconciliation / orphan-GC lifecycle
@@ -545,157 +516,40 @@ class K8sProviderStrategy(ProviderStrategy):
     @property
     def last_reconciliation_report(self) -> Optional[ReconciliationReport]:
         """Surface the most recent :class:`ReconciliationReport` for diagnostics."""
-        return self._last_reconciliation_report
+        return self._reconciliation_lifecycle.last_reconciliation_report
 
     def _get_metrics(self) -> Optional[Any]:
         """Return the shared :class:`K8sMetrics` instance, constructing on demand.
 
-        Returns ``None`` when ``config.metrics_enabled=False`` so
-        handlers and the watcher stay silent.  Constructed once per
-        strategy instance; a second invocation returns the same
-        object so all recorders share the same OTel meter.
+        Delegates to :class:`K8sWatchManagerLifecycle` which owns the
+        recorder so watcher and handlers share the same OTel meter.
         """
-        if not self._k8s_config.metrics_enabled:
-            return None
-        if self._metrics is None:
-            from orb.providers.k8s.infrastructure.services.metrics import K8sMetrics
-
-            self._metrics = K8sMetrics()
-        return self._metrics
+        return self._watch_lifecycle.get_metrics()
 
     def _shared_cache(self) -> PodStateCache:
-        """Return the cache used by both reconciler and watcher.
-
-        Constructed via :meth:`_ensure_watch_manager` so reconciler and
-        watcher always share the same instance — populating one
-        warms the other.
-        """
-        return self._ensure_watch_manager().cache
+        """Return the cache used by both reconciler and watcher."""
+        return self._watch_lifecycle.shared_cache()
 
     async def _run_startup_reconciler(self) -> None:
         """Run the startup reconciler before the watch task spawns.
 
-        The reconciler is constructed lazily here so tests that pass
-        ``startup_reconciler=`` directly into the strategy can skip the
-        default construction path entirely.  Only called from
+        Delegates to :class:`K8sReconciliationLifecycle`.  Only called from
         :meth:`start_daemon_services` — the CLI path never reaches this
         method.
         """
-        reconciler = self._startup_reconciler
-        if reconciler is None:
-            reconciler = StartupReconciler(
-                kubernetes_client=self.kubernetes_client,
-                config=self._k8s_config,
-                cache=self._shared_cache(),
-                logger=self._logger,
-                known_request_ids=self._known_request_ids_fn,
-            )
-            self._startup_reconciler = reconciler
-        try:
-            report = await reconciler.run_async()
-            self._last_reconciliation_report = report
-            # Only signal first-sync-complete when the reconciler
-            # actually succeeded.  ``run_async`` captures its own
-            # exceptions internally and sets ``report.completed = False``
-            # + ``report.error`` when the LIST failed — gating on the
-            # flag prevents ``is_healthy()`` from returning True with a
-            # cold, empty cache after a silent reconciler failure.
-            if report.completed and self._watch_manager is not None:
-                self._watch_manager.mark_first_sync_complete()
-            elif not report.completed:
-                self._logger.warning(
-                    "Kubernetes startup reconciler did not complete: %s "
-                    "(provider continues; is_healthy will report False until "
-                    "the next successful sync)",
-                    report.error,
-                )
-        except Exception as exc:
-            self._logger.warning(
-                "Kubernetes startup reconciler raised: %s (provider continues)",
-                exc,
-                exc_info=True,
-            )
+        await self._reconciliation_lifecycle.run_startup_reconciler()
 
     def _maybe_start_orphan_gc(self) -> None:
         """Spawn the orphan GC task when enabled and an event loop is available."""
-        if not self._k8s_config.orphan_gc_enabled:
-            return
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            self._logger.debug(
-                "Skipping orphan GC startup: no running event loop "
-                "(GC will not run in this process)."
-            )
-            return
-        if self._orphan_gc is None:
-            self._orphan_gc = OrphanGarbageCollector(
-                kubernetes_client=self.kubernetes_client,
-                config=self._k8s_config,
-                logger=self._logger,
-                known_request_ids=self._known_request_ids_fn,
-            )
-        try:
-            self._orphan_gc.start()
-            self._logger.info(
-                "Kubernetes orphan GC started (interval=%ss, auto_cleanup=%s)",
-                self._k8s_config.orphan_gc_interval_seconds,
-                self._k8s_config.auto_cleanup_orphans,
-            )
-        except Exception as exc:
-            self._logger.warning("Failed to start Kubernetes orphan GC: %s", exc, exc_info=True)
+        self._reconciliation_lifecycle.maybe_start_orphan_gc()
 
     def _stop_orphan_gc_sync(self, *, stop_timeout: float = 5.0) -> None:
         """Stop the orphan GC from a sync-or-async cleanup context.
 
-        Three paths depending on the calling context:
-
-        * **No running loop** — drives ``gc.stop()`` synchronously via
-          :func:`asyncio.run`.
-        * **Running loop, different thread** — schedules the coroutine via
-          :func:`asyncio.run_coroutine_threadsafe` and blocks with a timeout
-          so the coroutine completes before the client is closed.  If the
-          timeout elapses a warning is logged.
-        * **Running loop, same thread** — blocking here would deadlock, so
-          this path also uses :func:`asyncio.run_coroutine_threadsafe` but
-          from a dedicated daemon thread, ensuring the coroutine finishes
-          before this method returns.
-
-        Args:
-            stop_timeout: Maximum seconds to wait for the GC coroutine to
-                finish.  Defaults to ``5.0 s``.
+        Delegates to :class:`K8sReconciliationLifecycle`; see it for the
+        three context-dependent shutdown paths.
         """
-        gc = self._orphan_gc
-        if gc is None or not gc.is_running():
-            return
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-        if loop is None:
-            # No running event loop — drive the coroutine synchronously.
-            try:
-                asyncio.run(gc.stop())
-            except Exception as exc:
-                self._logger.debug("Orphan GC stop raised during cleanup: %s", exc, exc_info=True)
-            return
-
-        # There is a running event loop.  Use run_coroutine_threadsafe from
-        # the current thread (or a helper thread) to schedule and block on
-        # gc.stop().  This is safe regardless of whether we are on the loop
-        # thread itself or a foreign thread because the future is resolved
-        # asynchronously by the loop.
-        future = asyncio.run_coroutine_threadsafe(gc.stop(), loop)
-        try:
-            future.result(timeout=stop_timeout)
-        except TimeoutError:
-            self._logger.warning(
-                "Kubernetes orphan GC did not stop within %.1fs during cleanup; "
-                "proceeding anyway — the GC coroutine may still be running.",
-                stop_timeout,
-            )
-        except Exception as exc:
-            self._logger.debug("Orphan GC stop raised during cleanup: %s", exc, exc_info=True)
+        self._reconciliation_lifecycle.stop_orphan_gc_sync(stop_timeout=stop_timeout)
 
     # ------------------------------------------------------------------
     # Node watcher lifecycle
@@ -709,29 +563,11 @@ class K8sProviderStrategy(ProviderStrategy):
         ``False`` it is simply an empty cache that returns ``None`` for
         every lookup.
         """
-        return self._node_state_cache
+        return self._node_watch_lifecycle.node_state_cache
 
     def _maybe_start_node_watcher(self) -> None:
-        """Start the node watcher when enabled by config.
-
-        Unlike the asyncio pod watcher, the node watcher runs on a
-        plain background daemon thread so it does not require a running
-        event loop.  This means it can start from both synchronous
-        (CLI bootstrap) and async (daemon) contexts.
-        """
-        if not self._k8s_config.node_watch_enabled:
-            return
-        if self._node_watcher is None:
-            self._node_watcher = K8sNodeWatcher(
-                kubernetes_client=self.kubernetes_client,
-                cache=self._node_state_cache,
-                logger=self._logger,
-            )
-        try:
-            self._node_watcher.start()
-            self._logger.info("Kubernetes node watcher started (node_watch_enabled=True)")
-        except Exception as exc:
-            self._logger.warning("Failed to start Kubernetes node watcher: %s", exc, exc_info=True)
+        """Start the node watcher when enabled by config (delegated)."""
+        self._node_watch_lifecycle.maybe_start_node_watcher()
 
     # ------------------------------------------------------------------
     # Events watcher lifecycle
@@ -745,35 +581,11 @@ class K8sProviderStrategy(ProviderStrategy):
         ``False`` it is simply an empty cache that returns ``None`` for
         every lookup.
         """
-        return self._node_events_cache
+        return self._node_watch_lifecycle.node_events_cache
 
     def _maybe_start_events_watcher(self) -> None:
-        """Start the Events API watcher when enabled by config.
-
-        Like the node watcher, the events watcher runs on a plain
-        background daemon thread (not in the asyncio event loop) so it
-        can start from both synchronous (CLI bootstrap) and async
-        (daemon) contexts.
-
-        Requires the operator to have granted the ``events: get/list/watch``
-        RBAC verb on the core API group -- see
-        ``docs/root/providers/k8s/rbac.yaml``.
-        """
-        if not self._k8s_config.events_watch_enabled:
-            return
-        if self._events_watcher is None:
-            self._events_watcher = K8sEventsWatcher(
-                kubernetes_client=self.kubernetes_client,
-                cache=self._node_events_cache,
-                logger=self._logger,
-            )
-        try:
-            self._events_watcher.start()
-            self._logger.info("Kubernetes events watcher started (events_watch_enabled=True)")
-        except Exception as exc:
-            self._logger.warning(
-                "Failed to start Kubernetes events watcher: %s", exc, exc_info=True
-            )
+        """Start the Events API watcher when enabled by config (delegated)."""
+        self._node_watch_lifecycle.maybe_start_events_watcher()
 
     # ------------------------------------------------------------------
     # Operation dispatch
@@ -1178,145 +990,12 @@ class K8sProviderStrategy(ProviderStrategy):
 
     @classmethod
     def get_ui_column_schema(cls) -> list:  # type: ignore[override]
-        """Return k8s-specific UI column descriptors for machines, requests, and templates."""
-        from orb.application.dto.system import UIColumnDescriptor
+        """Return k8s-specific UI column descriptors for machines, requests, and templates.
 
-        return [
-            # ------------------------------------------------------------------
-            # machines — pod/workload-level columns
-            # ------------------------------------------------------------------
-            UIColumnDescriptor(
-                key="k8s_namespace",
-                path="provider_data.namespace",
-                label="Namespace",
-                kind="badge",
-                resource_type="machines",
-                provider="k8s",
-                sortable=True,
-                default_visible=True,
-            ),
-            UIColumnDescriptor(
-                key="k8s_node_name",
-                path="provider_data.node_name",
-                label="Node",
-                kind="text",
-                resource_type="machines",
-                provider="k8s",
-                sortable=True,
-                default_visible=True,
-            ),
-            UIColumnDescriptor(
-                key="k8s_phase",
-                path="provider_data.phase",
-                label="Phase",
-                kind="badge",
-                resource_type="machines",
-                provider="k8s",
-                badge_color_map={
-                    "Running": "green",
-                    "Pending": "orange",
-                    "Succeeded": "teal",
-                    "Failed": "red",
-                    "Unknown": "gray",
-                },
-                sortable=True,
-                default_visible=True,
-            ),
-            UIColumnDescriptor(
-                key="k8s_restart_count",
-                path="provider_data.restart_count",
-                label="Restarts",
-                kind="count",
-                resource_type="machines",
-                provider="k8s",
-                sortable=True,
-                default_visible=False,
-            ),
-            UIColumnDescriptor(
-                key="k8s_capacity_type",
-                path="provider_data.node_capacity_type",
-                label="Capacity Type",
-                kind="badge",
-                resource_type="machines",
-                provider="k8s",
-                badge_color_map={"spot": "orange", "on-demand": "blue", "on_demand": "blue"},
-                sortable=True,
-                default_visible=False,
-            ),
-            UIColumnDescriptor(
-                key="k8s_workload_kind",
-                path="provider_api",
-                label="Workload Kind",
-                kind="badge",
-                resource_type="machines",
-                provider="k8s",
-                badge_color_map={
-                    "Pod": "blue",
-                    "Deployment": "purple",
-                    "StatefulSet": "teal",
-                    "Job": "orange",
-                },
-                sortable=True,
-                default_visible=False,
-            ),
-            # ------------------------------------------------------------------
-            # requests — provider-level request columns
-            # ------------------------------------------------------------------
-            UIColumnDescriptor(
-                key="k8s_request_namespace",
-                path="provider_data.namespace",
-                label="Namespace",
-                kind="badge",
-                resource_type="requests",
-                provider="k8s",
-                sortable=True,
-                default_visible=True,
-            ),
-            UIColumnDescriptor(
-                key="k8s_request_provider_api",
-                path="provider_data.provider_api",
-                label="Workload Kind",
-                kind="badge",
-                resource_type="requests",
-                provider="k8s",
-                badge_color_map={
-                    "Pod": "blue",
-                    "Deployment": "purple",
-                    "StatefulSet": "teal",
-                    "Job": "orange",
-                },
-                default_visible=True,
-            ),
-            # ------------------------------------------------------------------
-            # templates — k8s template surface
-            # ------------------------------------------------------------------
-            UIColumnDescriptor(
-                key="k8s_template_provider_api",
-                path="provider_api",
-                label="Workload Kind",
-                kind="badge",
-                resource_type="templates",
-                provider="k8s",
-                badge_color_map={
-                    "Pod": "blue",
-                    "Deployment": "purple",
-                    "StatefulSet": "teal",
-                    "Job": "orange",
-                },
-                default_visible=True,
-                sortable=True,
-            ),
-            UIColumnDescriptor(
-                key="k8s_template_namespace",
-                path="namespace",
-                label="Namespace",
-                kind="text",
-                resource_type="templates",
-                provider="k8s",
-                default_visible=True,
-                sortable=True,
-            ),
-        ]
+        Delegates to :class:`K8sCapabilityService` which owns the descriptor
+        catalogue alongside the other capability/naming declarations.
+        """
+        return K8sCapabilityService.get_ui_column_schema()
 
     # ------------------------------------------------------------------
     # Region / CLI helpers
@@ -1404,55 +1083,12 @@ class K8sProviderStrategy(ProviderStrategy):
     def _resolve_native_spec_service(self) -> Optional[Any]:
         """Resolve :class:`K8sNativeSpecService` once on first handler build.
 
-        Returns ``None`` when the provider config opts out
-        (``native_spec_enabled=False``), when no ``ConfigurationPort`` is
-        wired, or when no ``native_spec_service`` was passed at construction
-        time.  All construction paths that need native-spec support must
-        supply the service via the constructor parameter — the
-        :func:`orb.providers.k8s.registration.create_k8s_strategy` factory
-        resolves it from the DI container at strategy-creation time and
-        passes it explicitly.  There is no ``get_container()`` fallback.
+        Delegates to :class:`K8sNativeSpecResolver` which owns the
+        config-port / injected-service gating.  Returns ``None`` when the
+        provider config opts out, when no ``ConfigurationPort`` is wired,
+        or when no ``native_spec_service`` was passed at construction time.
         """
-        if self._native_spec_service_resolved:
-            return self._k8s_native_spec_service
-        self._native_spec_service_resolved = True
-
-        if not self._k8s_config.native_spec_enabled:
-            return None
-
-        if self._config_port is None:
-            self._logger.debug(
-                "Kubernetes native-spec service unavailable: no ConfigurationPort "
-                "wired into the strategy (typed builder path will be used)."
-            )
-            return None
-
-        if self._injected_native_spec_service is None:
-            self._logger.debug(
-                "Kubernetes native-spec service unavailable: no NativeSpecService "
-                "injected at construction time (typed builder path will be used).  "
-                "Ensure create_k8s_strategy is used so the service is resolved from "
-                "the DI container before strategy construction."
-            )
-            return None
-
-        try:
-            from orb.providers.k8s.infrastructure.services.k8s_native_spec_service import (
-                K8sNativeSpecService,
-            )
-
-            self._k8s_native_spec_service = K8sNativeSpecService(
-                native_spec_service=self._injected_native_spec_service,
-                config_port=self._config_port,
-                k8s_config=self._k8s_config,
-            )
-            return self._k8s_native_spec_service
-        except Exception as exc:
-            self._logger.warning(
-                "K8sNativeSpecService unavailable, native spec enrichment disabled: %s",
-                exc,
-            )
-            return None
+        return self._native_spec_resolver.resolve()
 
     # ------------------------------------------------------------------
     # Handler dispatch — delegated to K8sHandlerRegistry
@@ -1561,168 +1197,3 @@ class K8sProviderStrategy(ProviderStrategy):
             f"namespace={self._k8s_config.namespace}, "
             f"initialized={self._initialized})"
         )
-
-
-def _build_provider_result_data(
-    *,
-    resource_ids: list[str],
-    metadata: Optional[dict[str, Any]] = None,
-    tracking_request_id: Optional[str] = None,
-) -> dict[str, Any]:
-    """Build the ``ProviderResult.data`` dict for k8s outcomes.
-
-    Resource-vs-machine model (Kubernetes):
-
-    * **Pod handler** — every Pod IS its own resource.  Acquire emits
-      ``resource_ids == machine_ids == [pod_name, ...]`` (1:1).  The
-      handler also surfaces a per-machine ``instances`` list with the
-      pod's ``status``, ``image_id`` and so on, populated lazily by the
-      status resolver.
-    * **Deployment / StatefulSet / Job handler** — the workload controller
-      is the *resource* (1 entry: ``[deployment_name]``); the Pods it
-      spawns are the *machines* (N entries, populated by the status
-      resolver).  Acquire emits ``machine_ids=[]`` because the
-      controller has not yet scheduled any pods.
-
-    The bridge therefore propagates whatever the handler put under
-    ``metadata['instances']`` verbatim (it carries the authoritative
-    ``resource_id`` ↔ ``machine_id`` mapping per pod) and otherwise
-    leaves ``instances`` empty so that downstream machine creation is
-    driven by a subsequent status read rather than by manufactured rows.
-    """
-    meta_dict = dict(metadata or {})
-    # ``machine_ids`` are the per-pod identifiers (1 per machine row);
-    # ``resource_ids`` are the per-controller (or per-pod for the Pod
-    # handler) identifiers.  Both are propagated through ``provider_data``
-    # so the application layer can reason about them independently.
-    machine_ids = list(meta_dict.get("machine_ids") or [])
-    instances = list(meta_dict.get("instances") or [])
-
-    data: dict[str, Any] = {
-        "resource_ids": resource_ids,
-        "instances": instances,
-        # ``instance_ids`` consumed by deprovisioning / sync paths that
-        # want the per-pod identifiers.  Falls back to ``resource_ids``
-        # for the Pod handler (where resource = machine) when the
-        # handler did not put machine_ids in metadata.
-        "instance_ids": machine_ids or resource_ids,
-        "provider_data": meta_dict,
-    }
-    if tracking_request_id is not None:
-        data["tracking_request_id"] = tracking_request_id
-    return data
-
-
-def _all_instances_terminal(instances: list[dict[str, Any]]) -> bool:
-    """Return True when every instance dict has reached a non-pending state.
-
-    Used by the bridge to detect synchronous completions: when an Accepted
-    outcome carries ``pending_resource_ids`` but ``metadata['instances']``
-    already shows every pod as running, succeeded, or terminated, the request
-    has effectively completed and ``fulfillment_final`` should be set so the
-    provisioning service does not keep it in IN_PROGRESS indefinitely.
-
-    An empty instances list is not considered terminal — the status resolver
-    has not yet populated instance data, so we cannot make a determination.
-    """
-    if not instances:
-        return False
-    terminal_states = {"running", "succeeded", "terminated"}
-    return all(inst.get("status") in terminal_states for inst in instances)
-
-
-def _outcome_to_provider_result(
-    outcome: OperationOutcome, *, fallback_operation: str
-) -> ProviderResult:
-    """Translate an :class:`OperationOutcome` into a :class:`ProviderResult`.
-
-    Used by ``execute_operation`` to bridge the kubernetes provider's typed
-    provisioning interface back to the shared ``ProviderOperation`` envelope
-    that the provisioning orchestration service consumes.
-
-    ``fulfillment_final=True`` is set in two cases:
-    * ``Completed`` outcome — always terminal.
-    * ``Accepted`` outcome where ``pending_resource_ids`` is non-empty AND
-      every instance in ``metadata['instances']`` already has a
-      running/terminal status.  This covers Pod handlers that schedule pods
-      synchronously so the provisioning service does not keep the request
-      in IN_PROGRESS waiting for a state transition that already happened.
-    """
-    from orb.domain.base.operation_outcome import (
-        Accepted,
-        Completed,
-        Failed,
-        RequiresFollowUp,
-    )
-
-    if isinstance(outcome, Failed):
-        return ProviderResult.error_result(outcome.error, "OPERATION_FAILED").model_copy(
-            update={
-                "metadata": {
-                    **(outcome.metadata or {}),
-                    "operation": fallback_operation,
-                    "provider": "k8s",
-                    "recoverable": outcome.recoverable,
-                }
-            }
-        )
-
-    if isinstance(outcome, Accepted):
-        meta = dict(outcome.metadata or {})
-        pending = list(outcome.pending_resource_ids)
-        if pending and _all_instances_terminal(list(meta.get("instances") or [])):
-            # All pods are already in a terminal/running state at accept time —
-            # promote to fulfillment_final so the provisioning service closes
-            # the request without a redundant status poll.
-            meta["fulfillment_final"] = True
-        return ProviderResult.success_result(
-            _build_provider_result_data(
-                resource_ids=pending,
-                metadata=meta,
-                tracking_request_id=outcome.request_id,
-            ),
-            {"operation": fallback_operation, "provider": "k8s"},
-        )
-
-    if isinstance(outcome, Completed):
-        # ``fulfillment_final=True`` signals to the provisioning service
-        # that the request has reached a terminal state — without it the
-        # request would stay IN_PROGRESS forever.
-        meta = {**dict(outcome.metadata or {}), "fulfillment_final": True}
-        return ProviderResult.success_result(
-            _build_provider_result_data(
-                resource_ids=list(outcome.resource_ids),
-                metadata=meta,
-            ),
-            {"operation": fallback_operation, "provider": "k8s"},
-        )
-
-    if isinstance(outcome, RequiresFollowUp):
-        ctx = outcome.context
-        # Both follow-up variants carry an ID list; surface it as
-        # ``resource_ids`` so the application layer keeps a handle on
-        # what's still pending.  ``follow_up_kind`` and the typed context
-        # ride along in ``provider_data`` for the background poller.
-        pending_ids: list[str] = list(
-            getattr(ctx, "pending_resource_ids", None)
-            or getattr(ctx, "pending_instance_ids", None)
-            or []
-        )
-        meta = {
-            **dict(outcome.metadata or {}),
-            "follow_up_kind": ctx.follow_up_kind,
-            "provider_handle": getattr(ctx, "provider_handle", None),
-            "expected_terminal_state": getattr(ctx, "expected_terminal_state", None),
-        }
-        return ProviderResult.success_result(
-            _build_provider_result_data(
-                resource_ids=pending_ids,
-                metadata=meta,
-            ),
-            {"operation": fallback_operation, "provider": "k8s"},
-        )
-
-    return ProviderResult.error_result(
-        f"Unknown OperationOutcome variant: {type(outcome).__name__}",
-        "UNSUPPORTED_OUTCOME",
-    )

--- a/src/orb/providers/k8s/strategy/native_spec_resolver.py
+++ b/src/orb/providers/k8s/strategy/native_spec_resolver.py
@@ -1,0 +1,100 @@
+"""Native-spec DI plumbing for the Kubernetes provider.
+
+Extracted from :class:`orb.providers.k8s.strategy.k8s_provider_strategy.
+K8sProviderStrategy`.  Wraps the raw ``NativeSpecService`` from the
+application layer in a :class:`K8sNativeSpecService` on first handler build,
+gated on config + wired ``ConfigurationPort`` + an injected service.
+
+The strategy delegates :meth:`resolve` from its
+``_resolve_native_spec_service`` accessor (which the handler registry calls
+via a provider closure) so the DI-resolution contract is unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from orb.domain.base.ports import LoggingPort
+from orb.domain.base.ports.configuration_port import ConfigurationPort
+from orb.providers.k8s.configuration.config import K8sProviderConfig
+
+
+class K8sNativeSpecResolver:
+    """Lazily resolve :class:`K8sNativeSpecService` once per strategy instance."""
+
+    def __init__(
+        self,
+        *,
+        config: K8sProviderConfig,
+        logger: LoggingPort,
+        config_port: Optional[ConfigurationPort],
+        injected_native_spec_service: Optional[Any],
+    ) -> None:
+        self._config = config
+        self._logger = logger
+        self._config_port = config_port
+        # Native-spec escape hatch.  Resolved lazily on first handler
+        # construction.  ``None`` after resolution means the service is
+        # unavailable (jinja2 missing, injected service not provided, etc.)
+        # — handlers fall back to the typed builder path.  The injected
+        # ``native_spec_service`` is the raw ``NativeSpecService`` from the
+        # application layer; :meth:`resolve` wraps it in
+        # ``K8sNativeSpecService`` on first call.  There is no DI container
+        # fallback — callers that need native-spec support must supply the
+        # service via the strategy constructor.
+        self._injected_native_spec_service: Optional[Any] = injected_native_spec_service
+        self._resolved: bool = False
+        self._k8s_native_spec_service: Optional[Any] = None
+
+    def resolve(self) -> Optional[Any]:
+        """Resolve :class:`K8sNativeSpecService` once on first handler build.
+
+        Returns ``None`` when the provider config opts out
+        (``native_spec_enabled=False``), when no ``ConfigurationPort`` is
+        wired, or when no ``native_spec_service`` was passed at construction
+        time.  All construction paths that need native-spec support must
+        supply the service via the constructor parameter — the
+        :func:`orb.providers.k8s.registration.create_k8s_strategy` factory
+        resolves it from the DI container at strategy-creation time and
+        passes it explicitly.  There is no ``get_container()`` fallback.
+        """
+        if self._resolved:
+            return self._k8s_native_spec_service
+        self._resolved = True
+
+        if not self._config.native_spec_enabled:
+            return None
+
+        if self._config_port is None:
+            self._logger.debug(
+                "Kubernetes native-spec service unavailable: no ConfigurationPort "
+                "wired into the strategy (typed builder path will be used)."
+            )
+            return None
+
+        if self._injected_native_spec_service is None:
+            self._logger.debug(
+                "Kubernetes native-spec service unavailable: no NativeSpecService "
+                "injected at construction time (typed builder path will be used).  "
+                "Ensure create_k8s_strategy is used so the service is resolved from "
+                "the DI container before strategy construction."
+            )
+            return None
+
+        try:
+            from orb.providers.k8s.infrastructure.services.k8s_native_spec_service import (
+                K8sNativeSpecService,
+            )
+
+            self._k8s_native_spec_service = K8sNativeSpecService(
+                native_spec_service=self._injected_native_spec_service,
+                config_port=self._config_port,
+                k8s_config=self._config,
+            )
+            return self._k8s_native_spec_service
+        except Exception as exc:
+            self._logger.warning(
+                "K8sNativeSpecService unavailable, native spec enrichment disabled: %s",
+                exc,
+            )
+            return None

--- a/src/orb/providers/k8s/strategy/node_watch_lifecycle.py
+++ b/src/orb/providers/k8s/strategy/node_watch_lifecycle.py
@@ -1,0 +1,149 @@
+"""Node-watcher + events-watcher lifecycle service for the Kubernetes provider.
+
+Extracted from :class:`orb.providers.k8s.strategy.k8s_provider_strategy.
+K8sProviderStrategy`.  Both watchers run on plain background daemon threads
+(not the asyncio loop) so they can start from synchronous CLI bootstrap and
+async daemon contexts alike.  Grouping them keeps the shared caches and the
+start/stop symmetry in one cohesive owner.
+
+The strategy re-exposes ``_node_watcher`` / ``_events_watcher`` /
+``node_state_cache`` / ``node_events_cache`` as delegating attributes and
+``_maybe_start_node_watcher`` / ``_maybe_start_events_watcher`` as delegating
+methods so the public + test-visible surface is unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from orb.domain.base.ports import LoggingPort
+from orb.providers.k8s.configuration.config import K8sProviderConfig
+from orb.providers.k8s.infrastructure.k8s_client import K8sClient
+from orb.providers.k8s.watch.events_watcher import K8sEventsWatcher, K8sNodeEventsCache
+from orb.providers.k8s.watch.node_state_cache import K8sNodeStateCache
+from orb.providers.k8s.watch.node_watcher import K8sNodeWatcher
+
+
+class K8sNodeWatchLifecycle:
+    """Own the node-watcher + events-watcher lifecycle for a single strategy instance."""
+
+    def __init__(
+        self,
+        *,
+        config: K8sProviderConfig,
+        logger: LoggingPort,
+        client_provider: Callable[[], K8sClient],
+        node_state_cache: Optional[K8sNodeStateCache] = None,
+        node_watcher: Optional[K8sNodeWatcher] = None,
+        node_events_cache: Optional[K8sNodeEventsCache] = None,
+        events_watcher: Optional[K8sEventsWatcher] = None,
+    ) -> None:
+        self._config = config
+        self._logger = logger
+        self._client_provider = client_provider
+        # Node watching.  When ``node_watch_enabled=True`` (opt-in via
+        # K8sProviderConfig) the strategy starts a K8sNodeWatcher on the
+        # background thread and exposes the populated K8sNodeStateCache to
+        # handlers so per-instance status dicts carry node metadata.
+        self._node_state_cache: K8sNodeStateCache = node_state_cache or K8sNodeStateCache()
+        self._node_watcher: Optional[K8sNodeWatcher] = node_watcher
+        # Events API watching.  When ``events_watch_enabled=True`` (opt-in via
+        # K8sProviderConfig) the strategy starts a K8sEventsWatcher on a
+        # background thread and populates K8sNodeEventsCache with Karpenter
+        # node-disruption events.
+        self._node_events_cache: K8sNodeEventsCache = node_events_cache or K8sNodeEventsCache()
+        self._events_watcher: Optional[K8sEventsWatcher] = events_watcher
+
+    # -- state accessors -------------------------------------------------
+
+    @property
+    def node_state_cache(self) -> K8sNodeStateCache:
+        return self._node_state_cache
+
+    @property
+    def node_events_cache(self) -> K8sNodeEventsCache:
+        return self._node_events_cache
+
+    @property
+    def node_watcher(self) -> Optional[K8sNodeWatcher]:
+        return self._node_watcher
+
+    @node_watcher.setter
+    def node_watcher(self, value: Optional[K8sNodeWatcher]) -> None:
+        self._node_watcher = value
+
+    @property
+    def events_watcher(self) -> Optional[K8sEventsWatcher]:
+        return self._events_watcher
+
+    @events_watcher.setter
+    def events_watcher(self, value: Optional[K8sEventsWatcher]) -> None:
+        self._events_watcher = value
+
+    # -- node watcher ----------------------------------------------------
+
+    def maybe_start_node_watcher(self) -> None:
+        """Start the node watcher when enabled by config.
+
+        Unlike the asyncio pod watcher, the node watcher runs on a
+        plain background daemon thread so it does not require a running
+        event loop.  This means it can start from both synchronous
+        (CLI bootstrap) and async (daemon) contexts.
+        """
+        if not self._config.node_watch_enabled:
+            return
+        if self._node_watcher is None:
+            self._node_watcher = K8sNodeWatcher(
+                kubernetes_client=self._client_provider(),
+                cache=self._node_state_cache,
+                logger=self._logger,
+            )
+        try:
+            self._node_watcher.start()
+            self._logger.info("Kubernetes node watcher started (node_watch_enabled=True)")
+        except Exception as exc:
+            self._logger.warning("Failed to start Kubernetes node watcher: %s", exc, exc_info=True)
+
+    # -- events watcher --------------------------------------------------
+
+    def maybe_start_events_watcher(self) -> None:
+        """Start the Events API watcher when enabled by config.
+
+        Like the node watcher, the events watcher runs on a plain
+        background daemon thread (not in the asyncio event loop) so it
+        can start from both synchronous (CLI bootstrap) and async
+        (daemon) contexts.
+
+        Requires the operator to have granted the ``events: get/list/watch``
+        RBAC verb on the core API group -- see
+        ``docs/root/providers/k8s/rbac.yaml``.
+        """
+        if not self._config.events_watch_enabled:
+            return
+        if self._events_watcher is None:
+            self._events_watcher = K8sEventsWatcher(
+                kubernetes_client=self._client_provider(),
+                cache=self._node_events_cache,
+                logger=self._logger,
+            )
+        try:
+            self._events_watcher.start()
+            self._logger.info("Kubernetes events watcher started (events_watch_enabled=True)")
+        except Exception as exc:
+            self._logger.warning(
+                "Failed to start Kubernetes events watcher: %s", exc, exc_info=True
+            )
+
+    # -- cleanup ---------------------------------------------------------
+
+    def stop_node_watcher(self) -> None:
+        """Stop and clear the node watcher (raises on failure — caller wraps)."""
+        if self._node_watcher is not None:
+            self._node_watcher.stop()
+            self._node_watcher = None
+
+    def stop_events_watcher(self) -> None:
+        """Stop and clear the events watcher (raises on failure — caller wraps)."""
+        if self._events_watcher is not None:
+            self._events_watcher.stop()
+            self._events_watcher = None

--- a/src/orb/providers/k8s/strategy/outcome_bridge.py
+++ b/src/orb/providers/k8s/strategy/outcome_bridge.py
@@ -1,0 +1,189 @@
+"""Outcome-to-``ProviderResult`` bridge for the Kubernetes provider.
+
+Extracted from :mod:`orb.providers.k8s.strategy.k8s_provider_strategy` so the
+strategy shell stays focused on lifecycle orchestration.  The three helpers
+here translate the typed :class:`OperationOutcome` union the k8s handlers
+produce into the shared :class:`ProviderResult` envelope the provisioning
+service consumes.
+
+The strategy module re-imports these names so existing callers and tests that
+reference them via ``k8s_provider_strategy`` keep working unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from orb.domain.base.operation_outcome import OperationOutcome
+from orb.providers.base.strategy import ProviderResult
+
+__all__ = [
+    "_all_instances_terminal",
+    "_build_provider_result_data",
+    "_outcome_to_provider_result",
+]
+
+
+def _build_provider_result_data(
+    *,
+    resource_ids: list[str],
+    metadata: Optional[dict[str, Any]] = None,
+    tracking_request_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build the ``ProviderResult.data`` dict for k8s outcomes.
+
+    Resource-vs-machine model (Kubernetes):
+
+    * **Pod handler** — every Pod IS its own resource.  Acquire emits
+      ``resource_ids == machine_ids == [pod_name, ...]`` (1:1).  The
+      handler also surfaces a per-machine ``instances`` list with the
+      pod's ``status``, ``image_id`` and so on, populated lazily by the
+      status resolver.
+    * **Deployment / StatefulSet / Job handler** — the workload controller
+      is the *resource* (1 entry: ``[deployment_name]``); the Pods it
+      spawns are the *machines* (N entries, populated by the status
+      resolver).  Acquire emits ``machine_ids=[]`` because the
+      controller has not yet scheduled any pods.
+
+    The bridge therefore propagates whatever the handler put under
+    ``metadata['instances']`` verbatim (it carries the authoritative
+    ``resource_id`` ↔ ``machine_id`` mapping per pod) and otherwise
+    leaves ``instances`` empty so that downstream machine creation is
+    driven by a subsequent status read rather than by manufactured rows.
+    """
+    meta_dict = dict(metadata or {})
+    # ``machine_ids`` are the per-pod identifiers (1 per machine row);
+    # ``resource_ids`` are the per-controller (or per-pod for the Pod
+    # handler) identifiers.  Both are propagated through ``provider_data``
+    # so the application layer can reason about them independently.
+    machine_ids = list(meta_dict.get("machine_ids") or [])
+    instances = list(meta_dict.get("instances") or [])
+
+    data: dict[str, Any] = {
+        "resource_ids": resource_ids,
+        "instances": instances,
+        # ``instance_ids`` consumed by deprovisioning / sync paths that
+        # want the per-pod identifiers.  Falls back to ``resource_ids``
+        # for the Pod handler (where resource = machine) when the
+        # handler did not put machine_ids in metadata.
+        "instance_ids": machine_ids or resource_ids,
+        "provider_data": meta_dict,
+    }
+    if tracking_request_id is not None:
+        data["tracking_request_id"] = tracking_request_id
+    return data
+
+
+def _all_instances_terminal(instances: list[dict[str, Any]]) -> bool:
+    """Return True when every instance dict has reached a non-pending state.
+
+    Used by the bridge to detect synchronous completions: when an Accepted
+    outcome carries ``pending_resource_ids`` but ``metadata['instances']``
+    already shows every pod as running, succeeded, or terminated, the request
+    has effectively completed and ``fulfillment_final`` should be set so the
+    provisioning service does not keep it in IN_PROGRESS indefinitely.
+
+    An empty instances list is not considered terminal — the status resolver
+    has not yet populated instance data, so we cannot make a determination.
+    """
+    if not instances:
+        return False
+    terminal_states = {"running", "succeeded", "terminated"}
+    return all(inst.get("status") in terminal_states for inst in instances)
+
+
+def _outcome_to_provider_result(
+    outcome: OperationOutcome, *, fallback_operation: str
+) -> ProviderResult:
+    """Translate an :class:`OperationOutcome` into a :class:`ProviderResult`.
+
+    Used by ``execute_operation`` to bridge the kubernetes provider's typed
+    provisioning interface back to the shared ``ProviderOperation`` envelope
+    that the provisioning orchestration service consumes.
+
+    ``fulfillment_final=True`` is set in two cases:
+    * ``Completed`` outcome — always terminal.
+    * ``Accepted`` outcome where ``pending_resource_ids`` is non-empty AND
+      every instance in ``metadata['instances']`` already has a
+      running/terminal status.  This covers Pod handlers that schedule pods
+      synchronously so the provisioning service does not keep the request
+      in IN_PROGRESS waiting for a state transition that already happened.
+    """
+    from orb.domain.base.operation_outcome import (
+        Accepted,
+        Completed,
+        Failed,
+        RequiresFollowUp,
+    )
+
+    if isinstance(outcome, Failed):
+        return ProviderResult.error_result(outcome.error, "OPERATION_FAILED").model_copy(
+            update={
+                "metadata": {
+                    **(outcome.metadata or {}),
+                    "operation": fallback_operation,
+                    "provider": "k8s",
+                    "recoverable": outcome.recoverable,
+                }
+            }
+        )
+
+    if isinstance(outcome, Accepted):
+        meta = dict(outcome.metadata or {})
+        pending = list(outcome.pending_resource_ids)
+        if pending and _all_instances_terminal(list(meta.get("instances") or [])):
+            # All pods are already in a terminal/running state at accept time —
+            # promote to fulfillment_final so the provisioning service closes
+            # the request without a redundant status poll.
+            meta["fulfillment_final"] = True
+        return ProviderResult.success_result(
+            _build_provider_result_data(
+                resource_ids=pending,
+                metadata=meta,
+                tracking_request_id=outcome.request_id,
+            ),
+            {"operation": fallback_operation, "provider": "k8s"},
+        )
+
+    if isinstance(outcome, Completed):
+        # ``fulfillment_final=True`` signals to the provisioning service
+        # that the request has reached a terminal state — without it the
+        # request would stay IN_PROGRESS forever.
+        meta = {**dict(outcome.metadata or {}), "fulfillment_final": True}
+        return ProviderResult.success_result(
+            _build_provider_result_data(
+                resource_ids=list(outcome.resource_ids),
+                metadata=meta,
+            ),
+            {"operation": fallback_operation, "provider": "k8s"},
+        )
+
+    if isinstance(outcome, RequiresFollowUp):
+        ctx = outcome.context
+        # Both follow-up variants carry an ID list; surface it as
+        # ``resource_ids`` so the application layer keeps a handle on
+        # what's still pending.  ``follow_up_kind`` and the typed context
+        # ride along in ``provider_data`` for the background poller.
+        pending_ids: list[str] = list(
+            getattr(ctx, "pending_resource_ids", None)
+            or getattr(ctx, "pending_instance_ids", None)
+            or []
+        )
+        meta = {
+            **dict(outcome.metadata or {}),
+            "follow_up_kind": ctx.follow_up_kind,
+            "provider_handle": getattr(ctx, "provider_handle", None),
+            "expected_terminal_state": getattr(ctx, "expected_terminal_state", None),
+        }
+        return ProviderResult.success_result(
+            _build_provider_result_data(
+                resource_ids=pending_ids,
+                metadata=meta,
+            ),
+            {"operation": fallback_operation, "provider": "k8s"},
+        )
+
+    return ProviderResult.error_result(
+        f"Unknown OperationOutcome variant: {type(outcome).__name__}",
+        "UNSUPPORTED_OUTCOME",
+    )

--- a/src/orb/providers/k8s/strategy/reconciliation_lifecycle.py
+++ b/src/orb/providers/k8s/strategy/reconciliation_lifecycle.py
@@ -1,0 +1,204 @@
+"""Startup-reconciler + orphan-GC lifecycle service for the Kubernetes provider.
+
+Extracted from :class:`orb.providers.k8s.strategy.k8s_provider_strategy.
+K8sProviderStrategy`.  Owns the startup reconciler run and the orphan
+garbage-collector start/stop, keeping the strategy shell free of the
+reconciliation plumbing while mirroring the AWS strategy's
+service-delegation shape.
+
+The strategy re-exposes ``_startup_reconciler`` / ``_orphan_gc`` /
+``_last_reconciliation_report`` as delegating properties and
+``_run_startup_reconciler`` / ``_maybe_start_orphan_gc`` /
+``_stop_orphan_gc_sync`` as delegating methods so the public +
+test-visible surface is unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Callable, Iterable, Optional
+
+from orb.domain.base.ports import LoggingPort
+from orb.providers.k8s.configuration.config import K8sProviderConfig
+from orb.providers.k8s.infrastructure.k8s_client import K8sClient
+from orb.providers.k8s.reconciliation.orphan_gc import OrphanGarbageCollector
+from orb.providers.k8s.reconciliation.startup_reconciler import (
+    ReconciliationReport,
+    StartupReconciler,
+)
+from orb.providers.k8s.strategy.watch_lifecycle import K8sWatchManagerLifecycle
+
+
+class K8sReconciliationLifecycle:
+    """Own startup reconciliation + orphan-GC for a single strategy instance."""
+
+    def __init__(
+        self,
+        *,
+        config: K8sProviderConfig,
+        logger: LoggingPort,
+        client_provider: Callable[[], K8sClient],
+        watch_lifecycle: K8sWatchManagerLifecycle,
+        known_request_ids: Callable[[], Iterable[str]],
+        startup_reconciler: Optional[StartupReconciler] = None,
+        orphan_gc: Optional[OrphanGarbageCollector] = None,
+    ) -> None:
+        self._config = config
+        self._logger = logger
+        self._client_provider = client_provider
+        self._watch_lifecycle = watch_lifecycle
+        self._known_request_ids_fn = known_request_ids
+        self._startup_reconciler: Optional[StartupReconciler] = startup_reconciler
+        self._orphan_gc: Optional[OrphanGarbageCollector] = orphan_gc
+        self._last_reconciliation_report: Optional[ReconciliationReport] = None
+
+    # -- state accessors -------------------------------------------------
+
+    @property
+    def startup_reconciler(self) -> Optional[StartupReconciler]:
+        return self._startup_reconciler
+
+    @startup_reconciler.setter
+    def startup_reconciler(self, value: Optional[StartupReconciler]) -> None:
+        self._startup_reconciler = value
+
+    @property
+    def orphan_gc(self) -> Optional[OrphanGarbageCollector]:
+        return self._orphan_gc
+
+    @orphan_gc.setter
+    def orphan_gc(self, value: Optional[OrphanGarbageCollector]) -> None:
+        self._orphan_gc = value
+
+    @property
+    def last_reconciliation_report(self) -> Optional[ReconciliationReport]:
+        return self._last_reconciliation_report
+
+    # -- startup reconciler ---------------------------------------------
+
+    async def run_startup_reconciler(self) -> None:
+        """Run the startup reconciler before the watch task spawns.
+
+        The reconciler is constructed lazily here so tests that pass
+        ``startup_reconciler=`` directly into the strategy can skip the
+        default construction path entirely.  Only called from
+        ``start_daemon_services`` — the CLI path never reaches this method.
+        """
+        reconciler = self._startup_reconciler
+        if reconciler is None:
+            reconciler = StartupReconciler(
+                kubernetes_client=self._client_provider(),
+                config=self._config,
+                cache=self._watch_lifecycle.shared_cache(),
+                logger=self._logger,
+                known_request_ids=self._known_request_ids_fn,
+            )
+            self._startup_reconciler = reconciler
+        try:
+            report = await reconciler.run_async()
+            self._last_reconciliation_report = report
+            # Only signal first-sync-complete when the reconciler
+            # actually succeeded.  ``run_async`` captures its own
+            # exceptions internally and sets ``report.completed = False``
+            # + ``report.error`` when the LIST failed — gating on the
+            # flag prevents ``is_healthy()`` from returning True with a
+            # cold, empty cache after a silent reconciler failure.
+            watch_manager = self._watch_lifecycle.watch_manager
+            if report.completed and watch_manager is not None:
+                watch_manager.mark_first_sync_complete()
+            elif not report.completed:
+                self._logger.warning(
+                    "Kubernetes startup reconciler did not complete: %s "
+                    "(provider continues; is_healthy will report False until "
+                    "the next successful sync)",
+                    report.error,
+                )
+        except Exception as exc:
+            self._logger.warning(
+                "Kubernetes startup reconciler raised: %s (provider continues)",
+                exc,
+                exc_info=True,
+            )
+
+    # -- orphan GC -------------------------------------------------------
+
+    def maybe_start_orphan_gc(self) -> None:
+        """Spawn the orphan GC task when enabled and an event loop is available."""
+        if not self._config.orphan_gc_enabled:
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            self._logger.debug(
+                "Skipping orphan GC startup: no running event loop "
+                "(GC will not run in this process)."
+            )
+            return
+        if self._orphan_gc is None:
+            self._orphan_gc = OrphanGarbageCollector(
+                kubernetes_client=self._client_provider(),
+                config=self._config,
+                logger=self._logger,
+                known_request_ids=self._known_request_ids_fn,
+            )
+        try:
+            self._orphan_gc.start()
+            self._logger.info(
+                "Kubernetes orphan GC started (interval=%ss, auto_cleanup=%s)",
+                self._config.orphan_gc_interval_seconds,
+                self._config.auto_cleanup_orphans,
+            )
+        except Exception as exc:
+            self._logger.warning("Failed to start Kubernetes orphan GC: %s", exc, exc_info=True)
+
+    def stop_orphan_gc_sync(self, *, stop_timeout: float = 5.0) -> None:
+        """Stop the orphan GC from a sync-or-async cleanup context.
+
+        Three paths depending on the calling context:
+
+        * **No running loop** — drives ``gc.stop()`` synchronously via
+          :func:`asyncio.run`.
+        * **Running loop, different thread** — schedules the coroutine via
+          :func:`asyncio.run_coroutine_threadsafe` and blocks with a timeout
+          so the coroutine completes before the client is closed.  If the
+          timeout elapses a warning is logged.
+        * **Running loop, same thread** — blocking here would deadlock, so
+          this path also uses :func:`asyncio.run_coroutine_threadsafe` but
+          from a dedicated daemon thread, ensuring the coroutine finishes
+          before this method returns.
+
+        Args:
+            stop_timeout: Maximum seconds to wait for the GC coroutine to
+                finish.  Defaults to ``5.0 s``.
+        """
+        gc = self._orphan_gc
+        if gc is None or not gc.is_running():
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop is None:
+            # No running event loop — drive the coroutine synchronously.
+            try:
+                asyncio.run(gc.stop())
+            except Exception as exc:
+                self._logger.debug("Orphan GC stop raised during cleanup: %s", exc, exc_info=True)
+            return
+
+        # There is a running event loop.  Use run_coroutine_threadsafe from
+        # the current thread (or a helper thread) to schedule and block on
+        # gc.stop().  This is safe regardless of whether we are on the loop
+        # thread itself or a foreign thread because the future is resolved
+        # asynchronously by the loop.
+        future = asyncio.run_coroutine_threadsafe(gc.stop(), loop)
+        try:
+            future.result(timeout=stop_timeout)
+        except TimeoutError:
+            self._logger.warning(
+                "Kubernetes orphan GC did not stop within %.1fs during cleanup; "
+                "proceeding anyway — the GC coroutine may still be running.",
+                stop_timeout,
+            )
+        except Exception as exc:
+            self._logger.debug("Orphan GC stop raised during cleanup: %s", exc, exc_info=True)

--- a/src/orb/providers/k8s/strategy/watch_lifecycle.py
+++ b/src/orb/providers/k8s/strategy/watch_lifecycle.py
@@ -1,0 +1,234 @@
+"""Watch-manager lifecycle service for the Kubernetes provider.
+
+Extracted from :class:`orb.providers.k8s.strategy.k8s_provider_strategy.
+K8sProviderStrategy` so the strategy shell delegates watch fan-out
+construction, start, and shutdown to a cohesive owner — mirroring how the
+AWS strategy delegates to focused services.
+
+Owns:
+
+* the lazily-constructed :class:`MultiNamespaceWatcher` and its shared
+  :class:`PodStateCache`;
+* the lazily-constructed :class:`K8sMetrics` recorder;
+* the three-path synchronous shutdown (:meth:`stop_sync`) that has to cope
+  with being called with no loop, from a foreign thread, or from the
+  event-loop thread itself.
+
+The strategy re-exposes ``_watch_manager`` as a delegating property and
+``_ensure_watch_manager`` / ``_maybe_start_watch_manager`` /
+``_stop_watch_manager_sync`` / ``_shared_cache`` / ``_get_metrics`` as
+delegating methods so the public + test-visible surface is unchanged.  The
+:class:`K8sMetrics` recorder is owned solely here and reached through
+``_get_metrics``; the strategy does not hold its own ``_metrics`` reference.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Callable, Optional
+
+from orb.domain.base.ports import LoggingPort
+from orb.providers.k8s.configuration.config import K8sProviderConfig
+from orb.providers.k8s.infrastructure.k8s_client import K8sClient
+from orb.providers.k8s.watch.multi_namespace import MultiNamespaceWatcher
+from orb.providers.k8s.watch.pod_state_cache import PodStateCache
+
+
+class K8sWatchManagerLifecycle:
+    """Own the watch fan-out lifecycle for a single strategy instance."""
+
+    def __init__(
+        self,
+        *,
+        config: K8sProviderConfig,
+        logger: LoggingPort,
+        client_provider: Callable[[], K8sClient],
+        watch_manager: Optional[MultiNamespaceWatcher] = None,
+    ) -> None:
+        self._config = config
+        self._logger = logger
+        self._client_provider = client_provider
+        # Watch fan-out.  Constructed lazily by :meth:`maybe_start` when
+        # ``config.watch_enabled`` is True and no override has been
+        # provided.  Tests inject a stub via ``watch_manager``.
+        self._watch_manager: Optional[MultiNamespaceWatcher] = watch_manager
+        # Prometheus metrics — constructed lazily on first use so tests
+        # that never touch the metrics path do not pollute the global
+        # ``prometheus_client.REGISTRY``.  Disabled entirely when
+        # ``config.metrics_enabled=False``.
+        self._metrics: Optional[Any] = None
+
+    # -- state accessors -------------------------------------------------
+
+    @property
+    def watch_manager(self) -> Optional[MultiNamespaceWatcher]:
+        return self._watch_manager
+
+    @watch_manager.setter
+    def watch_manager(self, value: Optional[MultiNamespaceWatcher]) -> None:
+        self._watch_manager = value
+
+    @property
+    def metrics(self) -> Optional[Any]:
+        return self._metrics
+
+    @metrics.setter
+    def metrics(self, value: Optional[Any]) -> None:
+        self._metrics = value
+
+    # -- metrics ---------------------------------------------------------
+
+    def get_metrics(self) -> Optional[Any]:
+        """Return the shared :class:`K8sMetrics` instance, constructing on demand.
+
+        Returns ``None`` when ``config.metrics_enabled=False`` so
+        handlers and the watcher stay silent.  Constructed once per
+        strategy instance; a second invocation returns the same
+        object so all recorders share the same OTel meter.
+        """
+        if not self._config.metrics_enabled:
+            return None
+        if self._metrics is None:
+            from orb.providers.k8s.infrastructure.services.metrics import K8sMetrics
+
+            self._metrics = K8sMetrics()
+        return self._metrics
+
+    # -- construction ----------------------------------------------------
+
+    def ensure(self) -> MultiNamespaceWatcher:
+        """Lazily construct (but do NOT start) the watch fan-out.
+
+        Exposed so the startup reconciler can share the watcher's
+        :class:`PodStateCache`: the reconciler warms the cache before
+        the watcher spawns, then the watcher takes over.  The watcher
+        is only started later by :meth:`maybe_start` when an event loop
+        is available.
+        """
+        if self._watch_manager is None:
+            self._watch_manager = MultiNamespaceWatcher(
+                kubernetes_client=self._client_provider(),
+                config=self._config,
+                logger=self._logger,
+                metrics=self.get_metrics(),
+            )
+        return self._watch_manager
+
+    def shared_cache(self) -> PodStateCache:
+        """Return the cache used by both reconciler and watcher.
+
+        Constructed via :meth:`ensure` so reconciler and watcher always
+        share the same instance — populating one warms the other.
+        """
+        return self.ensure().cache
+
+    # -- start -----------------------------------------------------------
+
+    def maybe_start(self) -> None:
+        """Start the watch fleet when enabled by config and a loop is available.
+
+        The fleet runs as an asyncio task and therefore needs a running
+        event loop.  When ``initialize`` is called from a synchronous
+        context (e.g. CLI bootstrap) we skip startup and let the
+        cache-less fallback path serve reads.  Daemon / REST callers
+        typically run inside an event loop and pick up the watcher.
+        """
+        if not self._config.watch_enabled:
+            return
+        manager = self.ensure()
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            self._logger.debug(
+                "Skipping Kubernetes watcher startup: no running event loop "
+                "(cache-less fallback will serve reads)."
+            )
+            return
+        try:
+            # MultiNamespaceWatcher.start() is idempotent: it guards on
+            # ``self._started`` at entry and returns immediately on a
+            # second call.  A SIGTERM that interrupts between the
+            # subsystem calls in start_daemon_services() therefore does
+            # not leave duplicate watchers running — a retry simply
+            # no-ops on the already-started watcher.
+            manager.start()
+        except Exception as exc:
+            self._logger.warning("Failed to start Kubernetes watcher fleet: %s", exc, exc_info=True)
+
+    # -- stop ------------------------------------------------------------
+
+    def stop_sync(self, *, shutdown_timeout: float = 10.0) -> None:
+        """Stop the watch manager, blocking until all watchers exit or the timeout elapses.
+
+        Three paths depending on the calling context:
+
+        * **No running loop** — drives ``manager.stop()`` synchronously
+          via :func:`asyncio.run`.
+        * **Running loop, different thread** (e.g. signal handler) —
+          schedules the coroutine via
+          :func:`asyncio.run_coroutine_threadsafe` and calls
+          ``.result(timeout)`` to block until the watchers exit.  If the
+          timeout elapses a warning is logged but the caller is not raised.
+        * **Running loop, same thread** (event-loop-thread cleanup path) —
+          blocking via ``.result()`` would deadlock, so this path falls
+          back to fire-and-forget scheduling while logging a warning.
+          Callers that need guaranteed completion should use
+          ``await manager.stop()`` directly instead.
+
+        Args:
+            shutdown_timeout: Maximum seconds to wait for the watcher loop
+                to exit when called from a different thread.  Defaults to
+                ``10.0 s``.
+        """
+        manager = self._watch_manager
+        if manager is None or not manager.is_started():
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is None:
+            # No running event loop — drive the coroutine synchronously.
+            try:
+                asyncio.run(manager.stop())
+            except Exception as exc:
+                self._logger.debug(
+                    "Watch manager stop raised during cleanup: %s", exc, exc_info=True
+                )
+            return
+
+        # There is a running event loop.  Determine whether this call is
+        # arriving from the event-loop thread itself or from a foreign
+        # thread (e.g. a signal handler or a cleanup thread).
+        loop_thread_id: int | None = getattr(loop, "_thread_id", None)
+        on_loop_thread = (
+            loop_thread_id is not None and threading.current_thread().ident == loop_thread_id
+        )
+
+        if on_loop_thread:
+            # Blocking here would deadlock — the event loop cannot make
+            # progress while the current frame is suspended.  Schedule
+            # fire-and-forget and warn so operators know the watcher may
+            # not finish before the process exits.
+            self._logger.warning(
+                "Kubernetes watcher stop scheduled without awaiting completion "
+                "(cleanup called from the event-loop thread; "
+                "watchers may outlive this cleanup call)."
+            )
+            loop.create_task(manager.stop())
+            return
+
+        # Foreign thread with a running loop — block with timeout.
+        future = asyncio.run_coroutine_threadsafe(manager.stop(), loop)
+        try:
+            future.result(timeout=shutdown_timeout)
+        except TimeoutError:
+            self._logger.warning(
+                "Kubernetes watcher fleet did not stop within %.1fs; "
+                "proceeding with shutdown anyway.",
+                shutdown_timeout,
+            )
+        except Exception as exc:
+            self._logger.debug("Watch manager stop raised during cleanup: %s", exc, exc_info=True)

--- a/tests/providers/k8s/unit/handlers/test_base_handler_metrics_wiring.py
+++ b/tests/providers/k8s/unit/handlers/test_base_handler_metrics_wiring.py
@@ -1,0 +1,374 @@
+"""Unit tests for K8s handler API-call metrics wiring.
+
+Covers:
+
+* ``with_retry`` increments ``orb_k8s_api_retries_total`` once per genuine
+  retry (attempts beyond the first) from the resilience/backoff path.
+* ``_record_api_exception`` / ``_classify_and_record_api_exception`` increment
+  ``orb_k8s_api_errors_total`` and, on a 429, ``orb_k8s_api_throttles_total``.
+* Status-resolver read/list paths record API errors when the call fails and
+  time the call via ``_timed_api_call`` (apiserver latency histogram).
+* ``read_namespaced_job`` is a first-class member of ``API_OPERATIONS`` so its
+  metric labels do not bucket to ``"unknown"``.
+
+The counter assertions use a MagicMock ``K8sMetrics`` so we can assert on the
+exact record_* calls, plus one end-to-end scrape test proving the retries
+counter surfaces on the Prometheus registry.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+from orb.infrastructure.resilience.retry_classifier_registry import (
+    clear_classifiers,
+    register_retry_classifier,
+)
+from orb.providers.k8s.configuration.config import K8sProviderConfig
+from orb.providers.k8s.infrastructure.handlers.base_handler import K8sHandlerBase
+from orb.providers.k8s.infrastructure.instrumentation.metrics import (
+    API_OPERATIONS,
+    K8sMetrics,
+)
+from orb.providers.k8s.resilience.retry_classifier import K8sRetryClassifier
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass — K8sHandlerBase is abstract.
+# ---------------------------------------------------------------------------
+
+
+class _ConcreteHandler(K8sHandlerBase):
+    """Minimal concrete handler for exercising the base class in isolation."""
+
+    PROVIDER_API = "TestResource"
+
+    async def acquire_hosts(self, request: Any, template: Any) -> dict[str, Any]:  # type: ignore[override]
+        return {}
+
+    def check_hosts_status(self, request: Any) -> Any:  # type: ignore[override]
+        return None
+
+    async def release_hosts(self, machine_ids: list[str], request: Any) -> None:  # type: ignore[override]
+        pass
+
+    @classmethod
+    def get_example_templates(cls) -> list[Any]:  # type: ignore[override]
+        return []
+
+
+def _make_handler(
+    *,
+    metrics: Any,
+    max_retries: int = 2,
+) -> _ConcreteHandler:
+    """Return a handler wired with *metrics* and a unique circuit key."""
+    handler = _ConcreteHandler(
+        kubernetes_client=MagicMock(),
+        config=K8sProviderConfig(namespace="orb-test"),
+        logger=MagicMock(),
+        max_retries=max_retries,
+        base_delay=0.0,
+        max_delay=0.0,
+        circuit_breaker_failure_threshold=100,
+        circuit_breaker_reset_timeout=60,
+        metrics=metrics,
+    )
+    # Unique PROVIDER_API → fresh circuit-breaker state per test.
+    handler.PROVIDER_API = f"Test_{uuid.uuid4().hex}"
+    return handler
+
+
+@pytest.fixture(autouse=True)
+def _register_k8s_classifier():
+    """Register the K8s retry classifier so 5xx is treated as retryable."""
+    register_retry_classifier(K8sRetryClassifier())
+    yield
+    clear_classifiers()
+
+
+# ---------------------------------------------------------------------------
+# Enum membership
+# ---------------------------------------------------------------------------
+
+
+def test_read_namespaced_job_is_a_known_operation() -> None:
+    """The Job read op must be first-class so its labels don't bucket to unknown."""
+    assert "read_namespaced_job" in API_OPERATIONS
+
+
+# ---------------------------------------------------------------------------
+# with_retry → api_retries counter
+# ---------------------------------------------------------------------------
+
+
+def test_with_retry_increments_retries_counter_once_per_retry() -> None:
+    """One transient failure then success → exactly one retry recorded."""
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = _make_handler(metrics=metrics, max_retries=3)
+
+    calls: list[int] = []
+
+    def _flaky() -> str:
+        calls.append(1)
+        if len(calls) < 2:
+            raise ApiException(status=500, reason="Internal Server Error")
+        return "ok"
+
+    result = handler.with_retry(_flaky, operation_name="read_namespaced_job")
+
+    assert result == "ok"
+    assert len(calls) == 2
+    # The second invocation is the retry → recorded exactly once.
+    metrics.record_api_retry.assert_called_once_with(operation="read_namespaced_job")
+
+
+def test_with_retry_records_no_retry_on_first_attempt_success() -> None:
+    """A call that succeeds immediately records zero retries."""
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = _make_handler(metrics=metrics)
+
+    handler.with_retry(lambda: "ok", operation_name="list_namespaced_pod")
+
+    metrics.record_api_retry.assert_not_called()
+
+
+def test_with_retry_records_multiple_retries_before_success() -> None:
+    """Two transient failures then success → two retries recorded."""
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = _make_handler(metrics=metrics, max_retries=5)
+
+    calls: list[int] = []
+
+    def _flaky() -> str:
+        calls.append(1)
+        if len(calls) < 3:
+            raise ApiException(status=503, reason="Service Unavailable")
+        return "ok"
+
+    handler.with_retry(_flaky, operation_name="create_namespaced_pod")
+
+    assert len(calls) == 3
+    assert metrics.record_api_retry.call_count == 2
+    for call in metrics.record_api_retry.call_args_list:
+        assert call.kwargs == {"operation": "create_namespaced_pod"}
+
+
+def test_with_retry_records_retries_until_budget_exhausted() -> None:
+    """Every retry is recorded even when the call ultimately fails."""
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = _make_handler(metrics=metrics, max_retries=2)
+
+    def _always_fails() -> None:
+        raise ApiException(status=500, reason="boom")
+
+    with pytest.raises(Exception):  # noqa: B017  # MaxRetriesExceededError
+        handler.with_retry(_always_fails, operation_name="read_namespaced_deployment")
+
+    # 1 initial + 2 retries = 3 attempts → 2 retries recorded.
+    assert metrics.record_api_retry.call_count == 2
+
+
+def test_with_retry_no_retry_for_non_retryable_status() -> None:
+    """A 409 is non-retryable → no retry counter increment."""
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = _make_handler(metrics=metrics, max_retries=3)
+
+    def _op() -> None:
+        raise ApiException(status=409, reason="Conflict")
+
+    with pytest.raises(ApiException):
+        handler.with_retry(_op, operation_name="create_namespaced_pod")
+
+    metrics.record_api_retry.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# error / throttle counters
+# ---------------------------------------------------------------------------
+
+
+def test_record_api_exception_records_status_code() -> None:
+    """A raw ApiException's HTTP status becomes the error_code label."""
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = _make_handler(metrics=metrics)
+
+    handler._record_api_exception(
+        ApiException(status=403, reason="Forbidden"),
+        operation="read_namespaced_deployment",
+    )
+
+    metrics.record_api_error.assert_called_once_with(
+        operation="read_namespaced_deployment", error_code="403"
+    )
+
+
+def test_record_api_exception_non_apiexception_buckets_unknown() -> None:
+    """A non-ApiException failure is recorded with error_code='unknown'."""
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = _make_handler(metrics=metrics)
+
+    handler._record_api_exception(RuntimeError("network down"), operation="list_namespaced_pod")
+
+    metrics.record_api_error.assert_called_once_with(
+        operation="list_namespaced_pod", error_code="unknown"
+    )
+
+
+def test_record_api_exception_unwraps_retry_wrapper() -> None:
+    """A MaxRetriesExceededError wrapping an ApiException still yields the code."""
+    from orb.infrastructure.resilience.exceptions import MaxRetriesExceededError
+
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = _make_handler(metrics=metrics)
+
+    wrapped = MaxRetriesExceededError(3, ApiException(status=429, reason="Too Many Requests"))
+    handler._record_api_exception(wrapped, operation="create_namespaced_pod")
+
+    metrics.record_api_error.assert_called_once_with(
+        operation="create_namespaced_pod", error_code="429"
+    )
+
+
+def test_classify_and_record_api_exception_records_error() -> None:
+    """The classify helper still emits the error counter for an ApiException."""
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = _make_handler(metrics=metrics)
+
+    typed = handler._classify_and_record_api_exception(
+        ApiException(status=500, reason="boom"),
+        operation="delete_namespaced_pod",
+    )
+
+    assert typed is not None
+    metrics.record_api_error.assert_called_once_with(
+        operation="delete_namespaced_pod", error_code="500"
+    )
+
+
+def test_record_api_exception_noop_without_metrics() -> None:
+    """When metrics are not wired the helper is a silent no-op."""
+    handler = _make_handler(metrics=None)
+    # Must not raise even though no K8sMetrics is present.
+    handler._record_api_exception(ApiException(status=500), operation="list_namespaced_pod")
+
+
+# ---------------------------------------------------------------------------
+# 429 throttle counter end-to-end via real K8sMetrics + Prometheus scrape
+# ---------------------------------------------------------------------------
+
+
+def _make_meter_and_registry() -> tuple[Any, Any]:
+    from opentelemetry.exporter.prometheus import PrometheusMetricReader
+    from opentelemetry.sdk.metrics import MeterProvider
+    from prometheus_client import CollectorRegistry
+
+    reg = CollectorRegistry()
+    reader = PrometheusMetricReader(registry=reg)
+    provider = MeterProvider(metric_readers=[reader])
+    return provider.get_meter("test"), reg
+
+
+def _scrape(registry: Any) -> str:
+    from prometheus_client import generate_latest
+
+    return generate_latest(registry).decode("utf-8")
+
+
+def test_retry_counter_surfaces_on_prometheus_scrape() -> None:
+    """End-to-end: a real retry increments the scraped orb_k8s_api_retries_total."""
+    meter, reg = _make_meter_and_registry()
+    metrics = K8sMetrics(meter=meter)
+    handler = _make_handler(metrics=metrics, max_retries=3)
+
+    calls: list[int] = []
+
+    def _flaky() -> str:
+        calls.append(1)
+        if len(calls) < 2:
+            raise ApiException(status=500, reason="boom")
+        return "ok"
+
+    handler.with_retry(_flaky, operation_name="read_namespaced_job")
+
+    text = _scrape(reg)
+    assert "orb_k8s_api_retries_total" in text
+    assert 'operation="read_namespaced_job"' in text
+
+
+def test_circuit_breaker_gauge_surfaces_via_with_retry() -> None:
+    """The breaker protecting apiserver calls emits ``orb_k8s_circuit_breaker_state``.
+
+    Proves the metrics-aware ``K8sCircuitBreaker`` is wired into the production
+    ``with_retry`` path — before the wiring fix this gauge was only emitted by
+    tests and stayed absent (always-zero / never present) in production.
+    """
+    meter, reg = _make_meter_and_registry()
+    metrics = K8sMetrics(meter=meter)
+    handler = _make_handler(metrics=metrics, max_retries=1)
+
+    # A recoverable failure drives the breaker through the retry path, which
+    # emits the CLOSED-state gauge on breaker construction.
+    def _flaky() -> str:
+        raise ApiException(status=500, reason="boom")
+
+    with pytest.raises(Exception):  # noqa: B017  # MaxRetriesExceededError
+        handler.with_retry(_flaky, operation_name="read_namespaced_job")
+
+    text = _scrape(reg)
+    assert "orb_k8s_circuit_breaker_state" in text
+
+
+def test_circuit_breaker_gauge_records_open_transition_via_with_retry() -> None:
+    """Once the breaker trips, the gauge reflects the OPEN (=1) state."""
+    from orb.infrastructure.resilience import CircuitBreakerOpenError
+    from orb.infrastructure.resilience.strategy.circuit_breaker import CircuitBreakerStrategy
+
+    meter, reg = _make_meter_and_registry()
+    metrics = K8sMetrics(meter=meter)
+    handler = _make_handler(metrics=metrics, max_retries=1)
+    # Low threshold so the breaker opens quickly.
+    handler._cb_failure_threshold = 2
+    service_key = f"kubernetes.{handler.PROVIDER_API.lower()}"
+    CircuitBreakerStrategy._circuit_states.pop(service_key, None)
+
+    def _always_fails() -> None:
+        raise ApiException(status=500, reason="boom")
+
+    for _ in range(20):
+        try:
+            handler.with_retry(_always_fails, operation_name="read_namespaced_job")
+        except CircuitBreakerOpenError:
+            break
+        except Exception:
+            continue
+
+    text = _scrape(reg)
+    open_lines = [
+        line
+        for line in text.splitlines()
+        if "orb_k8s_circuit_breaker_state" in line and f'name="{service_key}"' in line
+    ]
+    assert open_lines, f"circuit_breaker_state gauge not scraped for {service_key}"
+    assert any(line.strip().endswith("1.0") or line.strip().endswith(" 1") for line in open_lines)
+
+
+def test_throttle_counter_surfaces_on_429_exception() -> None:
+    """A recorded 429 API exception bumps both errors and throttles counters."""
+    meter, reg = _make_meter_and_registry()
+    metrics = K8sMetrics(meter=meter)
+    handler = _make_handler(metrics=metrics)
+
+    handler._record_api_exception(
+        ApiException(status=429, reason="Too Many Requests"),
+        operation="list_namespaced_pod",
+    )
+
+    text = _scrape(reg)
+    assert "orb_k8s_api_errors_total" in text
+    assert "orb_k8s_api_throttles_total" in text
+    assert 'error_code="429"' in text

--- a/tests/providers/k8s/unit/handlers/test_status_resolver_metrics.py
+++ b/tests/providers/k8s/unit/handlers/test_status_resolver_metrics.py
@@ -1,0 +1,265 @@
+"""Status-resolver metrics wiring tests.
+
+Every status-resolver read/list path must:
+
+* Record ``orb_k8s_apiserver_latency_seconds`` for the API call (via the
+  handler's ``_timed_api_call`` context manager), and
+* Record ``orb_k8s_api_errors_total`` when the call fails (the resolver
+  swallows the exception and returns an in_progress / empty verdict, so the
+  error would otherwise be invisible on dashboards).
+
+The four resolvers (Pod, Deployment, StatefulSet, Job) are exercised through
+their concrete handlers with a MagicMock ``K8sMetrics`` injected so the record_*
+calls can be asserted directly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+from orb.domain.request.aggregate import Request
+from orb.domain.request.value_objects import RequestId, RequestType
+from orb.providers.k8s.configuration.config import K8sProviderConfig
+from orb.providers.k8s.infrastructure.instrumentation.metrics import K8sMetrics
+
+
+def _req(*, provider_api: str, name: str = "wl-1", namespace: str = "ns") -> Request:
+    pd: dict[str, Any] = {
+        "namespace": namespace,
+        "deployment_name": name,
+        "statefulset_name": name,
+        "job_name": name,
+    }
+    return Request(
+        request_id=RequestId(value=f"req-{uuid.uuid4()}"),
+        request_type=RequestType.ACQUIRE,
+        provider_type="k8s",
+        provider_api=provider_api,
+        template_id="tpl-1",
+        requested_count=1,
+        provider_data=pd,
+    )
+
+
+def _pod_list() -> SimpleNamespace:
+    return SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                metadata=SimpleNamespace(
+                    name="pod-1", namespace="ns", labels={"orb.io/request-id": "req-x"}
+                ),
+                spec=SimpleNamespace(node_name="node-1"),
+                status=SimpleNamespace(
+                    phase="Running",
+                    pod_ip="10.0.0.1",
+                    host_ip="10.1.0.1",
+                    start_time=None,
+                    conditions=[SimpleNamespace(type="Ready", status="True", reason=None)],
+                    container_statuses=[],
+                ),
+            )
+        ]
+    )
+
+
+def _make_client() -> Any:
+    core_v1 = MagicMock()
+    apps_v1 = MagicMock()
+    batch_v1 = MagicMock()
+    client = MagicMock()
+    client.core_v1 = core_v1
+    client.apps_v1 = apps_v1
+    client.batch_v1 = batch_v1
+    return client
+
+
+def _config() -> K8sProviderConfig:
+    # TTL 0 disables the controller cache so the read GET always fires.
+    return K8sProviderConfig(namespace="ns", controller_status_cache_ttl_seconds=0.0)
+
+
+# Retry tuning passed to every handler so failing calls exhaust the budget
+# quickly (no backoff sleeps) during the error-path tests.
+_RETRY_KW: dict[str, Any] = {"max_retries": 1, "base_delay": 0.0, "max_delay": 0.0}
+
+
+@pytest.fixture(autouse=True)
+def _register_k8s_classifier():
+    from orb.infrastructure.resilience.retry_classifier_registry import (
+        clear_classifiers,
+        register_retry_classifier,
+    )
+    from orb.providers.k8s.resilience.retry_classifier import K8sRetryClassifier
+
+    register_retry_classifier(K8sRetryClassifier())
+    yield
+    clear_classifiers()
+
+
+# ---------------------------------------------------------------------------
+# Pod resolver
+# ---------------------------------------------------------------------------
+
+
+def test_pod_status_records_latency_on_success() -> None:
+    from orb.providers.k8s.infrastructure.handlers.pod_handler import K8sPodHandler
+
+    client = _make_client()
+    client.core_v1.list_namespaced_pod.return_value = _pod_list()
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = K8sPodHandler(
+        kubernetes_client=client,
+        config=_config(),
+        logger=MagicMock(),
+        metrics=metrics,
+        **_RETRY_KW,
+    )
+
+    handler.check_hosts_status(_req(provider_api="Pod"))
+
+    ops = [c.kwargs.get("operation") for c in metrics.record_apiserver_latency.call_args_list]
+    assert "list_namespaced_pod" in ops
+    metrics.record_api_error.assert_not_called()
+
+
+def test_pod_status_records_error_on_list_failure() -> None:
+    from orb.providers.k8s.infrastructure.handlers.pod_handler import K8sPodHandler
+
+    client = _make_client()
+    client.core_v1.list_namespaced_pod.side_effect = ApiException(status=500, reason="boom")
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = K8sPodHandler(
+        kubernetes_client=client,
+        config=_config(),
+        logger=MagicMock(),
+        metrics=metrics,
+        **_RETRY_KW,
+    )
+
+    result = handler.check_hosts_status(_req(provider_api="Pod"))
+
+    # Resolver swallows and returns in_progress, but the error must be recorded.
+    assert result.fulfilment.state == "in_progress"
+    metrics.record_api_error.assert_any_call(operation="list_namespaced_pod", error_code="500")
+    # Latency still recorded (timed context exits on exception).
+    ops = [c.kwargs.get("operation") for c in metrics.record_apiserver_latency.call_args_list]
+    assert "list_namespaced_pod" in ops
+
+
+# ---------------------------------------------------------------------------
+# Deployment resolver
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_status_records_error_on_read_failure() -> None:
+    from orb.providers.k8s.infrastructure.handlers.deployment_handler import K8sDeploymentHandler
+
+    client = _make_client()
+    client.core_v1.list_namespaced_pod.return_value = _pod_list()
+    client.apps_v1.read_namespaced_deployment.side_effect = ApiException(
+        status=503, reason="unavailable"
+    )
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = K8sDeploymentHandler(
+        kubernetes_client=client,
+        config=_config(),
+        logger=MagicMock(),
+        metrics=metrics,
+        **_RETRY_KW,
+    )
+
+    handler.check_hosts_status(_req(provider_api="Deployment"))
+
+    metrics.record_api_error.assert_any_call(
+        operation="read_namespaced_deployment", error_code="503"
+    )
+    ops = [c.kwargs.get("operation") for c in metrics.record_apiserver_latency.call_args_list]
+    assert "read_namespaced_deployment" in ops
+
+
+def test_deployment_status_404_read_does_not_record_error() -> None:
+    from orb.providers.k8s.infrastructure.handlers.deployment_handler import K8sDeploymentHandler
+
+    client = _make_client()
+    client.core_v1.list_namespaced_pod.return_value = _pod_list()
+    client.apps_v1.read_namespaced_deployment.side_effect = ApiException(
+        status=404, reason="not found"
+    )
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = K8sDeploymentHandler(
+        kubernetes_client=client,
+        config=_config(),
+        logger=MagicMock(),
+        metrics=metrics,
+        **_RETRY_KW,
+    )
+
+    handler.check_hosts_status(_req(provider_api="Deployment"))
+
+    # 404 on read is a normal pre-create / post-release signal, not an error.
+    for call in metrics.record_api_error.call_args_list:
+        assert call.kwargs.get("operation") != "read_namespaced_deployment"
+
+
+# ---------------------------------------------------------------------------
+# StatefulSet resolver
+# ---------------------------------------------------------------------------
+
+
+def test_statefulset_status_records_error_on_read_failure() -> None:
+    from orb.providers.k8s.infrastructure.handlers.statefulset_handler import K8sStatefulSetHandler
+
+    client = _make_client()
+    client.core_v1.list_namespaced_pod.return_value = _pod_list()
+    client.apps_v1.read_namespaced_stateful_set.side_effect = ApiException(
+        status=500, reason="boom"
+    )
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = K8sStatefulSetHandler(
+        kubernetes_client=client,
+        config=_config(),
+        logger=MagicMock(),
+        metrics=metrics,
+        **_RETRY_KW,
+    )
+
+    handler.check_hosts_status(_req(provider_api="StatefulSet"))
+
+    metrics.record_api_error.assert_any_call(
+        operation="read_namespaced_stateful_set", error_code="500"
+    )
+    ops = [c.kwargs.get("operation") for c in metrics.record_apiserver_latency.call_args_list]
+    assert "read_namespaced_stateful_set" in ops
+
+
+# ---------------------------------------------------------------------------
+# Job resolver
+# ---------------------------------------------------------------------------
+
+
+def test_job_status_records_error_on_read_failure() -> None:
+    from orb.providers.k8s.infrastructure.handlers.job_handler import K8sJobHandler
+
+    client = _make_client()
+    client.core_v1.list_namespaced_pod.return_value = _pod_list()
+    client.batch_v1.read_namespaced_job.side_effect = ApiException(status=500, reason="boom")
+    metrics = MagicMock(spec=K8sMetrics)
+    handler = K8sJobHandler(
+        kubernetes_client=client,
+        config=_config(),
+        logger=MagicMock(),
+        metrics=metrics,
+        **_RETRY_KW,
+    )
+
+    handler.check_hosts_status(_req(provider_api="Job"))
+
+    metrics.record_api_error.assert_any_call(operation="read_namespaced_job", error_code="500")
+    ops = [c.kwargs.get("operation") for c in metrics.record_apiserver_latency.call_args_list]
+    assert "read_namespaced_job" in ops

--- a/tests/providers/k8s/unit/infrastructure/test_k8s_client.py
+++ b/tests/providers/k8s/unit/infrastructure/test_k8s_client.py
@@ -52,6 +52,8 @@ def test_load_config_with_valid_kubeconfig(tmp_path: pytest.TempPathFactory) -> 
         config_file=cfg.kubeconfig_path,
         context=cfg.context,
         logger=client._logger,
+        proxy_url=cfg.proxy_url,
+        no_proxy=cfg.no_proxy,
     )
 
 

--- a/tests/providers/k8s/unit/strategy/test_handler_registry_resilience_wiring.py
+++ b/tests/providers/k8s/unit/strategy/test_handler_registry_resilience_wiring.py
@@ -1,0 +1,154 @@
+"""Unit tests for K8sHandlerRegistry resilience-knob threading.
+
+Proves that the circuit-breaker and retry knobs declared on
+:class:`K8sProviderConfig` (``circuit_breaker_failure_threshold``,
+``circuit_breaker_reset_timeout``, ``max_retries``, ``retry_base_delay``,
+``retry_max_delay``) are threaded through
+:meth:`K8sHandlerRegistry.get_handler` into the constructed handler so the
+handler's ``with_retry`` layer actually uses the configured values rather than
+the K8sHandlerBase hardcoded defaults.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from orb.infrastructure.resilience import MaxRetriesExceededError
+from orb.providers.k8s.configuration.config import K8sProviderConfig
+from orb.providers.k8s.strategy.handler_registry import K8sHandlerRegistry
+
+
+def _make_registry(
+    config: K8sProviderConfig,
+    *,
+    plugin_factories: dict[str, Any] | None = None,
+) -> K8sHandlerRegistry:
+    """Build a registry with a configured value; no cluster wiring needed."""
+    return K8sHandlerRegistry(
+        config=config,
+        logger=MagicMock(),
+        client_provider=MagicMock,
+        watch_manager_provider=lambda: None,
+        plugin_factories=lambda: dict(plugin_factories or {}),
+        native_spec_service_provider=lambda: None,
+    )
+
+
+class TestResilienceKnobThreading:
+    """Configured knobs must reach the built-in handler constructors."""
+
+    def test_configured_failure_threshold_reaches_handler(self) -> None:
+        config = K8sProviderConfig(circuit_breaker_failure_threshold=11)  # type: ignore[call-arg]
+        registry = _make_registry(config)
+
+        handler = registry.get_handler("Pod")
+
+        assert handler._cb_failure_threshold == 11
+
+    def test_all_five_knobs_reach_handler(self) -> None:
+        config = K8sProviderConfig(  # type: ignore[call-arg]
+            circuit_breaker_failure_threshold=7,
+            circuit_breaker_reset_timeout=99,
+            max_retries=9,
+            retry_base_delay=2.5,
+            retry_max_delay=45.0,
+        )
+        registry = _make_registry(config)
+
+        handler = registry.get_handler("Deployment")
+
+        assert handler._cb_failure_threshold == 7
+        assert handler._cb_reset_timeout == 99
+        assert handler._max_retries == 9
+        assert handler._base_delay == 2.5
+        assert handler._max_delay == 45.0
+
+    def test_defaults_preserved_when_config_unset(self) -> None:
+        """An unconfigured config yields the K8sHandlerBase defaults (no-op change)."""
+        registry = _make_registry(K8sProviderConfig())  # type: ignore[call-arg]
+
+        handler = registry.get_handler("Job")
+
+        assert handler._cb_failure_threshold == 5
+        assert handler._cb_reset_timeout == 60
+        assert handler._max_retries == 3
+        assert handler._base_delay == 1.0
+        assert handler._max_delay == 30.0
+
+    def test_knobs_feed_the_retry_decorator(self) -> None:
+        """The configured max_retries must reach the ``with_retry`` budget.
+
+        Drives ``with_retry`` against an always-failing recoverable operation
+        and asserts the operation is invoked ``max_retries + 1`` times (initial
+        attempt plus the configured retries), proving the config value flows all
+        the way into the retry decorator rather than the hardcoded default of 3.
+        """
+        from orb.infrastructure.resilience.strategy.circuit_breaker import (
+            CircuitBreakerStrategy,
+        )
+
+        # The circuit-breaker state is class-level and keyed by service name
+        # ("kubernetes.pod").  Clear it so accumulated failures from other tests
+        # in the session cannot pre-open the breaker and short-circuit the
+        # retry-budget assertion below.
+        CircuitBreakerStrategy._circuit_states.pop("kubernetes.pod", None)
+
+        config = K8sProviderConfig(  # type: ignore[call-arg]
+            max_retries=2,
+            retry_base_delay=0.01,
+            retry_max_delay=0.01,
+        )
+        registry = _make_registry(config)
+        handler = registry.get_handler("Pod")
+
+        calls = {"n": 0}
+
+        def _always_fails() -> None:
+            calls["n"] += 1
+            # 503 is a recoverable status the exponential strategy retries.
+            raise _ApiException503()
+
+        # Budget exhaustion surfaces MaxRetriesExceededError after the final
+        # attempt; the assertion below then verifies the invocation count.
+        with pytest.raises(MaxRetriesExceededError):
+            handler.with_retry(_always_fails, operation_name="unit_probe")
+
+        # initial attempt + 2 configured retries == 3 invocations
+        assert calls["n"] == 3
+
+
+class TestPluginPathThreading:
+    """Plugin-registered factories receive the same resilience knobs."""
+
+    def test_plugin_factory_receives_resilience_kwargs(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def _factory(**kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return MagicMock()
+
+        config = K8sProviderConfig(  # type: ignore[call-arg]
+            circuit_breaker_failure_threshold=13,
+            max_retries=6,
+        )
+        registry = _make_registry(config, plugin_factories={"Custom": _factory})
+
+        registry.get_handler("Custom")
+
+        assert captured["circuit_breaker_failure_threshold"] == 13
+        assert captured["max_retries"] == 6
+        assert captured["circuit_breaker_reset_timeout"] == 60
+        assert captured["base_delay"] == 1.0
+        assert captured["max_delay"] == 30.0
+
+
+class _ApiException503(Exception):
+    """Minimal stand-in carrying a 503 ``status`` for retry classification."""
+
+    status = 503
+
+    def __init__(self) -> None:
+        super().__init__("service unavailable")

--- a/tests/providers/k8s/unit/strategy/test_lifecycle_services.py
+++ b/tests/providers/k8s/unit/strategy/test_lifecycle_services.py
@@ -1,0 +1,345 @@
+"""Unit tests for the extracted k8s strategy lifecycle services.
+
+These cover the cohesive service classes carved out of the
+``K8sProviderStrategy`` god-class:
+
+* :class:`K8sWatchManagerLifecycle` — watch fan-out + metrics + shutdown
+* :class:`K8sReconciliationLifecycle` — startup reconciler + orphan GC
+* :class:`K8sNodeWatchLifecycle` — node watcher + events watcher
+* :class:`K8sNativeSpecResolver` — native-spec DI resolution
+
+They exercise the services directly (not through the strategy shell) so a
+regression in an extracted unit is pinned to that unit.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orb.providers.k8s.configuration.config import K8sProviderConfig
+from orb.providers.k8s.strategy.native_spec_resolver import K8sNativeSpecResolver
+from orb.providers.k8s.strategy.node_watch_lifecycle import K8sNodeWatchLifecycle
+from orb.providers.k8s.strategy.reconciliation_lifecycle import K8sReconciliationLifecycle
+from orb.providers.k8s.strategy.watch_lifecycle import K8sWatchManagerLifecycle
+
+
+def _config(**kwargs: Any) -> K8sProviderConfig:
+    return K8sProviderConfig(**kwargs)
+
+
+# ===========================================================================
+# K8sWatchManagerLifecycle
+# ===========================================================================
+
+
+class TestWatchManagerLifecycle:
+    def test_ensure_is_lazy_and_cached(self) -> None:
+        injected = MagicMock()
+        svc = K8sWatchManagerLifecycle(
+            config=_config(),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            watch_manager=injected,
+        )
+        # Pre-injected manager is returned without construction.
+        assert svc.ensure() is injected
+        assert svc.watch_manager is injected
+
+    def test_shared_cache_comes_from_watch_manager(self) -> None:
+        injected = MagicMock()
+        svc = K8sWatchManagerLifecycle(
+            config=_config(),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            watch_manager=injected,
+        )
+        assert svc.shared_cache() is injected.cache
+
+    def test_get_metrics_returns_none_when_disabled(self) -> None:
+        svc = K8sWatchManagerLifecycle(
+            config=_config(metrics_enabled=False),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+        )
+        assert svc.get_metrics() is None
+
+    def test_maybe_start_noop_when_watch_disabled(self) -> None:
+        svc = K8sWatchManagerLifecycle(
+            config=_config(watch_enabled=False),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+        )
+        svc.maybe_start()
+        # Nothing constructed / started.
+        assert svc.watch_manager is None
+
+    def test_maybe_start_skips_without_running_loop(self) -> None:
+        manager = MagicMock()
+        svc = K8sWatchManagerLifecycle(
+            config=_config(watch_enabled=True),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            watch_manager=manager,
+        )
+        # No running loop in this synchronous context → start is skipped.
+        svc.maybe_start()
+        manager.start.assert_not_called()
+
+    def test_stop_sync_noop_when_not_started(self) -> None:
+        manager = MagicMock()
+        manager.is_started.return_value = False
+        svc = K8sWatchManagerLifecycle(
+            config=_config(),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            watch_manager=manager,
+        )
+        # Should not attempt to drive stop().
+        svc.stop_sync()
+        manager.stop.assert_not_called()
+
+    def test_stop_sync_no_loop_runs_synchronously(self) -> None:
+        completed = {"n": 0}
+
+        async def _stop() -> None:
+            completed["n"] += 1
+
+        manager = MagicMock()
+        manager.is_started.return_value = True
+        manager.stop = AsyncMock(side_effect=_stop)
+        svc = K8sWatchManagerLifecycle(
+            config=_config(),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            watch_manager=manager,
+        )
+        svc.stop_sync()
+        assert completed["n"] == 1
+
+
+# ===========================================================================
+# K8sReconciliationLifecycle
+# ===========================================================================
+
+
+class TestReconciliationLifecycle:
+    def _make(self, **kwargs: Any) -> tuple[K8sReconciliationLifecycle, MagicMock]:
+        watch_manager: MagicMock = kwargs.pop("watch_manager", MagicMock())
+        watch = K8sWatchManagerLifecycle(
+            config=kwargs.get("config", _config()),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            watch_manager=watch_manager,
+        )
+        svc = K8sReconciliationLifecycle(
+            config=kwargs.get("config", _config()),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            watch_lifecycle=watch,
+            known_request_ids=lambda: (),
+            startup_reconciler=kwargs.get("startup_reconciler"),
+            orphan_gc=kwargs.get("orphan_gc"),
+        )
+        return svc, watch_manager
+
+    @pytest.mark.asyncio
+    async def test_run_startup_reconciler_records_report(self) -> None:
+        report = MagicMock()
+        report.completed = True
+        reconciler = MagicMock()
+        reconciler.run_async = AsyncMock(return_value=report)
+        svc, watch_manager = self._make(startup_reconciler=reconciler)
+
+        await svc.run_startup_reconciler()
+
+        assert svc.last_reconciliation_report is report
+        # first-sync-complete is signalled on the shared watch manager.
+        watch_manager.mark_first_sync_complete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_startup_reconciler_incomplete_does_not_mark_sync(self) -> None:
+        report = MagicMock()
+        report.completed = False
+        report.error = "boom"
+        reconciler = MagicMock()
+        reconciler.run_async = AsyncMock(return_value=report)
+        svc, watch_manager = self._make(startup_reconciler=reconciler)
+
+        await svc.run_startup_reconciler()
+
+        watch_manager.mark_first_sync_complete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_startup_reconciler_swallows_exception(self) -> None:
+        reconciler = MagicMock()
+        reconciler.run_async = AsyncMock(side_effect=RuntimeError("kaboom"))
+        svc, _ = self._make(startup_reconciler=reconciler)
+        # Must not raise — provider continues.
+        await svc.run_startup_reconciler()
+
+    def test_maybe_start_orphan_gc_noop_when_disabled(self) -> None:
+        gc = MagicMock()
+        svc, _ = self._make(config=_config(orphan_gc_enabled=False), orphan_gc=gc)
+        svc.maybe_start_orphan_gc()
+        gc.start.assert_not_called()
+
+    def test_maybe_start_orphan_gc_skips_without_loop(self) -> None:
+        gc = MagicMock()
+        svc, _ = self._make(config=_config(orphan_gc_enabled=True), orphan_gc=gc)
+        # No running loop → GC start skipped.
+        svc.maybe_start_orphan_gc()
+        gc.start.assert_not_called()
+
+    def test_stop_orphan_gc_sync_noop_when_not_running(self) -> None:
+        gc = MagicMock()
+        gc.is_running.return_value = False
+        svc, _ = self._make(orphan_gc=gc)
+        svc.stop_orphan_gc_sync()
+        gc.stop.assert_not_called()
+
+    def test_stop_orphan_gc_sync_no_loop_runs_synchronously(self) -> None:
+        completed = {"n": 0}
+
+        async def _stop() -> None:
+            completed["n"] += 1
+
+        gc = MagicMock()
+        gc.is_running.return_value = True
+        gc.stop = AsyncMock(side_effect=_stop)
+        svc, _ = self._make(orphan_gc=gc)
+        svc.stop_orphan_gc_sync()
+        assert completed["n"] == 1
+
+
+# ===========================================================================
+# K8sNodeWatchLifecycle
+# ===========================================================================
+
+
+class TestNodeWatchLifecycle:
+    def test_caches_always_present(self) -> None:
+        svc = K8sNodeWatchLifecycle(
+            config=_config(),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+        )
+        assert svc.node_state_cache is not None
+        assert svc.node_events_cache is not None
+
+    def test_maybe_start_node_watcher_noop_when_disabled(self) -> None:
+        watcher = MagicMock()
+        svc = K8sNodeWatchLifecycle(
+            config=_config(node_watch_enabled=False),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            node_watcher=watcher,
+        )
+        svc.maybe_start_node_watcher()
+        watcher.start.assert_not_called()
+
+    def test_maybe_start_node_watcher_starts_when_enabled(self) -> None:
+        watcher = MagicMock()
+        svc = K8sNodeWatchLifecycle(
+            config=_config(node_watch_enabled=True),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            node_watcher=watcher,
+        )
+        svc.maybe_start_node_watcher()
+        watcher.start.assert_called_once()
+
+    def test_maybe_start_events_watcher_noop_when_disabled(self) -> None:
+        watcher = MagicMock()
+        svc = K8sNodeWatchLifecycle(
+            config=_config(events_watch_enabled=False),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            events_watcher=watcher,
+        )
+        svc.maybe_start_events_watcher()
+        watcher.start.assert_not_called()
+
+    def test_maybe_start_events_watcher_starts_when_enabled(self) -> None:
+        watcher = MagicMock()
+        svc = K8sNodeWatchLifecycle(
+            config=_config(events_watch_enabled=True),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            events_watcher=watcher,
+        )
+        svc.maybe_start_events_watcher()
+        watcher.start.assert_called_once()
+
+    def test_stop_node_watcher_clears_reference(self) -> None:
+        watcher = MagicMock()
+        svc = K8sNodeWatchLifecycle(
+            config=_config(),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            node_watcher=watcher,
+        )
+        svc.stop_node_watcher()
+        watcher.stop.assert_called_once()
+        assert svc.node_watcher is None
+
+    def test_stop_events_watcher_clears_reference(self) -> None:
+        watcher = MagicMock()
+        svc = K8sNodeWatchLifecycle(
+            config=_config(),
+            logger=MagicMock(),
+            client_provider=MagicMock,
+            events_watcher=watcher,
+        )
+        svc.stop_events_watcher()
+        watcher.stop.assert_called_once()
+        assert svc.events_watcher is None
+
+
+# ===========================================================================
+# K8sNativeSpecResolver
+# ===========================================================================
+
+
+class TestNativeSpecResolver:
+    def test_returns_none_when_disabled(self) -> None:
+        resolver = K8sNativeSpecResolver(
+            config=_config(native_spec_enabled=False),
+            logger=MagicMock(),
+            config_port=MagicMock(),
+            injected_native_spec_service=MagicMock(),
+        )
+        assert resolver.resolve() is None
+
+    def test_returns_none_when_no_config_port(self) -> None:
+        resolver = K8sNativeSpecResolver(
+            config=_config(native_spec_enabled=True),
+            logger=MagicMock(),
+            config_port=None,
+            injected_native_spec_service=MagicMock(),
+        )
+        assert resolver.resolve() is None
+
+    def test_returns_none_when_no_injected_service(self) -> None:
+        resolver = K8sNativeSpecResolver(
+            config=_config(native_spec_enabled=True),
+            logger=MagicMock(),
+            config_port=MagicMock(),
+            injected_native_spec_service=None,
+        )
+        assert resolver.resolve() is None
+
+    def test_resolution_is_cached(self) -> None:
+        # Disabled config short-circuits, but the resolved flag must be
+        # sticky so a second call does not re-run the gating logic.
+        resolver = K8sNativeSpecResolver(
+            config=_config(native_spec_enabled=False),
+            logger=MagicMock(),
+            config_port=MagicMock(),
+            injected_native_spec_service=MagicMock(),
+        )
+        first = resolver.resolve()
+        second = resolver.resolve()
+        assert first is second is None

--- a/tests/providers/k8s/unit/test_auth_proxy_config.py
+++ b/tests/providers/k8s/unit/test_auth_proxy_config.py
@@ -1,0 +1,495 @@
+"""Unit tests for HTTP proxy support driven by :class:`K8sProviderConfig`.
+
+These complement ``test_auth.py`` (which covers the env-var-only proxy path)
+by exercising the config-supplied ``proxy_url`` / ``no_proxy`` fields and the
+precedence rule that an explicit provider config value wins over ambient
+environment variables.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from orb.providers.k8s.configuration.config import K8sProviderConfig
+from orb.providers.k8s.exceptions.k8s_exceptions import K8sAuthError
+
+# ---------------------------------------------------------------------------
+# Fake kubernetes module helpers
+# ---------------------------------------------------------------------------
+
+
+def _register_fake_kubernetes(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    incluster: bool = False,
+) -> MagicMock:
+    """Register a fake kubernetes module and return the config spy instance.
+
+    Returns the ``fake_configuration_instance`` that
+    ``Configuration.get_default_copy`` will return so tests can assert
+    ``proxy`` / ``no_proxy`` fields.
+    """
+    fake_cfg_instance = MagicMock()
+    fake_cfg_instance.proxy = None
+    fake_cfg_instance.no_proxy = None
+
+    fake_configuration_cls = MagicMock()
+    fake_configuration_cls.get_default_copy.return_value = fake_cfg_instance
+    fake_configuration_cls.set_default = MagicMock()
+
+    fake_client = SimpleNamespace(Configuration=fake_configuration_cls)
+    if incluster:
+        fake_config_mod = SimpleNamespace(load_incluster_config=MagicMock())
+    else:
+        fake_config_mod = SimpleNamespace(load_kube_config=MagicMock())
+    fake_kubernetes = SimpleNamespace(config=fake_config_mod, client=fake_client)
+
+    monkeypatch.setitem(sys.modules, "kubernetes", fake_kubernetes)
+    monkeypatch.setitem(sys.modules, "kubernetes.config", fake_config_mod)
+    monkeypatch.setitem(sys.modules, "kubernetes.client", fake_client)
+
+    return fake_cfg_instance
+
+
+def _clear_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_proxy_url / _resolve_no_proxy — config precedence (kubeconfig)
+# ---------------------------------------------------------------------------
+
+
+def test_kubeconfig_resolve_proxy_url_config_wins_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A config proxy_url takes precedence over HTTPS_PROXY."""
+    from orb.providers.k8s.auth.kubeconfig import _resolve_proxy_url
+
+    monkeypatch.setenv("HTTPS_PROXY", "https://env-proxy:3128")
+    assert _resolve_proxy_url("https://config-proxy:9000") == "https://config-proxy:9000"
+
+
+def test_kubeconfig_resolve_proxy_url_falls_back_to_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no config value is supplied, the env var is used."""
+    from orb.providers.k8s.auth.kubeconfig import _resolve_proxy_url
+
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "https://env-proxy:3128")
+    assert _resolve_proxy_url(None) == "https://env-proxy:3128"
+
+
+def test_kubeconfig_resolve_proxy_url_blank_config_falls_back_to_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whitespace-only config value must not shadow the env var."""
+    from orb.providers.k8s.auth.kubeconfig import _resolve_proxy_url
+
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("HTTP_PROXY", "http://env-proxy:8080")
+    assert _resolve_proxy_url("   ") == "http://env-proxy:8080"
+
+
+def test_kubeconfig_resolve_no_proxy_config_wins_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A config no_proxy takes precedence over NO_PROXY."""
+    from orb.providers.k8s.auth.kubeconfig import _resolve_no_proxy
+
+    monkeypatch.setenv("NO_PROXY", "env.internal")
+    assert _resolve_no_proxy("config.internal,.cluster.local") == "config.internal,.cluster.local"
+
+
+# ---------------------------------------------------------------------------
+# _apply_proxy_to_default_configuration — config precedence (kubeconfig)
+# ---------------------------------------------------------------------------
+
+
+def test_kubeconfig_apply_uses_config_proxy_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Config proxy_url is written to Configuration.proxy over the env var."""
+    monkeypatch.setenv("HTTPS_PROXY", "https://env-proxy:3128")
+    fake_cfg = _register_fake_kubernetes(monkeypatch)
+
+    from orb.providers.k8s.auth.kubeconfig import _apply_proxy_to_default_configuration
+
+    _apply_proxy_to_default_configuration(None, "https://config-proxy:9000", None)
+
+    assert fake_cfg.proxy == "https://config-proxy:9000"
+
+
+def test_kubeconfig_apply_uses_config_no_proxy_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Config no_proxy is written to Configuration.no_proxy over the env var."""
+    monkeypatch.setenv("NO_PROXY", "env.internal")
+    fake_cfg = _register_fake_kubernetes(monkeypatch)
+
+    from orb.providers.k8s.auth.kubeconfig import _apply_proxy_to_default_configuration
+
+    _apply_proxy_to_default_configuration(None, None, "config.internal")
+
+    assert fake_cfg.no_proxy == "config.internal"
+
+
+def test_kubeconfig_apply_config_proxy_when_no_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Config proxy_url is applied even when no env vars are present."""
+    _clear_proxy_env(monkeypatch)
+    fake_cfg = _register_fake_kubernetes(monkeypatch)
+
+    from orb.providers.k8s.auth.kubeconfig import _apply_proxy_to_default_configuration
+
+    _apply_proxy_to_default_configuration(None, "https://config-proxy:9000", None)
+
+    assert fake_cfg.proxy == "https://config-proxy:9000"
+
+
+# ---------------------------------------------------------------------------
+# load_kubeconfig forwards config values
+# ---------------------------------------------------------------------------
+
+
+def test_load_kubeconfig_forwards_config_proxy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """load_kubeconfig wires the supplied proxy_url/no_proxy into Configuration."""
+    _clear_proxy_env(monkeypatch)
+    kube_file = tmp_path / "config"
+    kube_file.write_text("apiVersion: v1\nkind: Config\n", encoding="utf-8")
+
+    fake_cfg = _register_fake_kubernetes(monkeypatch)
+
+    from orb.providers.k8s.auth.kubeconfig import load_kubeconfig
+
+    load_kubeconfig(
+        config_file=str(kube_file),
+        proxy_url="https://config-proxy:9000",
+        no_proxy="config.internal",
+    )
+
+    assert fake_cfg.proxy == "https://config-proxy:9000"
+    assert fake_cfg.no_proxy == "config.internal"
+
+
+# ---------------------------------------------------------------------------
+# in-cluster loader config precedence
+# ---------------------------------------------------------------------------
+
+
+def test_incluster_resolve_proxy_url_config_wins_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In-cluster resolver: config proxy_url takes precedence over env."""
+    from orb.providers.k8s.auth.in_cluster import _resolve_proxy_url
+
+    monkeypatch.setenv("HTTPS_PROXY", "https://env-proxy:3128")
+    assert _resolve_proxy_url("https://config-proxy:9000") == "https://config-proxy:9000"
+
+
+def test_incluster_apply_uses_config_proxy_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In-cluster apply: config value wins over the env var."""
+    monkeypatch.setenv("HTTPS_PROXY", "https://env-proxy:3128")
+    fake_cfg = _register_fake_kubernetes(monkeypatch, incluster=True)
+
+    from orb.providers.k8s.auth.in_cluster import _apply_proxy_to_default_configuration
+
+    _apply_proxy_to_default_configuration(None, "https://config-proxy:9000", "config.internal")
+
+    assert fake_cfg.proxy == "https://config-proxy:9000"
+    assert fake_cfg.no_proxy == "config.internal"
+
+
+def test_load_in_cluster_config_forwards_config_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """load_in_cluster_config wires the supplied proxy_url/no_proxy."""
+    _clear_proxy_env(monkeypatch)
+    fake_cfg = _register_fake_kubernetes(monkeypatch, incluster=True)
+
+    from orb.providers.k8s.auth.in_cluster import load_in_cluster_config
+
+    load_in_cluster_config(proxy_url="https://config-proxy:9000", no_proxy="config.internal")
+
+    assert fake_cfg.proxy == "https://config-proxy:9000"
+    assert fake_cfg.no_proxy == "config.internal"
+
+
+# ---------------------------------------------------------------------------
+# InClusterAuthAdapter carries proxy config through load + refresh
+# ---------------------------------------------------------------------------
+
+
+def test_incluster_adapter_carries_proxy_on_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adapter.load() forwards its stored proxy_url/no_proxy to the loader."""
+    from orb.providers.k8s.auth import in_cluster as in_cluster_mod
+    from orb.providers.k8s.auth.in_cluster import InClusterAuthAdapter
+
+    captured: dict[str, object] = {}
+
+    def _fake_loader(logger=None, proxy_url=None, no_proxy=None):  # type: ignore[no-untyped-def]
+        captured["proxy_url"] = proxy_url
+        captured["no_proxy"] = no_proxy
+
+    monkeypatch.setattr(in_cluster_mod, "load_in_cluster_config", _fake_loader)
+
+    adapter = InClusterAuthAdapter(
+        proxy_url="https://config-proxy:9000",
+        no_proxy="config.internal",
+    )
+    adapter.load()
+
+    assert captured == {"proxy_url": "https://config-proxy:9000", "no_proxy": "config.internal"}
+
+
+def test_incluster_adapter_carries_proxy_on_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale refresh re-applies the stored proxy settings."""
+    from orb.providers.k8s.auth import in_cluster as in_cluster_mod
+    from orb.providers.k8s.auth.in_cluster import InClusterAuthAdapter
+
+    calls: list[dict[str, object]] = []
+
+    def _fake_loader(logger=None, proxy_url=None, no_proxy=None):  # type: ignore[no-untyped-def]
+        calls.append({"proxy_url": proxy_url, "no_proxy": no_proxy})
+
+    monkeypatch.setattr(in_cluster_mod, "load_in_cluster_config", _fake_loader)
+
+    adapter = InClusterAuthAdapter(
+        token_refresh_seconds=0,  # force staleness immediately
+        proxy_url="https://config-proxy:9000",
+        no_proxy="config.internal",
+    )
+    adapter.load()
+    refreshed = adapter.refresh_if_stale()
+
+    assert refreshed is True
+    # Both the initial load and the refresh must carry the proxy config.
+    assert len(calls) == 2
+    assert all(
+        c == {"proxy_url": "https://config-proxy:9000", "no_proxy": "config.internal"}
+        for c in calls
+    )
+
+
+# ---------------------------------------------------------------------------
+# K8sClient wires config proxy into the adapter and loaders
+# ---------------------------------------------------------------------------
+
+
+def test_k8s_client_adapter_receives_config_proxy() -> None:
+    """K8sClient constructs its in-cluster adapter with the config proxy fields."""
+    from orb.providers.k8s.infrastructure.k8s_client import K8sClient
+
+    cfg = K8sProviderConfig(  # type: ignore[call-arg]
+        proxy_url="https://config-proxy:9000",
+        no_proxy="config.internal",
+    )
+    client = K8sClient(config=cfg, logger=MagicMock())
+
+    adapter = client._in_cluster_adapter
+    assert adapter is not None
+    assert adapter._proxy_url == "https://config-proxy:9000"
+    assert adapter._no_proxy == "config.internal"
+
+
+def test_k8s_client_load_config_forwards_proxy_to_kubeconfig(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """load_config (kubeconfig branch) forwards config proxy fields."""
+    from unittest.mock import patch
+
+    from orb.providers.k8s.infrastructure.k8s_client import K8sClient
+
+    kube_file = tmp_path / "kubeconfig"
+    kube_file.write_text("# stub", encoding="utf-8")
+    cfg = K8sProviderConfig(  # type: ignore[call-arg]
+        in_cluster=False,
+        kubeconfig_path=str(kube_file),
+        proxy_url="https://config-proxy:9000",
+        no_proxy="config.internal",
+    )
+    client = K8sClient(config=cfg, logger=MagicMock())
+
+    with patch("orb.providers.k8s.infrastructure.k8s_client.load_kubeconfig") as mock_lkc:
+        client.load_config()
+
+    mock_lkc.assert_called_once_with(
+        config_file=cfg.kubeconfig_path,
+        context=cfg.context,
+        logger=client._logger,
+        proxy_url="https://config-proxy:9000",
+        no_proxy="config.internal",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config field validation
+# ---------------------------------------------------------------------------
+
+
+def test_config_proxy_url_defaults_to_none() -> None:
+    cfg = K8sProviderConfig()  # type: ignore[call-arg]
+    assert cfg.proxy_url is None
+    assert cfg.no_proxy is None
+
+
+def test_config_proxy_url_accepts_valid_url() -> None:
+    cfg = K8sProviderConfig(proxy_url="http://proxy.corp.example:3128")  # type: ignore[call-arg]
+    assert cfg.proxy_url == "http://proxy.corp.example:3128"
+
+
+def test_config_proxy_url_strips_whitespace() -> None:
+    cfg = K8sProviderConfig(proxy_url="  https://proxy:3128  ")  # type: ignore[call-arg]
+    assert cfg.proxy_url == "https://proxy:3128"
+
+
+def test_config_proxy_url_rejects_blank() -> None:
+    with pytest.raises(ValueError, match="proxy_url must be a non-empty URL"):
+        K8sProviderConfig(proxy_url="   ")  # type: ignore[call-arg]
+
+
+def test_config_proxy_url_rejects_missing_scheme() -> None:
+    with pytest.raises(ValueError, match="not a valid proxy URL"):
+        K8sProviderConfig(proxy_url="proxy.corp.example:3128")  # type: ignore[call-arg]
+
+
+def test_config_proxy_url_rejects_non_http_scheme() -> None:
+    with pytest.raises(ValueError, match="not a valid proxy URL"):
+        K8sProviderConfig(proxy_url="socks5://proxy:1080")  # type: ignore[call-arg]
+
+
+def test_config_proxy_url_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ORB_K8S_PROXY_URL env var populates the field via BaseSettings."""
+    monkeypatch.setenv("ORB_K8S_PROXY_URL", "https://env-config-proxy:3128")
+    cfg = K8sProviderConfig()  # type: ignore[call-arg]
+    assert cfg.proxy_url == "https://env-config-proxy:3128"
+
+
+def test_load_in_cluster_config_wraps_errors_with_proxy_args(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SDK failure is still wrapped in K8sAuthError with proxy args supplied."""
+    fake_config = SimpleNamespace(load_incluster_config=MagicMock(side_effect=RuntimeError("boom")))
+    fake_kubernetes = SimpleNamespace(config=fake_config)
+    monkeypatch.setitem(sys.modules, "kubernetes", fake_kubernetes)
+    monkeypatch.setitem(sys.modules, "kubernetes.config", fake_config)
+
+    from orb.providers.k8s.auth.in_cluster import load_in_cluster_config
+
+    with pytest.raises(K8sAuthError, match="boom"):
+        load_in_cluster_config(proxy_url="https://config-proxy:9000")
+
+
+# ---------------------------------------------------------------------------
+# _redact_proxy_url — userinfo credentials must never be logged verbatim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "orb.providers.k8s.auth.in_cluster",
+        "orb.providers.k8s.auth.kubeconfig",
+    ],
+)
+def test_redact_proxy_url_redacts_scheme_and_credentials(module_name: str) -> None:
+    """A standard ``scheme://user:pass@host`` value is redacted, host kept."""
+    import importlib
+
+    module = importlib.import_module(module_name)
+    redacted = module._redact_proxy_url("https://user:s3cret@proxy.corp:3128")
+
+    assert "s3cret" not in redacted
+    assert "user" not in redacted
+    assert "proxy.corp:3128" in redacted
+    assert "***@proxy.corp:3128" in redacted
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "orb.providers.k8s.auth.in_cluster",
+        "orb.providers.k8s.auth.kubeconfig",
+    ],
+)
+def test_redact_proxy_url_redacts_schemeless_credentials(module_name: str) -> None:
+    """A scheme-less ``user:pass@host`` value must still be redacted.
+
+    ``urllib.parse.urlparse`` leaves ``username``/``password`` unset when no
+    scheme is present, so the naive check would log the raw credentials.  The
+    fallback userinfo detection must catch this case.
+    """
+    import importlib
+
+    module = importlib.import_module(module_name)
+    redacted = module._redact_proxy_url("user:s3cret@proxy.corp:3128")
+
+    assert "s3cret" not in redacted
+    assert "***@proxy.corp:3128" in redacted
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "orb.providers.k8s.auth.in_cluster",
+        "orb.providers.k8s.auth.kubeconfig",
+    ],
+)
+def test_redact_proxy_url_leaves_credentialless_url_untouched(module_name: str) -> None:
+    """A URL without userinfo is returned unchanged (nothing to redact)."""
+    import importlib
+
+    module = importlib.import_module(module_name)
+    assert module._redact_proxy_url("https://proxy.corp:3128") == "https://proxy.corp:3128"
+    assert module._redact_proxy_url("proxy.corp:3128") == "proxy.corp:3128"
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "orb.providers.k8s.auth.in_cluster",
+        "orb.providers.k8s.auth.kubeconfig",
+    ],
+)
+def test_apply_proxy_debug_log_redacts_schemeless_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+) -> None:
+    """The DEBUG log emitted on proxy wiring must not contain credentials.
+
+    Exercises the full ``_apply_proxy_to_default_configuration`` path with a
+    scheme-less credentialed proxy so the assertion covers what is actually
+    written to the log, not just the helper in isolation.
+    """
+    import importlib
+
+    _clear_proxy_env(monkeypatch)
+    incluster = module_name.endswith("in_cluster")
+    _register_fake_kubernetes(monkeypatch, incluster=incluster)
+
+    module = importlib.import_module(module_name)
+    mock_logger = MagicMock()
+
+    module._apply_proxy_to_default_configuration(mock_logger, "user:s3cret@proxy.corp:3128", None)
+
+    logged = " ".join(str(c) for c in mock_logger.debug.call_args_list)
+    assert "s3cret" not in logged
+    assert "***@proxy.corp:3128" in logged

--- a/tests/providers/k8s/unit/test_provider_strategy_logic.py
+++ b/tests/providers/k8s/unit/test_provider_strategy_logic.py
@@ -684,10 +684,12 @@ class TestRegisterHandler:
 class TestResolveNativeSpecService:
     def test_returns_cached_result_on_second_call(self) -> None:
         strategy = _make_strategy()
-        strategy._native_spec_service_resolved = True
-        strategy._k8s_native_spec_service = MagicMock()
+        resolver = strategy._native_spec_resolver
+        resolver._resolved = True
+        cached = MagicMock()
+        resolver._k8s_native_spec_service = cached
         result = strategy._resolve_native_spec_service()
-        assert result is strategy._k8s_native_spec_service
+        assert result is cached
 
     def test_returns_none_when_not_enabled(self) -> None:
         cfg = _make_config(native_spec_enabled=False)
@@ -859,7 +861,7 @@ class TestLastReconciliationReport:
     def test_stores_report(self) -> None:
         strategy = _make_strategy()
         mock_report = MagicMock()
-        strategy._last_reconciliation_report = mock_report
+        strategy._reconciliation_lifecycle._last_reconciliation_report = mock_report
         assert strategy.last_reconciliation_report is mock_report
 
 

--- a/tests/providers/k8s/unit/test_strategy_gaps.py
+++ b/tests/providers/k8s/unit/test_strategy_gaps.py
@@ -249,7 +249,7 @@ def test_run_startup_reconciler_lazy_constructs_when_none() -> None:
 
     with (
         patch(
-            "orb.providers.k8s.strategy.k8s_provider_strategy.StartupReconciler"
+            "orb.providers.k8s.strategy.reconciliation_lifecycle.StartupReconciler"
         ) as MockReconciler,
         patch.object(strategy, "_ensure_watch_manager", return_value=mock_manager),
     ):
@@ -373,7 +373,7 @@ def test_maybe_start_node_watcher_lazy_constructs_when_none() -> None:
     strategy = _make_strategy(config=_make_config(node_watch_enabled=True))
     assert strategy._node_watcher is None
 
-    with patch("orb.providers.k8s.strategy.k8s_provider_strategy.K8sNodeWatcher") as MockWatcher:
+    with patch("orb.providers.k8s.strategy.node_watch_lifecycle.K8sNodeWatcher") as MockWatcher:
         instance = MagicMock()
         instance.start = MagicMock()
         MockWatcher.return_value = instance
@@ -408,7 +408,7 @@ def test_maybe_start_events_watcher_lazy_constructs_when_none() -> None:
     strategy = _make_strategy(config=_make_config(events_watch_enabled=True))
     assert strategy._events_watcher is None
 
-    with patch("orb.providers.k8s.strategy.k8s_provider_strategy.K8sEventsWatcher") as MockWatcher:
+    with patch("orb.providers.k8s.strategy.node_watch_lifecycle.K8sEventsWatcher") as MockWatcher:
         instance = MagicMock()
         instance.start = MagicMock()
         MockWatcher.return_value = instance
@@ -493,12 +493,14 @@ def test_unregister_handler_noop_for_unknown_key() -> None:
 def test_resolve_native_spec_service_cached_after_first_call() -> None:
     """_resolve_native_spec_service() returns the cached value on second call."""
     strategy = _make_strategy()
-    strategy._native_spec_service_resolved = True
-    strategy._k8s_native_spec_service = MagicMock()
+    resolver = strategy._native_spec_resolver
+    resolver._resolved = True
+    cached = MagicMock()
+    resolver._k8s_native_spec_service = cached
 
     result = strategy._resolve_native_spec_service()
 
-    assert result is strategy._k8s_native_spec_service
+    assert result is cached
 
 
 @pytest.mark.unit

--- a/tests/providers/k8s/unit/test_strategy_stubs.py
+++ b/tests/providers/k8s/unit/test_strategy_stubs.py
@@ -538,7 +538,7 @@ def test_stop_watch_manager_blocks_until_stop_completes_from_foreign_thread() ->
     from unittest import mock
 
     with mock.patch(
-        "orb.providers.k8s.strategy.k8s_provider_strategy.asyncio.get_running_loop",
+        "orb.providers.k8s.strategy.watch_lifecycle.asyncio.get_running_loop",
         return_value=loop,
     ):
         strategy._stop_watch_manager_sync(shutdown_timeout=5.0)  # type: ignore[attr-defined]
@@ -579,6 +579,10 @@ def test_stop_watch_manager_respects_timeout_from_foreign_thread() -> None:
     strategy = _make_strategy_no_init()
     strategy._watch_manager = fake_manager  # type: ignore[attr-defined]
     strategy._logger = mock_logger  # type: ignore[attr-defined]
+    # The watch-manager shutdown logic lives in the extracted lifecycle
+    # service, which holds its own logger reference; point it at the mock
+    # so the timeout warning is captured here.
+    strategy._watch_lifecycle._logger = mock_logger  # type: ignore[attr-defined]
 
     loop_ready = threading.Event()
     loop_ref: list[asyncio.AbstractEventLoop] = []
@@ -597,7 +601,7 @@ def test_stop_watch_manager_respects_timeout_from_foreign_thread() -> None:
     from unittest import mock
 
     with mock.patch(
-        "orb.providers.k8s.strategy.k8s_provider_strategy.asyncio.get_running_loop",
+        "orb.providers.k8s.strategy.watch_lifecycle.asyncio.get_running_loop",
         return_value=loop,
     ):
         # Use a very short timeout so the test finishes quickly.
@@ -632,7 +636,7 @@ def test_stop_watch_manager_no_loop_runs_synchronously() -> None:
     from unittest import mock
 
     with mock.patch(
-        "orb.providers.k8s.strategy.k8s_provider_strategy.asyncio.get_running_loop",
+        "orb.providers.k8s.strategy.watch_lifecycle.asyncio.get_running_loop",
         side_effect=RuntimeError("no running event loop"),
     ):
         strategy._stop_watch_manager_sync()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Description

Finishes the Kubernetes → AWS provider parity work. Four independent improvements, all confined to `src/orb/providers/k8s/`:

- **Config-driven resilience**: `K8sHandlerRegistry.get_handler()` now threads the circuit-breaker failure threshold / reset timeout, max retries, and retry base/max delay from `K8sProviderConfig` into handler construction. Previously these were accepted by the handlers but never passed, so handlers always ran on hardcoded defaults. Covered for both built-in and plugin-factory construction paths.
- **HTTP proxy support**: the kubeconfig and in-cluster auth loaders now honor `proxy_url`/`no_proxy` from config (also settable via `ORB_K8S_PROXY_URL`/`ORB_K8S_NO_PROXY`), with config taking precedence over ambient env vars and falling back to env when unset. URL is validated (scheme+host) and the proxy is re-applied on in-cluster token refresh. Credentialed proxy URLs are redacted before logging.
- **Metrics completeness**: apiserver-latency timing now wraps all handler and status-resolver API calls; `api_errors`/`throttles`/`retries` counters increment from the real resilience retry/error path (previously never called); HTTP 429 auto-buckets as a throttle. The circuit-breaker state gauge is now wired into the handler retry path.
- **Strategy decomposition**: the `k8s_provider_strategy.py` god-class shrinks by extracting watch / node-watch / reconciliation lifecycle, native-spec resolution, and outcome bridging into dedicated service modules. The strategy's public interface is unchanged.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code cleanup or refactor
- [ ] Dependencies update
- [ ] CI/CD or build process changes

## Related Issues
N/A

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed

New tests cover: configured resilience knobs reaching the handler (including an end-to-end retry-budget test), proxy config-vs-env precedence + validation + refresh re-application + credential redaction, and metric counters incrementing on retry/error.

## Test Configuration
* Python version: 3.12
* OS: macOS / Linux CI
* AWS region: n/a
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Performance Impact
- [x] No significant performance impact

## Dependencies
None.

## Migration Guide
n/a — config fields are additive with safe defaults; proxy falls back to env-var behavior when unset.

## Deployment Notes
Operators can now set `proxy_url`/`no_proxy` and the resilience knobs in the k8s provider config (or via `ORB_K8S_*` env) and have them take effect.

## Reviewers
@finos/open-resource-broker-maintainers
