### PR TITLE
refactor(cli): consolidate argument schema with intent-based parent parsers

### DIFF
--- a/src/orb/cli/args.py
+++ b/src/orb/cli/args.py
@@ -42,56 +42,114 @@ except ImportError:
     HELP_FORMATTER = argparse.RawDescriptionHelpFormatter
 
 
-def add_global_arguments(parser):
-    """Add arguments that should be available on all commands."""
-    parser.add_argument(
-        "-f",
-        dest="hf_file",
-        metavar="FILE",
-        help="Input JSON file path (HostFactory compatibility)",
-    )
-    parser.add_argument(
-        "-d",
-        dest="hf_data",
-        metavar="DATA",
-        help="Input JSON data string (HostFactory compatibility)",
-    )
-    parser.add_argument(
-        "--provider-name",
-        dest="provider_name",
-        metavar="NAME",
-        help="Restrict to a specific provider instance by exact name (e.g. aws-prod)",
-    )
-    add_provider_type_arg(parser)
-    parser.add_argument(
-        "--scheduler", choices=["default", "hostfactory"], help="Override scheduler strategy"
-    )
-    parser.add_argument("--dry-run", action="store_true", help="Preview without executing")
-    parser.add_argument("--yes", "-y", action="store_true", help="Assume yes to all prompts")
-    parser.add_argument("--all", action="store_true", help="Apply to all resources")
-    parser.add_argument(
-        "--format", choices=["json", "yaml", "table", "list"], default="json", help="Output format"
-    )
-    parser.add_argument("--verbose", action="store_true", help="Verbose output")
-    parser.add_argument("--quiet", action="store_true", help="Suppress output")
-    parser.add_argument("--no-color", action="store_true", help="Disable colored output")
-    parser.add_argument(
-        "--limit",
-        type=int,
-        default=None,
-        help="Maximum number of results to return (handler-specific default applies when omitted)",
-    )
-    parser.add_argument("--offset", type=int, default=0, help="Number of results to skip")
-    parser.add_argument(
-        "--filter",
-        action="append",
-        help="Generic filter using snake_case field names: field=value, field~value, field=~regex. Can be combined with specific filters. Use multiple times for AND logic.",
-    )
+# ---------------------------------------------------------------------------
+# Parent parsers grouped by intent (open-resource-broker CLI schema refactor)
+# ---------------------------------------------------------------------------
+#
+# Every sub-parser composes the parent parsers relevant to its intent via the
+# argparse ``parents=[...]`` mechanism instead of calling a single
+# ``add_global_arguments`` boilerplate helper.  The upside is structural:
+#
+#   * A flag belongs to exactly one intent group, so its meaning is unambiguous.
+#   * argparse raises ``ArgumentError`` at *build* time if a sub-parser composes
+#     two parents that both declare the same option string — the duplicate is
+#     caught by ``build_parser()`` rather than surfacing as a parse-time crash.
+#
+# Intent groups:
+#   common_parser          — cross-cutting flags valid on every command
+#   list_parser            — read/list-shaped commands (pagination + output)
+#   write_parser           — mutating commands (--force / --yes confirmation)
+#   provider_scope_parser  — commands that select/filter a provider
+#   hf_compat_parser       — HostFactory-invoked commands needing -f/-d
+#
+# The intent parsers are intentionally FLAT (they do not inherit one another).
+# Each sub-parser composes ``common_parser`` explicitly alongside the intent
+# parsers it needs, e.g. ``parents=[common_parser, list_parser,
+# provider_scope_parser]``.  If the intent parsers themselves re-inherited
+# ``common_parser``, a command needing two of them (e.g. list + provider-scope)
+# would add ``--verbose`` twice and argparse would raise ``ArgumentError`` at
+# build time.  Keeping them flat preserves the build-time duplicate-detection
+# guarantee (a genuine collision between two composed parents still raises)
+# without the spurious diamond conflict.
 
 
-def add_force_argument(parser):
-    """Add --force argument for destructive operations."""
-    parser.add_argument("--force", action="store_true", help="Force without confirmation")
+class ParentParsers:
+    """Container for the intent-grouped parent parsers.
+
+    Built once per ``build_parser()`` call and threaded through the
+    ``add_*_actions`` helpers so every sub-parser composes the same shared
+    parent instances via ``parents=[...]``.
+    """
+
+    def __init__(self) -> None:
+        # common — cross-cutting flags on every command
+        common = argparse.ArgumentParser(add_help=False)
+        common.add_argument("--verbose", action="store_true", help="Verbose output")
+        common.add_argument("--quiet", action="store_true", help="Suppress output")
+        common.add_argument("--no-color", action="store_true", help="Disable colored output")
+        common.add_argument("--dry-run", action="store_true", help="Preview without executing")
+
+        # list — pagination + output shaping for read/list commands
+        list_ = argparse.ArgumentParser(add_help=False)
+        list_.add_argument(
+            "--format",
+            choices=["json", "yaml", "table", "list"],
+            default="json",
+            help="Output format",
+        )
+        list_.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Maximum number of results to return (handler-specific default applies when omitted)",
+        )
+        list_.add_argument("--offset", type=int, default=0, help="Number of results to skip")
+        list_.add_argument(
+            "--filter",
+            action="append",
+            help="Generic filter using snake_case field names: field=value, field~value, field=~regex. Can be combined with specific filters. Use multiple times for AND logic.",
+        )
+
+        # write — confirmation flags for mutating/destructive commands
+        write = argparse.ArgumentParser(add_help=False)
+        write.add_argument("--force", action="store_true", help="Force without confirmation")
+        write.add_argument("--yes", "-y", action="store_true", help="Assume yes to all prompts")
+
+        # provider-scope — provider selection/filter flags
+        provider_scope = argparse.ArgumentParser(add_help=False)
+        provider_scope.add_argument(
+            "--provider-name",
+            dest="provider_name",
+            metavar="NAME",
+            help="Restrict to a specific provider instance by exact name (e.g. aws-prod)",
+        )
+        add_provider_type_arg(provider_scope)
+        provider_scope.add_argument(
+            "--scheduler", choices=["default", "hostfactory"], help="Override scheduler strategy"
+        )
+
+        # hf-compat — HostFactory -f/-d with distinct dests (hf_file/hf_data),
+        # applied only to HF-invoked commands so they never collide with the
+        # root parser's -f/--file (dest 'file') or subcommand-local --file.
+        hf_compat = argparse.ArgumentParser(add_help=False)
+        hf_compat.add_argument(
+            "-f",
+            dest="hf_file",
+            metavar="FILE",
+            help="Input JSON file path (HostFactory compatibility)",
+        )
+        hf_compat.add_argument(
+            "-d",
+            dest="hf_data",
+            metavar="DATA",
+            help="Input JSON data string (HostFactory compatibility)",
+        )
+
+        self.common = common
+        self.list = list_
+        self.write = write
+        self.provider_scope = provider_scope
+        self.hf_compat = hf_compat
 
 
 def add_multi_provider_arguments(parser):
@@ -99,14 +157,21 @@ def add_multi_provider_arguments(parser):
     parser.add_argument("--all-providers", action="store_true", help="Apply to all providers")
 
 
-def add_machine_actions(subparsers):
+def add_force_argument(parser):
+    """Add --force argument for destructive operations (init only)."""
+    parser.add_argument("--force", action="store_true", help="Force without confirmation")
+
+
+def add_machine_actions(subparsers, pp: "ParentParsers | None" = None):
     """Add machine actions to a subparser."""
+    if pp is None:
+        pp = ParentParsers()
     machines_list = subparsers.add_parser(
         "list",
         help="List machines",
         description="List machines with filtering support. Use specific filters (--status, --request-id) or generic filters (--filter field=value).",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
-    add_global_arguments(machines_list)
     machines_list.add_argument(
         "--status",
         choices=[s.value for s in MachineStatus],
@@ -120,15 +185,21 @@ def add_machine_actions(subparsers):
         help="Timestamp format: auto (scheduler default), unix (seconds), iso (ISO 8601)",
     )
 
-    machines_show = subparsers.add_parser("show", help="Show machine details")
-    add_global_arguments(machines_show)
+    machines_show = subparsers.add_parser(
+        "show",
+        help="Show machine details",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
     machines_show.add_argument("machine_id", nargs="?", help="Machine ID to show")
     machines_show.add_argument(
         "--machine-id", "-m", dest="flag_machine_id", help="Machine ID to show"
     )
 
-    machines_request = subparsers.add_parser("request", help="Request machines")
-    add_global_arguments(machines_request)
+    machines_request = subparsers.add_parser(
+        "request",
+        help="Request machines",
+        parents=[pp.common, pp.list, pp.provider_scope, pp.hf_compat],
+    )
     machines_request.add_argument("template_id", nargs="?", help="Template ID to use")
     machines_request.add_argument(
         "machine_count", nargs="?", type=int, help="Number of machines to request"
@@ -146,9 +217,14 @@ def add_machine_actions(subparsers):
         "--timeout", type=int, default=300, help="Wait timeout in seconds"
     )
 
-    machines_return = subparsers.add_parser("return", help="Return machines")
-    add_global_arguments(machines_return)
-    add_force_argument(machines_return)
+    machines_return = subparsers.add_parser(
+        "return",
+        help="Return machines",
+        parents=[pp.common, pp.list, pp.write, pp.provider_scope, pp.hf_compat],
+    )
+    machines_return.add_argument(
+        "--all", action="store_true", help="Return all machines for the active provider"
+    )
     machines_return.add_argument("machine_ids", nargs="*", help="Machine IDs to return")
     machines_return.add_argument(
         "--machine-id", "-m", action="append", dest="machine_ids_flag", help="Machine ID to return"
@@ -167,9 +243,14 @@ def add_machine_actions(subparsers):
     )
     machines_return.add_argument("--timeout", type=int, default=300, help="Wait timeout in seconds")
 
-    machines_terminate = subparsers.add_parser("terminate", help="Terminate (return) machines")
-    add_global_arguments(machines_terminate)
-    add_force_argument(machines_terminate)
+    machines_terminate = subparsers.add_parser(
+        "terminate",
+        help="Terminate (return) machines",
+        parents=[pp.common, pp.list, pp.write, pp.provider_scope],
+    )
+    machines_terminate.add_argument(
+        "--all", action="store_true", help="Terminate all machines for the active provider"
+    )
     machines_terminate.add_argument("machine_ids", nargs="*", help="Machine IDs to terminate")
     machines_terminate.add_argument(
         "--machine-id",
@@ -185,37 +266,56 @@ def add_machine_actions(subparsers):
         "--timeout", type=int, default=300, help="Wait timeout in seconds"
     )
 
-    machines_status = subparsers.add_parser("status", help="Check machine status")
-    add_global_arguments(machines_status)
+    machines_status = subparsers.add_parser(
+        "status",
+        help="Check machine status",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
+    machines_status.add_argument(
+        "--all", action="store_true", help="Check status of all machines for the active provider"
+    )
     machines_status.add_argument("machine_ids", nargs="*", help="Machine IDs to check")
     machines_status.add_argument(
         "--machine-id", "-m", action="append", dest="machine_ids_flag", help="Machine ID to check"
     )
 
-    machines_stop = subparsers.add_parser("stop", help="Stop running machines")
-    add_global_arguments(machines_stop)
-    add_force_argument(machines_stop)
+    machines_stop = subparsers.add_parser(
+        "stop",
+        help="Stop running machines",
+        parents=[pp.common, pp.list, pp.write, pp.provider_scope],
+    )
+    machines_stop.add_argument(
+        "--all", action="store_true", help="Stop all running machines for the active provider"
+    )
     machines_stop.add_argument("machine_ids", nargs="*", help="Machine IDs to stop")
     machines_stop.add_argument(
         "--machine-id", "-m", action="append", dest="machine_ids_flag", help="Machine ID to stop"
     )
 
-    machines_start = subparsers.add_parser("start", help="Start stopped machines")
-    add_global_arguments(machines_start)
+    machines_start = subparsers.add_parser(
+        "start",
+        help="Start stopped machines",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
+    machines_start.add_argument(
+        "--all", action="store_true", help="Start all stopped machines for the active provider"
+    )
     machines_start.add_argument("machine_ids", nargs="*", help="Machine IDs to start")
     machines_start.add_argument(
         "--machine-id", "-m", action="append", dest="machine_ids_flag", help="Machine ID to start"
     )
 
 
-def add_request_actions(subparsers):
+def add_request_actions(subparsers, pp: "ParentParsers | None" = None):
     """Add request actions to a subparser."""
+    if pp is None:
+        pp = ParentParsers()
     requests_list = subparsers.add_parser(
         "list",
         help="List requests",
         description="List requests with filtering support. Use specific filters (--status, --template-id) or generic filters (--filter field=value).",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
-    add_global_arguments(requests_list)
     requests_list.add_argument(
         "--status",
         choices=[s.value for s in RequestStatus],
@@ -228,30 +328,47 @@ def add_request_actions(subparsers):
         help="Filter by request type (specific filter)",
     )
 
-    requests_show = subparsers.add_parser("show", help="Show request details")
-    add_global_arguments(requests_show)
+    requests_show = subparsers.add_parser(
+        "show",
+        help="Show request details",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
+    requests_show.add_argument(
+        "--all", action="store_true", help="Show status for all active requests"
+    )
     requests_show.add_argument("request_id", nargs="?", help="Request ID to show")
     requests_show.add_argument(
         "--request-id", "-r", dest="flag_request_id", help="Request ID to show"
     )
 
-    requests_cancel = subparsers.add_parser("cancel", help="Cancel request")
-    add_global_arguments(requests_cancel)
-    add_force_argument(requests_cancel)
+    requests_cancel = subparsers.add_parser(
+        "cancel",
+        help="Cancel request",
+        parents=[pp.common, pp.list, pp.write, pp.provider_scope],
+    )
     requests_cancel.add_argument("request_id", nargs="?", help="Request ID to cancel")
     requests_cancel.add_argument(
         "--request-id", "-r", dest="flag_request_id", help="Request ID to cancel"
     )
 
-    requests_status = subparsers.add_parser("status", help="Check request status")
-    add_global_arguments(requests_status)
+    requests_status = subparsers.add_parser(
+        "status",
+        help="Check request status",
+        parents=[pp.common, pp.list, pp.provider_scope, pp.hf_compat],
+    )
+    requests_status.add_argument(
+        "--all", action="store_true", help="Check status of all active requests"
+    )
     requests_status.add_argument("request_ids", nargs="*", help="Request IDs to check")
     requests_status.add_argument(
         "--request-id", "-r", action="append", dest="flag_request_ids", help="Request ID to check"
     )
 
-    requests_watch = subparsers.add_parser("watch", help="Watch request status in real time")
-    add_global_arguments(requests_watch)
+    requests_watch = subparsers.add_parser(
+        "watch",
+        help="Watch request status in real time",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
     requests_watch.add_argument(
         "request_id", nargs="?", help="Request ID to watch (latest if omitted)"
     )
@@ -259,19 +376,24 @@ def add_request_actions(subparsers):
         "--interval", type=int, default=5, help="Poll interval in seconds (default: 5)"
     )
 
-    requests_list_returns = subparsers.add_parser("list-returns", help="List return requests")
-    add_global_arguments(requests_list_returns)
+    requests_list_returns = subparsers.add_parser(
+        "list-returns",
+        help="List return requests",
+        parents=[pp.common, pp.list, pp.provider_scope, pp.hf_compat],
+    )
     requests_list_returns.add_argument("--status", help="Filter by return request status")
 
 
-def add_infrastructure_actions(subparsers):
+def add_infrastructure_actions(subparsers, pp: "ParentParsers | None" = None):
     """Add infrastructure actions to a subparser."""
+    if pp is None:
+        pp = ParentParsers()
     infra_discover = subparsers.add_parser(
         "discover",
         help="Scan AWS to find available infrastructure (VPCs, subnets, security groups)",
         description="Discover available infrastructure in your AWS account.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
-    add_global_arguments(infra_discover)
     add_multi_provider_arguments(infra_discover)
     infra_discover.add_argument(
         "--show",
@@ -287,105 +409,137 @@ def add_infrastructure_actions(subparsers):
         "show",
         help="Show current ORB infrastructure configuration",
         description="Display what infrastructure ORB is currently configured to use.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
-    add_global_arguments(infra_show)
     add_multi_provider_arguments(infra_show)
 
-    infra_validate = subparsers.add_parser(
+    subparsers.add_parser(
         "validate",
         help="Verify configured infrastructure still exists in AWS",
         description="Check if the infrastructure configured in ORB still exists in your AWS account.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
-    add_global_arguments(infra_validate)
 
 
-def add_provider_actions(subparsers):
+def add_provider_actions(subparsers, pp: "ParentParsers | None" = None):
     """Add provider actions to a subparser."""
-    providers_list = subparsers.add_parser(
+    if pp is None:
+        pp = ParentParsers()
+    subparsers.add_parser(
         "list",
         help="List providers",
         description="List providers with filtering support.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
-    add_global_arguments(providers_list)
-    providers_show = subparsers.add_parser("show", help="Show provider details")
-    add_global_arguments(providers_show)
+    providers_show = subparsers.add_parser(
+        "show",
+        help="Show provider details",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
     providers_show.add_argument("provider_name", nargs="?", help="Provider name to show")
 
-    providers_health = subparsers.add_parser("health", help="Check provider health")
-    add_global_arguments(providers_health)
+    subparsers.add_parser(
+        "health",
+        help="Check provider health",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
 
-    providers_add = subparsers.add_parser("add", help="Add new provider")
-    add_global_arguments(providers_add)
+    providers_add = subparsers.add_parser(
+        "add", help="Add new provider", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     for _spec in CLISpecRegistry.all().values():
         _spec.add_arguments(providers_add)
     providers_add.add_argument("--name", help="Provider instance name")
     providers_add.add_argument("--discover", action="store_true", help="Discover infrastructure")
 
-    providers_remove = subparsers.add_parser("remove", help="Remove provider")
-    add_global_arguments(providers_remove)
+    providers_remove = subparsers.add_parser(
+        "remove", help="Remove provider", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     providers_remove.add_argument("provider_name", help="Provider instance name to remove")
 
-    providers_update = subparsers.add_parser("update", help="Update provider configuration")
-    add_global_arguments(providers_update)
+    providers_update = subparsers.add_parser(
+        "update",
+        help="Update provider configuration",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
     providers_update.add_argument("provider_name", help="Provider instance name")
     for _spec in CLISpecRegistry.all().values():
         _spec.add_arguments(providers_update)
 
-    providers_set_default = subparsers.add_parser("set-default", help="Set default provider")
-    add_global_arguments(providers_set_default)
+    providers_set_default = subparsers.add_parser(
+        "set-default",
+        help="Set default provider",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
     providers_set_default.add_argument("provider_name", help="Provider name to set as default")
 
-    providers_get = subparsers.add_parser("get", help="Get provider details by name")
-    add_global_arguments(providers_get)
+    providers_get = subparsers.add_parser(
+        "get", help="Get provider details by name", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     providers_get.add_argument("name", help="Provider name")
 
-    providers_get_default = subparsers.add_parser("get-default", help="Show default provider")
-    add_global_arguments(providers_get_default)
+    subparsers.add_parser(
+        "get-default", help="Show default provider", parents=[pp.common, pp.list, pp.provider_scope]
+    )
 
-    providers_select = subparsers.add_parser("select", help="Select provider instance")
-    add_global_arguments(providers_select)
+    providers_select = subparsers.add_parser(
+        "select", help="Select provider instance", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     providers_select.add_argument("provider_name", help="Provider name to select")
 
-    providers_exec = subparsers.add_parser("exec", help="Execute provider command")
-    add_global_arguments(providers_exec)
+    providers_exec = subparsers.add_parser(
+        "exec", help="Execute provider command", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     providers_exec.add_argument("operation", help="Operation to execute")
     providers_exec.add_argument(
         "--params", "--args", dest="params", help="Operation parameters (JSON format)"
     )
 
-    providers_metrics = subparsers.add_parser("metrics", help="Show provider metrics")
-    add_global_arguments(providers_metrics)
+    providers_metrics = subparsers.add_parser(
+        "metrics", help="Show provider metrics", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     providers_metrics.add_argument(
         "--timeframe", default="1h", help="Metrics timeframe (e.g., 1h, 24h, 7d)"
     )
 
 
-def add_template_actions(subparsers):
+def add_template_actions(subparsers, pp: "ParentParsers | None" = None):
     """Add template actions to a subparser."""
+    if pp is None:
+        pp = ParentParsers()
     templates_list = subparsers.add_parser(
         "list",
         help="List templates",
         description="List templates with filtering support.",
+        parents=[pp.common, pp.list, pp.provider_scope, pp.hf_compat],
     )
-    add_global_arguments(templates_list)
     templates_list.add_argument("--provider-api", help="Filter by provider API type")
 
-    templates_show = subparsers.add_parser("show", help="Show template details")
-    add_global_arguments(templates_show)
+    templates_show = subparsers.add_parser(
+        "show",
+        help="Show template details",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
     templates_show.add_argument("template_id", nargs="?", help="Template ID to show")
     templates_show.add_argument(
         "--template-id", "-t", dest="flag_template_id", help="Template ID to show"
     )
 
-    templates_create = subparsers.add_parser("create", help="Create template")
-    add_global_arguments(templates_create)
+    templates_create = subparsers.add_parser(
+        "create",
+        help="Create template",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
     templates_create.add_argument("--file", required=True, help="Template configuration file")
     templates_create.add_argument(
         "--validate-only", action="store_true", help="Only validate, do not create"
     )
 
-    templates_update = subparsers.add_parser("update", help="Update template")
-    add_global_arguments(templates_update)
+    templates_update = subparsers.add_parser(
+        "update",
+        help="Update template",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
     templates_update.add_argument("template_id", nargs="?", help="Template ID to update")
     templates_update.add_argument(
         "--template-id", "-t", dest="flag_template_id", help="Template ID to update"
@@ -394,29 +548,39 @@ def add_template_actions(subparsers):
         "--file", required=True, help="Updated template configuration file"
     )
 
-    templates_delete = subparsers.add_parser("delete", help="Delete template")
-    add_global_arguments(templates_delete)
-    add_force_argument(templates_delete)
+    templates_delete = subparsers.add_parser(
+        "delete",
+        help="Delete template",
+        parents=[pp.common, pp.list, pp.write, pp.provider_scope],
+    )
     templates_delete.add_argument("template_id", nargs="?", help="Template ID to delete")
     templates_delete.add_argument(
         "--template-id", "-t", dest="flag_template_id", help="Template ID to delete"
     )
 
-    templates_validate = subparsers.add_parser("validate", help="Validate template")
-    add_global_arguments(templates_validate)
+    templates_validate = subparsers.add_parser(
+        "validate",
+        help="Validate template",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
+    templates_validate.add_argument("--all", action="store_true", help="Validate all templates")
     templates_validate.add_argument("template_id", nargs="?", help="Template ID to validate")
     templates_validate.add_argument(
         "--template-id", "-t", dest="flag_template_id", help="Template ID to validate"
     )
     templates_validate.add_argument("--file", help="Template file to validate (pre-import)")
 
-    templates_refresh = subparsers.add_parser("refresh", help="Refresh template cache")
-    add_global_arguments(templates_refresh)
-    add_force_argument(templates_refresh)
+    subparsers.add_parser(
+        "refresh",
+        help="Refresh template cache",
+        parents=[pp.common, pp.list, pp.write, pp.provider_scope],
+    )
 
-    templates_generate = subparsers.add_parser("generate", help="Generate example templates")
-    add_global_arguments(templates_generate)
-    add_force_argument(templates_generate)
+    templates_generate = subparsers.add_parser(
+        "generate",
+        help="Generate example templates",
+        parents=[pp.common, pp.list, pp.write, pp.provider_scope],
+    )
     add_multi_provider_arguments(templates_generate)
     templates_generate.add_argument(
         "--provider-api", help="Provider API type (EC2Fleet, SpotFleet, ASG, RunInstances)"
@@ -485,6 +649,11 @@ For more information, visit: {DOCS_URL}
 
     parser.add_argument("--version", action="version", version=version_string)
 
+    # Intent-grouped parent parsers, built once and shared across all
+    # sub-parsers via parents=[...]. Any duplicate option string introduced by
+    # composing two parents raises argparse.ArgumentError here at build time.
+    pp = ParentParsers()
+
     subparsers = parser.add_subparsers(
         dest="resource", help="Available resources or legacy commands"
     )
@@ -499,8 +668,8 @@ For more information, visit: {DOCS_URL}
     resource_parsers["template"] = template_parser
     template_subparsers = template_parser.add_subparsers(dest="action", help="Template actions")
 
-    add_template_actions(templates_subparsers)
-    add_template_actions(template_subparsers)
+    add_template_actions(templates_subparsers, pp)
+    add_template_actions(template_subparsers, pp)
 
     # Machines
     machines_parser = subparsers.add_parser("machines", help="Compute instances")
@@ -511,8 +680,8 @@ For more information, visit: {DOCS_URL}
     resource_parsers["machine"] = machine_parser
     machine_subparsers = machine_parser.add_subparsers(dest="action", help="Machine actions")
 
-    add_machine_actions(machines_subparsers)
-    add_machine_actions(machine_subparsers)
+    add_machine_actions(machines_subparsers, pp)
+    add_machine_actions(machine_subparsers, pp)
 
     # Requests
     requests_parser = subparsers.add_parser("requests", help="Provisioning requests")
@@ -523,8 +692,8 @@ For more information, visit: {DOCS_URL}
     resource_parsers["request"] = request_parser
     request_subparsers = request_parser.add_subparsers(dest="action", help="Request actions")
 
-    add_request_actions(requests_subparsers)
-    add_request_actions(request_subparsers)
+    add_request_actions(requests_subparsers, pp)
+    add_request_actions(request_subparsers, pp)
 
     # System
     system_parser = subparsers.add_parser("system", help="System operations")
@@ -533,16 +702,22 @@ For more information, visit: {DOCS_URL}
         dest="action", help="System actions", required=True
     )
 
-    system_status = system_subparsers.add_parser("status", help="Show system status")
-    add_global_arguments(system_status)
+    system_subparsers.add_parser(
+        "status", help="Show system status", parents=[pp.common, pp.list, pp.provider_scope]
+    )
 
-    system_health = system_subparsers.add_parser("health", help="Check system health")
-    add_global_arguments(system_health)
-    system_metrics = system_subparsers.add_parser("metrics", help="Show system metrics")
-    add_global_arguments(system_metrics)
+    system_subparsers.add_parser(
+        "health", help="Check system health", parents=[pp.common, pp.list, pp.provider_scope]
+    )
+    system_subparsers.add_parser(
+        "metrics", help="Show system metrics", parents=[pp.common, pp.list, pp.provider_scope]
+    )
 
-    system_reload = system_subparsers.add_parser("reload", help="Reload provider configuration")
-    add_global_arguments(system_reload)
+    system_subparsers.add_parser(
+        "reload",
+        help="Reload provider configuration",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
 
     # Server (process lifecycle — local daemon control)
     server_parser = subparsers.add_parser(
@@ -555,7 +730,6 @@ For more information, visit: {DOCS_URL}
     )
 
     def _add_server_start_args(p):
-        add_global_arguments(p)
         # Intentional binding for server deployment.
         p.add_argument("--host", default=None, help="Server host (overrides config)")  # nosec B104
         p.add_argument("--port", type=int, default=None, help="Server port (overrides config)")
@@ -582,12 +756,15 @@ For more information, visit: {DOCS_URL}
         )
 
     server_start = server_subparsers.add_parser(
-        "start", help="Start the ORB server (daemonised by default)"
+        "start",
+        help="Start the ORB server (daemonised by default)",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     _add_server_start_args(server_start)
 
-    server_stop = server_subparsers.add_parser("stop", help="Stop the running ORB server")
-    add_global_arguments(server_stop)
+    server_stop = server_subparsers.add_parser(
+        "stop", help="Stop the running ORB server", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     server_stop.add_argument(
         "--timeout",
         type=int,
@@ -595,10 +772,15 @@ For more information, visit: {DOCS_URL}
         help="Seconds to wait for graceful shutdown before SIGKILL (defaults to config)",
     )
 
-    server_status = server_subparsers.add_parser("status", help="Show ORB server status + health")
-    add_global_arguments(server_status)
+    server_subparsers.add_parser(
+        "status",
+        help="Show ORB server status + health",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
 
-    server_restart = server_subparsers.add_parser("restart", help="Restart the ORB server")
+    server_restart = server_subparsers.add_parser(
+        "restart", help="Restart the ORB server", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     _add_server_start_args(server_restart)
     server_restart.add_argument(
         "--restart-timeout",
@@ -608,20 +790,22 @@ For more information, visit: {DOCS_URL}
         help="Seconds to wait for graceful shutdown before SIGKILL during stop phase",
     )
 
-    server_logs = server_subparsers.add_parser("logs", help="Tail the ORB server log file")
-    add_global_arguments(server_logs)
+    server_logs = server_subparsers.add_parser(
+        "logs", help="Tail the ORB server log file", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     server_logs.add_argument("-n", "--lines", type=int, default=50, help="Lines to tail")
 
-    server_reload_cmd = server_subparsers.add_parser(
-        "reload", help="Send SIGHUP to the running ORB server"
+    server_subparsers.add_parser(
+        "reload",
+        help="Send SIGHUP to the running ORB server",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
-    add_global_arguments(server_reload_cmd)
 
     server_ui_export = server_subparsers.add_parser(
         "ui-export",
         help="Copy the compiled SPA bundle to a local directory for CDN / static-host serving",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
-    add_global_arguments(server_ui_export)
     server_ui_export.add_argument(
         "--dest",
         required=True,
@@ -644,8 +828,8 @@ For more information, visit: {DOCS_URL}
     resource_parsers["infra"] = infra_parser
     infra_subparsers = infra_parser.add_subparsers(dest="action", help="Infrastructure actions")
 
-    add_infrastructure_actions(infrastructure_subparsers)
-    add_infrastructure_actions(infra_subparsers)
+    add_infrastructure_actions(infrastructure_subparsers, pp)
+    add_infrastructure_actions(infra_subparsers, pp)
 
     # Config
     config_parser = subparsers.add_parser("config", help="Configuration")
@@ -654,24 +838,31 @@ For more information, visit: {DOCS_URL}
         dest="action", help="Config actions", required=True
     )
 
-    config_show = config_subparsers.add_parser("show", help="Show configuration")
-    add_global_arguments(config_show)
+    config_subparsers.add_parser(
+        "show", help="Show configuration", parents=[pp.common, pp.list, pp.provider_scope]
+    )
 
-    config_set = config_subparsers.add_parser("set", help="Set configuration")
-    add_global_arguments(config_set)
+    config_set = config_subparsers.add_parser(
+        "set", help="Set configuration", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     config_set.add_argument("key", help="Configuration key")
     config_set.add_argument("value", help="Configuration value")
 
-    config_get = config_subparsers.add_parser("get", help="Get configuration")
-    add_global_arguments(config_get)
+    config_get = config_subparsers.add_parser(
+        "get", help="Get configuration", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     config_get.add_argument("key", help="Configuration key")
 
-    config_validate = config_subparsers.add_parser("validate", help="Validate configuration")
-    add_global_arguments(config_validate)
+    config_validate = config_subparsers.add_parser(
+        "validate", help="Validate configuration", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     config_validate.add_argument("--file", help="Configuration file to validate")
 
-    config_reload = config_subparsers.add_parser("reload", help="Reload provider configuration")
-    add_global_arguments(config_reload)
+    config_subparsers.add_parser(
+        "reload",
+        help="Reload provider configuration",
+        parents=[pp.common, pp.list, pp.provider_scope],
+    )
 
     # Providers
     providers_parser = subparsers.add_parser("providers", help="Cloud providers")
@@ -682,8 +873,8 @@ For more information, visit: {DOCS_URL}
     resource_parsers["provider"] = provider_parser
     provider_subparsers = provider_parser.add_subparsers(dest="action", help="Provider actions")
 
-    add_provider_actions(providers_subparsers)
-    add_provider_actions(provider_subparsers)
+    add_provider_actions(providers_subparsers, pp)
+    add_provider_actions(provider_subparsers, pp)
 
     # Storage
     storage_parser = subparsers.add_parser("storage", help="Storage")
@@ -692,33 +883,39 @@ For more information, visit: {DOCS_URL}
         dest="action", help="Storage actions", required=True
     )
 
-    storage_list = storage_subparsers.add_parser("list", help="List storage strategies")
-    add_global_arguments(storage_list)
+    storage_subparsers.add_parser(
+        "list", help="List storage strategies", parents=[pp.common, pp.list, pp.provider_scope]
+    )
 
-    storage_show = storage_subparsers.add_parser("show", help="Show storage configuration")
-    add_global_arguments(storage_show)
+    storage_show = storage_subparsers.add_parser(
+        "show", help="Show storage configuration", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     storage_show.add_argument("--strategy", help="Show specific storage strategy details")
 
-    storage_validate = storage_subparsers.add_parser("validate", help="Validate storage")
-    add_global_arguments(storage_validate)
+    storage_validate = storage_subparsers.add_parser(
+        "validate", help="Validate storage", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     storage_validate.add_argument("--strategy", help="Validate specific storage strategy")
 
-    storage_test = storage_subparsers.add_parser("test", help="Test storage connectivity")
-    add_global_arguments(storage_test)
+    storage_test = storage_subparsers.add_parser(
+        "test", help="Test storage connectivity", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     storage_test.add_argument("--strategy", help="Test specific storage strategy")
     storage_test.add_argument("--timeout", type=int, default=30, help="Test timeout in seconds")
 
-    storage_health = storage_subparsers.add_parser("health", help="Check storage health")
-    add_global_arguments(storage_health)
-    storage_metrics = storage_subparsers.add_parser("metrics", help="Show storage metrics")
-    add_global_arguments(storage_metrics)
+    storage_subparsers.add_parser(
+        "health", help="Check storage health", parents=[pp.common, pp.list, pp.provider_scope]
+    )
+    storage_metrics = storage_subparsers.add_parser(
+        "metrics", help="Show storage metrics", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     storage_metrics.add_argument("--strategy", help="Show metrics for specific storage strategy")
 
     storage_migrate = storage_subparsers.add_parser(
         "migrate",
         help="Run SQL storage migrations (Alembic). No-op for JSON backend.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
-    add_global_arguments(storage_migrate)
     storage_migrate.add_argument(
         "migrate_subcommand",
         choices=["up", "down", "current", "history"],
@@ -732,15 +929,18 @@ For more information, visit: {DOCS_URL}
         dest="action", help="Scheduler actions", required=True
     )
 
-    scheduler_list = scheduler_subparsers.add_parser("list", help="List scheduler strategies")
-    add_global_arguments(scheduler_list)
+    scheduler_subparsers.add_parser(
+        "list", help="List scheduler strategies", parents=[pp.common, pp.list, pp.provider_scope]
+    )
 
-    scheduler_show = scheduler_subparsers.add_parser("show", help="Show scheduler details")
-    add_global_arguments(scheduler_show)
+    scheduler_show = scheduler_subparsers.add_parser(
+        "show", help="Show scheduler details", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     scheduler_show.add_argument("--strategy", help="Show specific scheduler strategy details")
 
-    scheduler_validate = scheduler_subparsers.add_parser("validate", help="Validate scheduler")
-    add_global_arguments(scheduler_validate)
+    scheduler_validate = scheduler_subparsers.add_parser(
+        "validate", help="Validate scheduler", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     scheduler_validate.add_argument("--strategy", help="Validate specific scheduler strategy")
 
     # MCP
@@ -751,28 +951,33 @@ For more information, visit: {DOCS_URL}
     mcp_tools = mcp_subparsers.add_parser("tools", help="MCP tools management")
     mcp_tools_sub = mcp_tools.add_subparsers(dest="tools_action", required=True)
 
-    mcp_tools_list = mcp_tools_sub.add_parser("list", help="List MCP tools")
-    add_global_arguments(mcp_tools_list)
+    mcp_tools_list = mcp_tools_sub.add_parser(
+        "list", help="List MCP tools", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     mcp_tools_list.add_argument(
         "--type", choices=["command", "query"], help="Filter tools by handler type"
     )
 
-    mcp_tools_call = mcp_tools_sub.add_parser("call", help="Call MCP tool")
-    add_global_arguments(mcp_tools_call)
+    mcp_tools_call = mcp_tools_sub.add_parser(
+        "call", help="Call MCP tool", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     mcp_tools_call.add_argument("tool_name", help="Name of tool to call")
     mcp_tools_call.add_argument("--args", help="Tool arguments as JSON string")
     mcp_tools_call.add_argument("--file", help="Tool arguments from JSON file")
 
-    mcp_tools_info = mcp_tools_sub.add_parser("info", help="Show MCP tool details")
-    add_global_arguments(mcp_tools_info)
+    mcp_tools_info = mcp_tools_sub.add_parser(
+        "info", help="Show MCP tool details", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     mcp_tools_info.add_argument("tool_name", help="Name of tool to get info for")
 
-    mcp_validate = mcp_subparsers.add_parser("validate", help="Validate MCP")
-    add_global_arguments(mcp_validate)
+    mcp_validate = mcp_subparsers.add_parser(
+        "validate", help="Validate MCP", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     mcp_validate.add_argument("--config", help="MCP configuration file to validate")
 
-    mcp_serve = mcp_subparsers.add_parser("serve", help="Start MCP server")
-    add_global_arguments(mcp_serve)
+    mcp_serve = mcp_subparsers.add_parser(
+        "serve", help="Start MCP server", parents=[pp.common, pp.list, pp.provider_scope]
+    )
     mcp_serve.add_argument("--port", type=int, default=3000, help="Server port (default: 3000)")
     mcp_serve.add_argument("--host", default="localhost", help="Server host (default: localhost)")
     mcp_serve.add_argument(

--- a/src/orb/cli/main.py
+++ b/src/orb/cli/main.py
@@ -143,25 +143,13 @@ async def main() -> None:
             except Exception as e:
                 logger.warning("Failed to override scheduler strategy: %s", e, exc_info=True)
 
-        if hasattr(args, "provider_name") and args.provider_name:
-            try:
-                from orb.domain.base.ports.configuration_port import ConfigurationPort
-
-                container = get_container()
-                config = container.get(ConfigurationPort)
-                config.override_provider_name(args.provider_name)
-            except Exception as e:
-                logger.warning("Failed to override provider name: %s", e, exc_info=True)
-
-        if hasattr(args, "provider_type") and args.provider_type:
-            try:
-                from orb.domain.base.ports.configuration_port import ConfigurationPort
-
-                container = get_container()
-                config = container.get(ConfigurationPort)
-                config.override_provider_type(args.provider_type)
-            except Exception as e:
-                logger.warning("Failed to override provider type: %s", e, exc_info=True)
+        # Provider filter (--provider-name / --provider-type) is NOT stashed on
+        # container state.  It flows request-scoped through the query/command
+        # DTOs: interface handlers read args.provider_name / args.provider_type
+        # and pass them into the DTO, orchestrators forward them into
+        # select_active_provider(provider_name=..., provider_type=...).  This is
+        # the single, thread-safe conduit — see ConfigurationPort (no override
+        # methods) and the orchestration DTOs.
 
         # Skip application initialization for init command
         if args.resource == "init":

--- a/src/orb/config/managers/configuration_manager.py
+++ b/src/orb/config/managers/configuration_manager.py
@@ -74,10 +74,6 @@ class ConfigurationManager:
         # Scheduler override support
         self._scheduler_override: Optional[str] = None
 
-        # Provider selection overrides (from CLI --provider-name / --provider-type)
-        self._provider_name_override: Optional[str] = None
-        self._provider_type_override: Optional[str] = None
-
     @property
     def config_file(self) -> str | None:
         """Return the config file path this manager was initialised with.
@@ -295,38 +291,41 @@ class ConfigurationManager:
         """Restore original scheduler strategy."""
         self._scheduler_override = None
 
-    def override_provider_name(self, provider_name: str) -> None:
-        """Temporarily override provider instance by exact name."""
-        self._provider_name_override = provider_name
-
-    def override_provider_type(self, provider_type: str) -> None:
-        """Temporarily restrict selection to a provider type."""
-        self._provider_type_override = provider_type
-
-    def get_active_provider_name_override(self) -> str | None:
-        """Get current provider name override."""
-        return self._provider_name_override
-
-    def get_active_provider_type_override(self) -> str | None:
-        """Get current provider type override."""
-        return self._provider_type_override
-
     def get_loaded_config_file(self) -> str | None:
-        """Get the actual config file that was loaded."""
-        # If a config file path is already stored (set in __init__ or reload), use it
-        if self._config_file is not None:
-            from pathlib import Path
+        """Get the actual config file that was loaded.
 
-            if Path(self._config_file).exists():
-                return self._config_file
+        Routes through the single ``platform_dirs.resolve_config_file`` source of
+        truth so discovery order (explicit path, ORB_CONFIG_FILE, ORB_CONFIG_DIR,
+        platform-dirs location, ~/.orb fallback) stays consistent with the
+        startup validator and every other consumer.
 
-        # Fall back to platform-resolved location
-        from orb.config.platform_dirs import get_config_location
+        This is a *best-effort discovery* used for reporting the effective
+        config file. It may point at a candidate that exists on disk but was
+        not the source this manager loaded (e.g. an ``ORB_CONFIG_FILE`` set
+        after construction). Callers that need the exact source this manager
+        read — for example to choose a safe default save target — must use
+        :meth:`get_source_config_file` instead.
+        """
+        from orb.config.platform_dirs import resolve_config_file
 
-        candidate = get_config_location() / "config.json"
-        if candidate.exists():
-            return str(candidate)
-        return None
+        resolved = resolve_config_file("config.json", explicit_path=self._config_file)
+        return str(resolved) if resolved is not None else None
+
+    def get_source_config_file(self) -> str | None:
+        """Get the file this manager actually loaded configuration from.
+
+        Unlike :meth:`get_loaded_config_file`, this never synthesises a target
+        from ``ORB_CONFIG_FILE`` or the ``~/.orb`` fallback. It returns the
+        construction path only when that file exists on disk (which is what the
+        loader read), and ``None`` when configuration came from an in-memory
+        dict, environment only, or a path with no backing file. This makes it
+        safe to use as an implicit save destination.
+        """
+        if self._config_file is None:
+            return None
+        from pathlib import Path
+
+        return self._config_file if Path(self._config_file).exists() else None
 
     def get_provider_type(self) -> str:
         """Get provider type."""

--- a/src/orb/config/platform_dirs.py
+++ b/src/orb/config/platform_dirs.py
@@ -154,3 +154,67 @@ def get_cache_location() -> Path:
     if env_dir := os.environ.get("ORB_CACHE_DIR"):
         return Path(env_dir)
     return get_work_location() / ".cache"
+
+
+def resolve_config_file(
+    filename: str = "config.json",
+    explicit_path: str | None = None,
+) -> Path | None:
+    """Shared existence-based discovery for the config-file *consumers*.
+
+    Provides one ordered lookup for the callers that need to know which config
+    file already exists on disk: ``StartupValidator._find_config_file`` (which
+    fails fast when nothing is found) and ``ConfigurationManager`` reporting
+    (``get_loaded_config_file``). Both route through here so their discovery
+    order stays identical.
+
+    This is deliberately *not* the loader's path resolver.
+    ``PathResolutionService`` remains a separate concern: it serves the
+    ``ConfigurationLoader`` for every file type (config, template, legacy, log,
+    work, events, snapshots), applies scheduler-directory priority, and returns
+    a candidate path that may not yet exist (so callers can create it). This
+    function, by contrast, only answers "does a config/template file already
+    exist, and where?" and returns ``None`` when none is found.
+
+    Resolution order (first existing match wins):
+      1. ``explicit_path`` — a caller-supplied path (e.g. ``orb --config ...``).
+         Returned as-is when it exists.
+      2. ``$ORB_CONFIG_FILE`` — full-path override for the primary config file.
+      3. ``$ORB_CONFIG_DIR/<filename>`` — directory override + filename.
+      4. ``get_config_location()/<filename>`` — the platform-scoped location
+         (respects venv / pyproject / uv-tool detection via get_root_location).
+      5. ``~/.orb/config/<filename>`` — user-home fallback so operators running
+         from inside a source checkout (which pins platform_dirs to the repo)
+         still pick up their initialised config.
+
+    Args:
+        filename: The file to locate (e.g. ``"config.json"``,
+            ``"awsprov_templates.json"``).  Ignored for the ``ORB_CONFIG_FILE``
+            candidate, which is a full path in its own right.
+        explicit_path: An explicit path supplied by the caller.  When it exists
+            it wins outright.
+
+    Returns:
+        The first :class:`~pathlib.Path` that exists, or ``None`` when no
+        candidate is found.  Callers decide how to surface a missing file
+        (fail-fast vs. fall back to defaults).
+    """
+    if explicit_path and Path(explicit_path).exists():
+        return Path(explicit_path)
+
+    candidates: list[Path] = []
+
+    if env_file := os.environ.get("ORB_CONFIG_FILE"):
+        candidates.append(Path(env_file))
+
+    if env_dir := os.environ.get("ORB_CONFIG_DIR"):
+        candidates.append(Path(env_dir) / filename)
+
+    candidates.append(get_config_location() / filename)
+    candidates.append(Path.home() / ".orb" / "config" / filename)
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    return None

--- a/src/orb/domain/base/ports/configuration_port.py
+++ b/src/orb/domain/base/ports/configuration_port.py
@@ -159,22 +159,6 @@ class ConfigurationPort(ProviderConfigPort):
         """
         return {}
 
-    @abstractmethod
-    def get_active_provider_name_override(self) -> str | None:
-        """Get current provider name override from CLI (exact instance name)."""
-
-    @abstractmethod
-    def get_active_provider_type_override(self) -> str | None:
-        """Get current provider type override from CLI (type filter)."""
-
-    @abstractmethod
-    def override_provider_name(self, provider_name: str) -> None:
-        """Override the active provider by exact instance name."""
-
-    @abstractmethod
-    def override_provider_type(self, provider_type: str) -> None:
-        """Restrict selection to a provider type."""
-
     @property
     def app_config(self) -> Any:
         """Get the full application configuration."""

--- a/src/orb/infrastructure/adapters/configuration_adapter.py
+++ b/src/orb/infrastructure/adapters/configuration_adapter.py
@@ -180,11 +180,14 @@ class ConfigurationAdapter(ConfigurationPort):
     def save_config(self, path: str | None = None) -> str:
         """Persist the in-memory raw config to disk.
 
-        If ``path`` is None, writes to the currently-loaded config file.
-        Returns the resolved path that was written. Raises if no path can
-        be resolved (e.g. config came from env only, no file backing).
+        If ``path`` is None, writes back to the file this manager actually
+        loaded from — never to a candidate synthesised from ``ORB_CONFIG_FILE``
+        or the ``~/.orb`` fallback that was never the real source. Returns the
+        resolved path that was written. Raises when no backing file exists
+        (e.g. config came from env or an in-memory dict) so an explicit path
+        must be supplied.
         """
-        target = path or self._config_manager.get_loaded_config_file()
+        target = path if path is not None else self._config_manager.get_source_config_file()
         if not target:
             raise ValueError(
                 "No config file path resolved — config was not loaded from a file. "
@@ -373,22 +376,6 @@ class ConfigurationAdapter(ConfigurationPort):
     def override_scheduler_strategy(self, strategy: str) -> None:  # type: ignore[override]
         """Override scheduler strategy - delegate to ConfigurationManager."""
         self._config_manager.override_scheduler_strategy(strategy)
-
-    def override_provider_name(self, provider_name: str) -> None:
-        """Override provider instance by exact name - delegate to ConfigurationManager."""
-        self._config_manager.override_provider_name(provider_name)
-
-    def override_provider_type(self, provider_type: str) -> None:
-        """Restrict selection to a provider type - delegate to ConfigurationManager."""
-        self._config_manager.override_provider_type(provider_type)
-
-    def get_active_provider_name_override(self) -> str | None:
-        """Get current provider name override from CLI."""
-        return self._config_manager.get_active_provider_name_override()
-
-    def get_active_provider_type_override(self) -> str | None:
-        """Get current provider type override from CLI."""
-        return self._config_manager.get_active_provider_type_override()
 
     def get_resource_prefix(self, resource_type: str) -> str:
         """Get resource naming prefix for the given resource type."""

--- a/src/orb/infrastructure/scheduler/hostfactory/hostfactory_strategy.py
+++ b/src/orb/infrastructure/scheduler/hostfactory/hostfactory_strategy.py
@@ -406,13 +406,20 @@ class HostFactorySchedulerStrategy(BaseSchedulerStrategy):
         return mapping.get(hf_field, hf_field)
 
     def get_config_file_path(self) -> str:
-        """Get config file path using configuration."""
-        # Get raw config and build path manually
+        """Get config file path using configuration.
+
+        The provider-config root is resolved via ``SchedulerConfig.get_config_root()``
+        so an explicit ``scheduler.config_root`` override is honoured and,
+        when unset, it defers to ``platform_dirs.get_config_location()`` — the
+        single platform-scoped source of truth — instead of a bare relative
+        ``"config"`` directory that depended on the process working directory.
+        """
         config = self.config_manager.app_config.model_dump()
 
-        # Get scheduler config root
-        scheduler_config = config.get("scheduler", {})
-        config_root = scheduler_config.get("config_root", "config")
+        # Resolve the config root via SchedulerConfig so an explicit
+        # scheduler.config_root override wins and the default falls back to the
+        # platform-scoped config location rather than a relative "config" dir.
+        config_root = self.config_manager.app_config.scheduler.get_config_root()
 
         # Get provider type from active provider
         provider_config = config.get("provider", {})

--- a/src/orb/infrastructure/validation/startup_validator.py
+++ b/src/orb/infrastructure/validation/startup_validator.py
@@ -104,33 +104,19 @@ class StartupValidator:
             self._console.info("  Check your provider configuration and credentials")
 
     def _find_config_file(self) -> bool:
-        """Find config file using discovery hierarchy."""
-        if self.config_path and Path(self.config_path).exists():
+        """Find config file via the single platform_dirs.resolve_config_file source.
+
+        Delegates the entire discovery hierarchy (explicit path, ORB_CONFIG_FILE,
+        ORB_CONFIG_DIR, platform-dirs location, ~/.orb fallback) to
+        :func:`orb.config.platform_dirs.resolve_config_file` so there is exactly
+        one place that knows how a config file is located.
+        """
+        from orb.config.platform_dirs import resolve_config_file
+
+        resolved = resolve_config_file("config.json", explicit_path=self.config_path)
+        if resolved is not None:
+            self.config_path = str(resolved)
             return True
-
-        from pathlib import Path as _Path
-
-        from orb.config.platform_dirs import get_config_location
-
-        # Discovery hierarchy — must match ConfigurationManager's resolution order.
-        # ORB_CONFIG_FILE and ORB_CONFIG_DIR/config.json are kept explicitly so the
-        # validator can surface a meaningful error when they are set but wrong.
-        # Then the platform-dirs path (respects venv / pyproject / uv-tool detection).
-        # Finally the user-home path so operators running from inside a checkout
-        # (which pins platform_dirs to the repo) still pick up ~/.orb/config/config.json
-        # when the repo has no local config.
-        candidates = [
-            os.environ.get("ORB_CONFIG_FILE"),
-            os.path.join(os.environ.get("ORB_CONFIG_DIR", ""), "config.json"),
-            str(get_config_location() / "config.json"),
-            str(_Path.home() / ".orb" / "config" / "config.json"),
-        ]
-
-        for candidate in candidates:
-            if candidate and Path(candidate).exists():
-                self.config_path = candidate
-                return True
-
         return False
 
     def _check_templates_file(self) -> bool:

--- a/src/orb/providers/aws/infrastructure/aws_handler_factory.py
+++ b/src/orb/providers/aws/infrastructure/aws_handler_factory.py
@@ -35,6 +35,7 @@ class AWSHandlerFactory:
         logger: LoggingPort,
         config: Optional[ConfigurationPort] = None,
         native_spec_service: Optional["NativeSpecServiceProtocol"] = None,
+        provider_name: Optional[str] = None,
     ) -> None:
         """
         Initialize the factory.
@@ -45,10 +46,14 @@ class AWSHandlerFactory:
             config: Configuration port for accessing configuration (optional)
             native_spec_service: Pre-resolved NativeSpecService instance (optional).
                 When provided, used directly instead of resolving from the DI container.
+            provider_name: Exact instance name of the provider this factory serves.
+                Handlers use it to scope configuration lookups (e.g. fleet_role)
+                to the selected provider rather than the first match.
         """
         self._aws_client = aws_client
         self._logger = logger
         self._config = config
+        self._provider_name = provider_name
         self._handlers: dict[str, AWSHandler] = {}
         self._handler_classes: dict[str, type[AWSHandler]] = {}
 
@@ -171,6 +176,7 @@ class AWSHandlerFactory:
             launch_template_manager=launch_template_manager,
             machine_adapter=machine_adapter,
             config_port=config_port,
+            provider_name=self._provider_name,
         )
 
         # Cache the handler for future use

--- a/src/orb/providers/aws/infrastructure/handlers/asg/handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/asg/handler.py
@@ -70,6 +70,7 @@ class ASGHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
         machine_adapter: Optional[AWSMachineAdapter] = None,
         aws_native_spec_service=None,
         config_port: Optional[ConfigurationPort] = None,
+        provider_name: Optional[str] = None,
     ) -> None:
         """
         Initialize the ASG handler with integrated dependencies.
@@ -91,6 +92,7 @@ class ASGHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
             machine_adapter,
             aws_native_spec_service=aws_native_spec_service,
             config_port=config_port,
+            provider_name=provider_name,
         )
         self._config_builder = ASGConfigBuilder(aws_native_spec_service, config_port, logger)
         self._capacity_manager = ASGCapacityManager(

--- a/src/orb/providers/aws/infrastructure/handlers/base_handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/base_handler.py
@@ -83,6 +83,7 @@ class AWSHandler(ABC):
         error_handler: Optional[ErrorHandlingPort] = None,
         aws_native_spec_service: Optional[Any] = None,
         config_port: Optional[ConfigurationPort] = None,
+        provider_name: Optional[str] = None,
     ) -> None:
         """
         Initialize AWS handler with standardized dependencies.
@@ -95,6 +96,8 @@ class AWSHandler(ABC):
             request_adapter: Request adapter for terminating instances (optional)
             machine_adapter: Machine adapter for provider-specific instance mapping (optional)
             error_handler: Error handling port for exception management (optional)
+            provider_name: Exact instance name of the provider this handler serves,
+                used to scope provider-specific configuration lookups (optional)
         """
         self.aws_client = aws_client
         self._logger = logger
@@ -103,6 +106,7 @@ class AWSHandler(ABC):
         self.error_handler = error_handler
         self.aws_native_spec_service = aws_native_spec_service
         self.config_port = config_port
+        self._provider_name = provider_name
         self.max_retries = 3
         self.base_delay = 1  # seconds
         self.max_delay = 10  # seconds

--- a/src/orb/providers/aws/infrastructure/handlers/ec2_fleet/handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/ec2_fleet/handler.py
@@ -82,6 +82,7 @@ class EC2FleetHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
         machine_adapter: Optional[AWSMachineAdapter] = None,
         aws_native_spec_service=None,
         config_port: Optional[ConfigurationPort] = None,
+        provider_name: Optional[str] = None,
         fleet_config_builder: Optional[EC2FleetConfigBuilder] = None,
         fleet_release_manager: Optional[EC2FleetReleaseManager] = None,
     ) -> None:
@@ -111,6 +112,7 @@ class EC2FleetHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
             machine_adapter,
             aws_native_spec_service=aws_native_spec_service,
             config_port=config_port,
+            provider_name=provider_name,
         )
         self._fleet_config_builder = fleet_config_builder or EC2FleetConfigBuilder(
             native_spec_service=aws_native_spec_service,

--- a/src/orb/providers/aws/infrastructure/handlers/microvm/handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/microvm/handler.py
@@ -69,6 +69,7 @@ class MicroVMHandler(AWSHandler):
         machine_adapter: Optional[AWSMachineAdapter] = None,
         aws_native_spec_service=None,
         config_port: Optional[ConfigurationPort] = None,
+        provider_name: Optional[str] = None,
     ) -> None:
         super().__init__(
             aws_client,
@@ -79,6 +80,7 @@ class MicroVMHandler(AWSHandler):
             machine_adapter,
             aws_native_spec_service=aws_native_spec_service,
             config_port=config_port,
+            provider_name=provider_name,
         )
 
     def _validate_prerequisites(self, template: AWSTemplate) -> None:

--- a/src/orb/providers/aws/infrastructure/handlers/run_instances/handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/run_instances/handler.py
@@ -72,6 +72,7 @@ class RunInstancesHandler(AWSHandler, BaseContextMixin):
         error_handler: ErrorHandlingPort = None,  # type: ignore[assignment]
         aws_native_spec_service=None,
         config_port: Optional[ConfigurationPort] = None,
+        provider_name: Optional[str] = None,
     ) -> None:
         """
         Initialize RunInstances handler with integrated dependencies.
@@ -95,6 +96,7 @@ class RunInstancesHandler(AWSHandler, BaseContextMixin):
             error_handler,
             aws_native_spec_service=aws_native_spec_service,
             config_port=config_port,
+            provider_name=provider_name,
         )
 
     @handle_infrastructure_exceptions(context="run_instances_creation")

--- a/src/orb/providers/aws/infrastructure/handlers/spot_fleet/handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/spot_fleet/handler.py
@@ -77,6 +77,7 @@ class SpotFleetHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
         machine_adapter: Optional[AWSMachineAdapter] = None,
         aws_native_spec_service=None,
         config_port: Optional[ConfigurationPort] = None,
+        provider_name: Optional[str] = None,
         spot_fleet_validator: Optional[SpotFleetValidator] = None,
         config_builder: Optional[SpotFleetConfigBuilder] = None,
         release_manager: Optional[SpotFleetReleaseManager] = None,
@@ -106,6 +107,7 @@ class SpotFleetHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
             machine_adapter,
             aws_native_spec_service=aws_native_spec_service,
             config_port=config_port,
+            provider_name=provider_name,
         )
         self._spot_fleet_validator = spot_fleet_validator or SpotFleetValidator(
             aws_client, logger, aws_ops
@@ -210,16 +212,7 @@ class SpotFleetHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
         """
         fleet_role = aws_template.fleet_role
         if not fleet_role and self.config_port is not None:
-            provider_config = self.config_port.get_provider_config()
-            if provider_config is not None:
-                active_override = self.config_port.get_active_provider_name_override()
-                providers = getattr(provider_config, "providers", [])
-                for p in providers:
-                    if active_override and getattr(p, "name", None) != active_override:
-                        continue
-                    fleet_role = (p.config or {}).get("fleet_role")
-                    if fleet_role:
-                        break
+            fleet_role = self._fleet_role_from_provider_config()
         if not fleet_role:
             return aws_template
 
@@ -246,6 +239,34 @@ class SpotFleetHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
         if resolved != aws_template.fleet_role:
             aws_template = aws_template.model_copy(update={"fleet_role": resolved})
         return aws_template
+
+    def _fleet_role_from_provider_config(self) -> Optional[str]:
+        """Read fleet_role from the provider instance this handler serves.
+
+        Scoped to ``self._provider_name`` so that in a multi-provider config the
+        role is taken from the selected provider rather than the first provider
+        that happens to define one. Falls back to the single provider entry when
+        no provider name was threaded through (single-provider deployments).
+        """
+        if self.config_port is None:
+            return None
+
+        # Preferred path: look up the exact provider instance by name.
+        if self._provider_name:
+            instance = self.config_port.get_provider_instance_config(self._provider_name)
+            if instance is not None:
+                return (getattr(instance, "config", None) or {}).get("fleet_role")
+            return None
+
+        # No provider name available (single-provider deployment): only trust a
+        # lone provider entry so we never silently pick another provider's role.
+        provider_config = self.config_port.get_provider_config()
+        if provider_config is None:
+            return None
+        providers = getattr(provider_config, "providers", [])
+        if len(providers) == 1:
+            return (providers[0].config or {}).get("fleet_role")
+        return None
 
     def check_hosts_status(self, request: Request) -> CheckHostsStatusResult:
         """Check the status of instances across all spot fleets in the request.

--- a/src/orb/providers/aws/strategy/aws_provider_strategy.py
+++ b/src/orb/providers/aws/strategy/aws_provider_strategy.py
@@ -491,7 +491,10 @@ class AWSProviderStrategy(ProviderStrategy):
             from orb.providers.aws.infrastructure.aws_handler_factory import AWSHandlerFactory
 
             return AWSHandlerFactory(
-                aws_client=self.aws_client, logger=self._logger, config=self._config_port
+                aws_client=self.aws_client,
+                logger=self._logger,
+                config=self._config_port,
+                provider_name=self._provider_name,
             )
         return None
 

--- a/tests/providers/aws/unit/infrastructure/handlers/test_spot_fleet_handler.py
+++ b/tests/providers/aws/unit/infrastructure/handlers/test_spot_fleet_handler.py
@@ -339,14 +339,19 @@ class TestSpotFleetHandlerNameTag:
             assert "hf-" not in name_tag["Value"]
 
 
-def _make_handler_with_config_port(config_port):
+def _make_handler_with_config_port(config_port, provider_name=None):
     aws_client = MagicMock()
     aws_client.sts_client.get_caller_identity.return_value = {"Account": "123456789012"}
     logger = MagicMock()
     aws_ops = MagicMock()
     launch_template_manager = MagicMock()
     return SpotFleetHandler(
-        aws_client, logger, aws_ops, launch_template_manager, config_port=config_port
+        aws_client,
+        logger,
+        aws_ops,
+        launch_template_manager,
+        config_port=config_port,
+        provider_name=provider_name,
     )
 
 
@@ -415,7 +420,6 @@ class TestResolveFleetRole:
     def test_fleet_role_resolved_from_provider_config(self):
         """When fleet_role is absent from template but present in provider config, it is injected."""
         config_port = MagicMock()
-        config_port.get_active_provider_name_override.return_value = None
         config_port.get_provider_config.return_value = _make_provider_config(
             fleet_role_in_config=FULL_SPOT_FLEET_ARN
         )
@@ -429,36 +433,7 @@ class TestResolveFleetRole:
     def test_fleet_role_not_found_returns_template_unchanged(self):
         """When fleet_role is absent from both template and provider config, template is unchanged."""
         config_port = MagicMock()
-        config_port.get_active_provider_name_override.return_value = None
         config_port.get_provider_config.return_value = _make_provider_config()
-        handler = _make_handler_with_config_port(config_port)
-        template = self._make_template(fleet_role=None)
-
-        result = handler._resolve_fleet_role(template)
-
-        assert result.fleet_role is None
-
-    def test_provider_override_matches_uses_fleet_role(self):
-        """When active_provider_override names the same provider, fleet_role is injected."""
-        config_port = MagicMock()
-        config_port.get_active_provider_name_override.return_value = "aws_test_eu-west-2"
-        config_port.get_provider_config.return_value = _make_provider_config(
-            fleet_role_in_config=FULL_SPOT_FLEET_ARN
-        )
-        handler = _make_handler_with_config_port(config_port)
-        template = self._make_template(fleet_role=None)
-
-        result = handler._resolve_fleet_role(template)
-
-        assert result.fleet_role == FULL_SPOT_FLEET_ARN
-
-    def test_provider_override_no_match_returns_template_unchanged(self):
-        """When active_provider_override names a different provider, fleet_role stays None."""
-        config_port = MagicMock()
-        config_port.get_active_provider_name_override.return_value = "aws_other_provider"
-        config_port.get_provider_config.return_value = _make_provider_config(
-            fleet_role_in_config=FULL_SPOT_FLEET_ARN
-        )
         handler = _make_handler_with_config_port(config_port)
         template = self._make_template(fleet_role=None)
 
@@ -475,10 +450,9 @@ class TestResolveFleetRole:
 
         assert result.fleet_role is None
 
-    def test_first_provider_with_fleet_role_is_used(self):
-        """The first provider entry that has a fleet_role is used when no template role is set."""
+    def test_single_provider_fleet_role_is_used(self):
+        """With one provider entry and no name, its fleet_role is used when no template role is set."""
         config_port = MagicMock()
-        config_port.get_active_provider_name_override.return_value = None
         config_port.get_provider_config.return_value = _make_provider_config(
             fleet_role_in_config=FULL_SPOT_FLEET_ARN
         )
@@ -489,6 +463,66 @@ class TestResolveFleetRole:
 
         assert result.fleet_role == FULL_SPOT_FLEET_ARN
 
+    def test_multi_provider_resolves_from_selected_provider(self):
+        """In a multi-provider config, the handler's own provider's fleet_role is used."""
+        other_arn = (
+            "arn:aws:iam::111111111111:role/aws-service-role/"
+            "spotfleet.amazonaws.com/AWSServiceRoleForEC2SpotFleet"
+        )
+        first = _FakeProvider("aws_first", config={"fleet_role": other_arn})
+        selected = _FakeProvider("aws_selected", config={"fleet_role": FULL_SPOT_FLEET_ARN})
+        by_name = {"aws_first": first, "aws_selected": selected}
+
+        config_port = MagicMock()
+        config_port.get_provider_config.return_value = _FakeProviderConfig(
+            providers=[first, selected]
+        )
+        config_port.get_provider_instance_config.side_effect = lambda name: by_name.get(name)
+
+        handler = _make_handler_with_config_port(config_port, provider_name="aws_selected")
+        template = self._make_template(fleet_role=None)
+
+        result = handler._resolve_fleet_role(template)
+
+        assert result.fleet_role == FULL_SPOT_FLEET_ARN
+        config_port.get_provider_instance_config.assert_called_once_with("aws_selected")
+
+    def test_multi_provider_does_not_borrow_other_providers_role(self):
+        """The selected provider without a fleet_role must not fall back to another provider's."""
+        other = _FakeProvider("aws_other", config={"fleet_role": FULL_SPOT_FLEET_ARN})
+        selected = _FakeProvider("aws_selected", config={})
+        by_name = {"aws_other": other, "aws_selected": selected}
+
+        config_port = MagicMock()
+        config_port.get_provider_config.return_value = _FakeProviderConfig(
+            providers=[other, selected]
+        )
+        config_port.get_provider_instance_config.side_effect = lambda name: by_name.get(name)
+
+        handler = _make_handler_with_config_port(config_port, provider_name="aws_selected")
+        template = self._make_template(fleet_role=None)
+
+        result = handler._resolve_fleet_role(template)
+
+        assert result.fleet_role is None
+
+    def test_multi_provider_without_name_does_not_guess(self):
+        """With multiple providers and no selected name, no role is borrowed from any of them."""
+        first = _FakeProvider("aws_first", config={"fleet_role": FULL_SPOT_FLEET_ARN})
+        second = _FakeProvider("aws_second", config={"fleet_role": FULL_SPOT_FLEET_ARN})
+
+        config_port = MagicMock()
+        config_port.get_provider_config.return_value = _FakeProviderConfig(
+            providers=[first, second]
+        )
+
+        handler = _make_handler_with_config_port(config_port, provider_name=None)
+        template = self._make_template(fleet_role=None)
+
+        result = handler._resolve_fleet_role(template)
+
+        assert result.fleet_role is None
+
     def test_ec2fleet_role_arn_converted_to_spotfleet_arn(self):
         """An EC2Fleet service-linked role ARN is converted to the SpotFleet equivalent."""
         ec2fleet_arn = (
@@ -496,7 +530,6 @@ class TestResolveFleetRole:
             "ec2fleet.amazonaws.com/AWSServiceRoleForEC2Fleet"
         )
         config_port = MagicMock()
-        config_port.get_active_provider_name_override.return_value = None
         config_port.get_provider_config.return_value = _make_provider_config(
             fleet_role_in_config=ec2fleet_arn
         )
@@ -512,7 +545,6 @@ class TestResolveFleetRole:
     def test_short_role_name_expanded_to_full_arn(self):
         """The short name 'AWSServiceRoleForEC2SpotFleet' is expanded to a full ARN."""
         config_port = MagicMock()
-        config_port.get_active_provider_name_override.return_value = None
         config_port.get_provider_config.return_value = _make_provider_config(
             fleet_role_in_config="AWSServiceRoleForEC2SpotFleet"
         )

--- a/tests/unit/cli/test_args.py
+++ b/tests/unit/cli/test_args.py
@@ -233,6 +233,72 @@ class TestGlobalFlags:
         assert ns.yes is True
 
 
+class TestAllScope:
+    """--all is scoped to the sub-commands that consume it, not global.
+
+    After the CLI schema refactor, --all no longer lives on add_global_arguments
+    (it had three different meanings). It is declared explicitly on the
+    per-command sub-parsers where it is meaningful.
+    """
+
+    def test_all_present_on_machines_return(self):
+        ns = _parse(["machines", "return", "--all", "--force"])
+        assert ns.all is True
+
+    def test_all_present_on_machines_stop(self):
+        ns = _parse(["machines", "stop", "--all", "--force"])
+        assert ns.all is True
+
+    def test_all_present_on_machines_start(self):
+        ns = _parse(["machines", "start", "--all"])
+        assert ns.all is True
+
+    def test_all_present_on_machines_status(self):
+        ns = _parse(["machines", "status", "--all"])
+        assert ns.all is True
+
+    def test_all_present_on_requests_status(self):
+        ns = _parse(["requests", "status", "--all"])
+        assert ns.all is True
+
+    def test_all_present_on_templates_validate(self):
+        ns = _parse(["templates", "validate", "--all"])
+        assert ns.all is True
+
+    def test_all_absent_on_machines_list(self):
+        """machines list never used --all — it must no longer be accepted."""
+        with patch.object(sys, "argv", ["orb", "machines", "list", "--all"]):
+            with pytest.raises(SystemExit) as exc_info:
+                parse_args()
+        assert exc_info.value.code == 2
+
+    def test_all_absent_on_config_show(self):
+        """config show never used --all — it must no longer be accepted."""
+        with patch.object(sys, "argv", ["orb", "config", "show", "--all"]):
+            with pytest.raises(SystemExit) as exc_info:
+                parse_args()
+        assert exc_info.value.code == 2
+
+
+class TestHostFactoryCompatFlags:
+    """-f/-d resolve to hf_file/hf_data only on HostFactory-invoked commands."""
+
+    def test_hf_file_on_machines_request(self):
+        ns = _parse(["machines", "request", "-f", "/tmp/in.json"])
+        assert ns.hf_file == "/tmp/in.json"
+
+    def test_hf_data_on_requests_status(self):
+        ns = _parse(["requests", "status", "-d", '{"x":1}'])
+        assert ns.hf_data == '{"x":1}'
+
+    def test_hf_flags_absent_on_config_show(self):
+        """config show is not HF-invoked — -f must not be accepted there."""
+        with patch.object(sys, "argv", ["orb", "config", "show", "-f", "/tmp/x"]):
+            with pytest.raises(SystemExit) as exc_info:
+                parse_args()
+        assert exc_info.value.code == 2
+
+
 class TestRequestsWatch:
     """requests watch positional and flag arguments."""
 

--- a/tests/unit/cli/test_common_args.py
+++ b/tests/unit/cli/test_common_args.py
@@ -171,10 +171,11 @@ class TestAddProviderTypeArg:
 class TestBuildParserNoConflict:
     """Guard against the argparse conflict error that caused 104 test failures.
 
-    build_parser() calls add_global_arguments() on every leaf subparser and
-    also attaches --provider-type on init.  If the same parser ever receives
-    two registrations of the same flag, argparse raises ValueError immediately.
-    This test ensures that never happens.
+    build_parser() composes intent-grouped parent parsers (common/list/write/
+    provider-scope/hf-compat) onto every leaf subparser via parents=[...] and
+    also attaches --provider-type on init.  If a parser ever composes two
+    parents that both declare the same option string, argparse raises
+    ArgumentError at build time.  This test ensures that never happens.
     """
 
     def test_build_parser_raises_no_argparse_conflict(self):

--- a/tests/unit/config/test_configuration_manager_coverage.py
+++ b/tests/unit/config/test_configuration_manager_coverage.py
@@ -352,16 +352,6 @@ class TestSchedulerProviderOverrides:
         mgr._provider_manager.get_scheduler_strategy.return_value = "default"
         assert mgr.get_scheduler_strategy() == "default"
 
-    def test_override_provider_name(self):
-        mgr = self._make_mgr()
-        mgr.override_provider_name("aws-east")
-        assert mgr.get_active_provider_name_override() == "aws-east"
-
-    def test_override_provider_type(self):
-        mgr = self._make_mgr()
-        mgr.override_provider_type("k8s")
-        assert mgr.get_active_provider_type_override() == "k8s"
-
 
 # ---------------------------------------------------------------------------
 # get_loaded_config_file
@@ -393,6 +383,44 @@ class TestGetLoadedConfigFile:
             result = mgr.get_loaded_config_file()
 
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_source_config_file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetSourceConfigFile:
+    def test_returns_construction_path_when_it_exists(self, tmp_path):
+        from orb.config.managers.configuration_manager import ConfigurationManager
+
+        p = tmp_path / "config.json"
+        p.write_text("{}")
+        mgr = ConfigurationManager(config_file=str(p), config_dict={})
+        mgr._raw_config = {}
+        assert mgr.get_source_config_file() == str(p)
+
+    def test_returns_none_when_construction_path_absent(self, tmp_path):
+        from orb.config.managers.configuration_manager import ConfigurationManager
+
+        mgr = ConfigurationManager(config_file=str(tmp_path / "missing.json"), config_dict={})
+        mgr._raw_config = {}
+        assert mgr.get_source_config_file() is None
+
+    def test_does_not_synthesise_from_env(self, tmp_path, monkeypatch):
+        # An in-memory config with no backing file must not resolve a save
+        # target from ORB_CONFIG_FILE even when that file exists on disk.
+        from orb.config.managers.configuration_manager import ConfigurationManager
+
+        env_file = tmp_path / "env_config.json"
+        env_file.write_text("{}")
+        monkeypatch.setenv("ORB_CONFIG_FILE", str(env_file))
+
+        mgr = ConfigurationManager(config_dict={})
+        mgr._config_file = None
+        mgr._raw_config = {}
+        assert mgr.get_source_config_file() is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/config/test_platform_dirs.py
+++ b/tests/unit/config/test_platform_dirs.py
@@ -11,6 +11,7 @@ from orb.config.platform_dirs import (
     get_root_location,
     get_scripts_location,
     get_work_location,
+    resolve_config_file,
 )
 
 # ---------------------------------------------------------------------------
@@ -155,3 +156,63 @@ def test_root_config_dir_infers_root(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ORB_ROOT_DIR", raising=False)
     monkeypatch.setenv("ORB_CONFIG_DIR", "/some/config")
     assert get_root_location() == Path("/some")
+
+
+# ---------------------------------------------------------------------------
+# resolve_config_file — single source of truth for config-file discovery
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_config_file_explicit_path_wins(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.delenv("ORB_CONFIG_FILE", raising=False)
+    monkeypatch.delenv("ORB_CONFIG_DIR", raising=False)
+    explicit = tmp_path / "explicit.json"
+    explicit.write_text("{}")
+    assert resolve_config_file("config.json", explicit_path=str(explicit)) == explicit
+
+
+def test_resolve_config_file_env_file_wins_over_config_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    env_file = tmp_path / "envfile.json"
+    env_file.write_text("{}")
+    cfg_dir = tmp_path / "cfgdir"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text("{}")
+    monkeypatch.setenv("ORB_CONFIG_FILE", str(env_file))
+    monkeypatch.setenv("ORB_CONFIG_DIR", str(cfg_dir))
+    assert resolve_config_file("config.json") == env_file
+
+
+def test_resolve_config_file_config_dir_used_when_no_env_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.delenv("ORB_CONFIG_FILE", raising=False)
+    cfg_dir = tmp_path / "cfgdir"
+    cfg_dir.mkdir()
+    target = cfg_dir / "config.json"
+    target.write_text("{}")
+    monkeypatch.setenv("ORB_CONFIG_DIR", str(cfg_dir))
+    assert resolve_config_file("config.json") == target
+
+
+def test_resolve_config_file_returns_none_when_absent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.delenv("ORB_CONFIG_FILE", raising=False)
+    monkeypatch.setenv("ORB_CONFIG_DIR", str(tmp_path / "empty"))
+    monkeypatch.setattr("orb.config.platform_dirs.get_config_location", lambda: tmp_path / "nope")
+    # Home fallback almost certainly absent under tmp; explicit path missing too.
+    assert resolve_config_file("config.json", explicit_path=str(tmp_path / "x.json")) is None
+
+
+def test_resolve_config_file_honours_custom_filename(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.delenv("ORB_CONFIG_FILE", raising=False)
+    cfg_dir = tmp_path / "cfgdir"
+    cfg_dir.mkdir()
+    target = cfg_dir / "awsprov_templates.json"
+    target.write_text("{}")
+    monkeypatch.setenv("ORB_CONFIG_DIR", str(cfg_dir))
+    assert resolve_config_file("awsprov_templates.json") == target

--- a/tests/unit/infrastructure/adapters/coverage_gap/test_configuration_adapter.py
+++ b/tests/unit/infrastructure/adapters/coverage_gap/test_configuration_adapter.py
@@ -253,9 +253,9 @@ class TestGetMetricsConfig:
 
 
 class TestSaveConfig:
-    def test_save_config_uses_loaded_file_path_when_no_path_given(self):
+    def test_save_config_uses_source_file_path_when_no_path_given(self):
         adapter, cm = _make_adapter()
-        cm.get_loaded_config_file.return_value = "/etc/orb/config.yaml"
+        cm.get_source_config_file.return_value = "/etc/orb/config.yaml"
 
         result = adapter.save_config()
 
@@ -270,12 +270,24 @@ class TestSaveConfig:
         cm.save.assert_called_once_with("/tmp/my_config.yaml")
         assert result == "/tmp/my_config.yaml"
 
-    def test_save_config_raises_when_no_path_resolvable(self):
+    def test_save_config_raises_when_no_source_file(self):
         adapter, cm = _make_adapter()
-        cm.get_loaded_config_file.return_value = None
+        cm.get_source_config_file.return_value = None
 
         with pytest.raises(ValueError, match="No config file path resolved"):
             adapter.save_config()
+
+    def test_save_config_ignores_discovered_file_that_was_not_loaded(self):
+        # get_loaded_config_file may resolve a candidate that exists on disk but
+        # was never the loaded source; save_config(None) must not write there.
+        adapter, cm = _make_adapter()
+        cm.get_source_config_file.return_value = None
+        cm.get_loaded_config_file.return_value = "/etc/orb/discovered.yaml"
+
+        with pytest.raises(ValueError, match="No config file path resolved"):
+            adapter.save_config()
+
+        cm.save.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -530,26 +542,6 @@ class TestDelegationMethods:
         adapter, cm = _make_adapter()
         adapter.override_scheduler_strategy("hostfactory")
         cm.override_scheduler_strategy.assert_called_once_with("hostfactory")
-
-    def test_override_provider_name_delegates(self):
-        adapter, cm = _make_adapter()
-        adapter.override_provider_name("my-provider")
-        cm.override_provider_name.assert_called_once_with("my-provider")
-
-    def test_override_provider_type_delegates(self):
-        adapter, cm = _make_adapter()
-        adapter.override_provider_type("k8s")
-        cm.override_provider_type.assert_called_once_with("k8s")
-
-    def test_get_active_provider_name_override_delegates(self):
-        adapter, cm = _make_adapter()
-        cm.get_active_provider_name_override.return_value = "my-prov"
-        assert adapter.get_active_provider_name_override() == "my-prov"
-
-    def test_get_active_provider_type_override_delegates(self):
-        adapter, cm = _make_adapter()
-        cm.get_active_provider_type_override.return_value = "aws"
-        assert adapter.get_active_provider_type_override() == "aws"
 
     def test_get_configuration_value_delegates(self):
         adapter, cm = _make_adapter()

--- a/tests/unit/infrastructure/scheduler/test_symphony_hostfactory_strategy.py
+++ b/tests/unit/infrastructure/scheduler/test_symphony_hostfactory_strategy.py
@@ -21,6 +21,8 @@ class TestSymphonyHostFactorySchedulerStrategy:
             "scheduler": {"type": "hostfactory", "config_root": "/test/config"},
             "provider": {"active_provider": "aws-default"},
         }
+        # get_config_file_path resolves the root via SchedulerConfig.get_config_root()
+        mock_app_config.scheduler.get_config_root.return_value = "/test/config"
         self.mock_config_manager.app_config = mock_app_config
 
         self.mock_logger = Mock()
@@ -41,6 +43,7 @@ class TestSymphonyHostFactorySchedulerStrategy:
             "scheduler": {"config_root": "/test/config"},
             "provider": {"active_provider": "provider1-production"},
         }
+        mock_app_config.scheduler.get_config_root.return_value = "/test/config"
         self.mock_config_manager.app_config = mock_app_config
 
         config_path = self.strategy.get_config_file_path()

--- a/tests/unit/infrastructure/test_configuration_manager.py
+++ b/tests/unit/infrastructure/test_configuration_manager.py
@@ -217,24 +217,6 @@ class TestConfigurationManager:
             f"Found AWS-specific methods that should be renamed: {aws_methods}"
         )
 
-    def test_override_provider_name(self, tmp_path):
-        """Test overriding provider by exact instance name."""
-        config_file = tmp_path / "config.json"
-        config_file.write_text(json.dumps({}))
-
-        manager = ConfigurationManager(config_file=str(config_file))
-        manager.override_provider_name("aws-us-east-1")
-        assert manager.get_active_provider_name_override() == "aws-us-east-1"
-
-    def test_override_provider_type(self, tmp_path):
-        """Test overriding provider type filter."""
-        config_file = tmp_path / "config.json"
-        config_file.write_text(json.dumps({}))
-
-        manager = ConfigurationManager(config_file=str(config_file))
-        manager.override_provider_type("k8s")
-        assert manager.get_active_provider_type_override() == "k8s"
-
     def test_override_scheduler_strategy(self, tmp_path):
         """Test overriding scheduler strategy."""
         config_file = tmp_path / "config.json"

--- a/tests/unit/providers/registry/test_provider_registry_selection.py
+++ b/tests/unit/providers/registry/test_provider_registry_selection.py
@@ -45,8 +45,6 @@ def _make_config_port(providers, selection_policy="FIRST_AVAILABLE"):
 
     config_port = MagicMock(spec=ConfigurationPort)
     config_port.get_provider_config.return_value = provider_config
-    config_port.get_active_provider_name_override.return_value = None
-    config_port.get_active_provider_type_override.return_value = None
     return config_port
 
 

--- a/tests/unit/test_injectable_migration.py
+++ b/tests/unit/test_injectable_migration.py
@@ -96,20 +96,6 @@ class MockConfigurationPort(ConfigurationPort):
         """Get metrics configuration."""
         return self._config.get("metrics", {})
 
-    def get_active_provider_name_override(self) -> str | None:
-        """Get current provider name override from CLI."""
-        return None
-
-    def get_active_provider_type_override(self) -> str | None:
-        """Get current provider type override from CLI."""
-        return None
-
-    def override_provider_name(self, provider_name: str) -> None:
-        """Override the active provider by exact instance name."""
-
-    def override_provider_type(self, provider_type: str) -> None:
-        """Restrict selection to a provider type."""
-
     def override_provider_region(self, region: str) -> None:
         """Override the provider region for this session."""
 

--- a/tests/unit/test_spot_fleet_ordering.py
+++ b/tests/unit/test_spot_fleet_ordering.py
@@ -159,7 +159,6 @@ class TestFleetRoleResolutionPassesValidation:
         provider.config = {"fleet_role": "AWSServiceRoleForEC2SpotFleet"}
         provider_config.providers = [provider]
         config_port.get_provider_config.return_value = provider_config
-        config_port.get_active_provider_name_override.return_value = None
 
         # Use a real validator so we confirm it actually passes
         aws_client = MagicMock()


### PR DESCRIPTION
## Description
Consolidates the CLI argument schema around a small set of intent-based **ParentParsers** (common, list, write, provider-scope, hf-compat). Subcommands are now composed from these shared parsers instead of ~40 hand-written `add_global_arguments` calls.

Because flags are declared once on a shared parent and composed in, duplicate flags now raise at parser **build-time** rather than surfacing as confusing conflicts at parse-time. This PR also fixes the long-standing `-f`/`--file` destination collision, consolidates the provider filter into a single request-scoped conduit, tightens `--all` scoping, and single-sources config-file discovery.

### What / Why
- **Intent-based parent parsers** — replace ~40 manual `add_global_arguments` calls; each flag is declared once, so collisions fail fast at build-time.
- **`-f`/`--file` dest collision** — each parser now uses a single, unambiguous `dest`, removing the ambiguity between the two flags.
- **Provider-filter conduit** — the provider filter now travels on the query/command DTO (request-scoped) instead of being smuggled through container state. This removes the `ConfigurationPort` override methods and the matching `ConfigurationManager` private fields.
- **`--all` scoping** — moved from the global flag set to per-command opt-in for commands that actually support it.
- **Config-file discovery** — single-sourced through `platform_dirs.resolve_config_file()`.

## Type of Change
- [x] Code cleanup or refactor
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related Issues
N/A

## How Has This Been Tested?
- [x] Unit tests added/updated
- [x] Integration tests added/updated

### Intentional CLI behavior changes
- `--all` is **no longer a global flag**; it is now per-command opt-in for commands that support it.
- `--yes` is now **scoped to write commands** only.
- The provider filter is passed on the **request DTO**, no longer via shared container state.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Migration Guide
- Scripts relying on `--all` as a global flag must move it to the specific command that supports it.
- `--yes` is only accepted on write commands now.
- Any tooling that relied on the provider filter being set via container/configuration state should pass it as part of the request instead.

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications

## Reviewers
@finos/open-resource-broker-maintainers
