### PR TITLE
ci(sdk): unify SDK publishing — GitHub Packages, config-driven multi-registry, one release train

### DIFF
--- a/.github/actions/get-config/action.yml
+++ b/.github/actions/get-config/action.yml
@@ -28,6 +28,15 @@ outputs:
   short-name:
     description: 'Short CLI command name (project.short_name in .project.yml)'
     value: ${{ steps.config.outputs.short-name }}
+  npm-targets:
+    description: 'JSON array of enabled npm publish destinations (e.g. ["github","npmjs"])'
+    value: ${{ steps.config.outputs.npm-targets }}
+  maven-targets:
+    description: 'JSON array of enabled maven publish destinations (e.g. ["github","central"])'
+    value: ${{ steps.config.outputs.maven-targets }}
+  nuget-targets:
+    description: 'JSON array of enabled nuget publish destinations (e.g. ["github","nuget_org"])'
+    value: ${{ steps.config.outputs.nuget-targets }}
 runs:
   using: 'composite'
   steps:
@@ -48,7 +57,27 @@ runs:
         PYPI_NAME=$(yq '.project.pypi_name' .project.yml)
         BUILD_PLATFORMS=$(yq '.build.platforms | join(",")' .project.yml)
         SHORT_NAME=$(yq '.project.short_name' .project.yml)
-        
+
+        # SDK publish targets: emit a compact JSON array of only the enabled
+        # destinations per language, read from the .sdk_publish booleans.
+        # 'github' is the always-on default; public destinations flip on when
+        # their booleans are set to true. Missing/false keys are omitted.
+        # fromJSON(...) in the workflows turns each array into a job matrix.
+        build_targets() {
+          # $1 = yq path to the destination block, remaining args = dest names
+          local path="$1"; shift
+          local items=""
+          for dest in "$@"; do
+            if [[ "$(yq "(${path}.${dest} // false) == true" .project.yml)" == "true" ]]; then
+              items="${items:+$items,}\"$dest\""
+            fi
+          done
+          echo "[$items]"
+        }
+        NPM_TARGETS=$(build_targets ".sdk_publish.npm" github npmjs)
+        MAVEN_TARGETS=$(build_targets ".sdk_publish.maven" github central)
+        NUGET_TARGETS=$(build_targets ".sdk_publish.nuget" github nuget_org)
+
         # Centralized version generation using Makefile infrastructure
         if [[ "${{ github.event_name }}" == "release" ]]; then
           # Only actual release events are treated as releases
@@ -70,6 +99,9 @@ runs:
           echo "pypi-name=$PYPI_NAME"
           echo "build-platforms=$BUILD_PLATFORMS"
           echo "short-name=$SHORT_NAME"
+          echo "npm-targets=$NPM_TARGETS"
+          echo "maven-targets=$MAVEN_TARGETS"
+          echo "nuget-targets=$NUGET_TARGETS"
         } >> "$GITHUB_OUTPUT"
 
         echo "Default Python version: $DEFAULT_PYTHON_VERSION"
@@ -81,3 +113,6 @@ runs:
         echo "PyPI name: $PYPI_NAME"
         echo "Build platforms: $BUILD_PLATFORMS"
         echo "Short name: $SHORT_NAME"
+        echo "npm targets: $NPM_TARGETS"
+        echo "maven targets: $MAVEN_TARGETS"
+        echo "nuget targets: $NUGET_TARGETS"

--- a/.github/workflows/dev-pypi.yml
+++ b/.github/workflows/dev-pypi.yml
@@ -16,12 +16,21 @@ env:
 
 on:
   # Trigger only after Unit Tests pass so TestPyPI always receives a package
-  # that has passed the quality gate.  Using a single sentinel workflow avoids
+  # that has passed the test suite.  Using a single sentinel workflow avoids
   # the double-fire that occurs when multiple entries in the workflows list
   # complete independently on the same push — both would fire and the second
   # publish attempt would fail with "version already exists".
-  # Unit Tests is the right sentinel: it is the comprehensive per-push gate
-  # and its completion implies the Quality Checks gate ran first (via needs).
+  #
+  # Unit Tests is the single sentinel by design.  It does NOT run the Quality
+  # Checks (ruff / pyright / architecture validation): those live in the
+  # separate "Quality Checks" workflow (ci-quality.yml), which runs in parallel
+  # and is NOT a `needs:` dependency of Unit Tests — a job cannot depend on a
+  # job in a different workflow file.  A push that passes Unit Tests but fails
+  # a quality check would therefore still reach this workflow.  To close that
+  # gap WITHOUT adding a second workflow_run sentinel (which would reintroduce
+  # the double-fire / double-publish described above), the `quality-gate` job
+  # below queries the GitHub API for the Quality Checks run on this exact commit
+  # (workflow_run.head_sha) and blocks the release unless it concluded 'success'.
   workflow_run:
     workflows: ["Unit Tests"]
     types: [completed]
@@ -39,10 +48,84 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Cross-workflow quality gate.  Unit Tests (the workflow_run sentinel) does
+  # NOT include ruff / pyright / architecture validation — those run in the
+  # separate "Quality Checks" workflow.  Because a job cannot `needs:` a job in
+  # another workflow file, we enforce the dependency here at runtime: block the
+  # release unless the Quality Checks run for THIS commit concluded 'success'.
+  # This preserves the single-sentinel design (no second workflow_run trigger,
+  # so no double-fire / double-publish) while closing the gate hole.
+  quality-gate:
+    name: Quality Checks Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Same guard as config: skip when the sentinel Unit Tests run did not
+    # succeed.  For manual workflow_dispatch there is no upstream run to
+    # inspect, so the API step below is skipped and this job passes as a
+    # deliberate no-op (manual publish is an authorized override).
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read   # read the Quality Checks workflow run conclusion
+      contents: read
+    steps:
+    - name: Require Quality Checks success on this commit
+      if: github.event_name == 'workflow_run'
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        set -euo pipefail
+
+        # Look up the "Quality Checks" run (ci-quality.yml) for the exact commit
+        # that the sentinel Unit Tests run tested.  Quality Checks runs in
+        # parallel with Unit Tests and usually finishes first, but it may lag,
+        # so poll for a bounded window before deciding.
+        attempts=30
+        sleep_s=20
+        latest=""
+        for i in $(seq 1 "$attempts"); do
+          latest=$(gh api \
+            "/repos/${REPO}/actions/workflows/ci-quality.yml/runs?head_sha=${HEAD_SHA}&per_page=100" \
+            --jq '[.workflow_runs[]] | sort_by(.created_at) | last // empty | {status: .status, conclusion: .conclusion}')
+
+          if [ -z "$latest" ]; then
+            # No Quality Checks run exists for this commit.  Quality Checks has a
+            # path filter (src/**, tests/**, pyproject.toml, requirements*.txt,
+            # uv.lock, .ruff.toml) that is a superset of everything affecting
+            # ruff/pyright/arch outcomes.  No run means no quality-relevant file
+            # changed on this commit, so the quality status is unchanged and it
+            # is safe to proceed.
+            echo "No Quality Checks run for ${HEAD_SHA}; no quality-relevant paths changed. Allowing release."
+            exit 0
+          fi
+
+          status=$(echo "$latest" | jq -r '.status')
+          if [ "$status" = "completed" ]; then
+            break
+          fi
+          echo "Quality Checks still running for ${HEAD_SHA} (attempt ${i}/${attempts}); waiting ${sleep_s}s..."
+          sleep "$sleep_s"
+        done
+
+        status=$(echo "$latest" | jq -r '.status')
+        conclusion=$(echo "$latest" | jq -r '.conclusion')
+
+        if [ "$status" != "completed" ]; then
+          echo "::error::Quality Checks did not complete for ${HEAD_SHA} within the wait window. Blocking release."
+          exit 1
+        fi
+        if [ "$conclusion" != "success" ]; then
+          echo "::error::Quality Checks concluded '${conclusion}' (not success) for ${HEAD_SHA}. Blocking release."
+          exit 1
+        fi
+        echo "Quality Checks succeeded for ${HEAD_SHA}. Proceeding with release."
+
   config:
     name: Get Configuration
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: [quality-gate]
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     outputs:
       default-python-version: ${{ steps.config.outputs.default-python-version }}

--- a/.github/workflows/dev-sdk.yml
+++ b/.github/workflows/dev-sdk.yml
@@ -1,0 +1,82 @@
+name: Dev SDK Publishing
+
+# ---------------------------------------------------------------------------
+# SDK TEST CHANNEL — the SDK equivalent of the TestPyPI wheel (dev-pypi.yml).
+#
+# This workflow publishes DEV-versioned SDKs (1.x.y.devN) to GitHub Packages
+# ONLY, on every main push that passes CI.  It is the symmetric counterpart to
+# dev-pypi.yml: where that publishes the dev wheel to TestPyPI, this publishes
+# the dev SDKs to GitHub Packages so consumers can smoke-test the latest SDKs
+# straight off main before a release.
+#
+# GitHub Packages only: public registries (npm.js, Maven Central, NuGet.org) are
+# the PRODUCTION distribution channels and are handled exclusively by
+# prod-release.yml on a real GitHub Release.  This test channel never touches
+# them — it passes ["github"] for every language so only GitHub Packages
+# receives the dev build.  Go is a no-op on the test channel (its dev
+# distribution is pseudo-versions served by the module proxy straight off the
+# commit — `go get .../sdk/go@<commit>` — so nothing needs publishing).
+#
+# The actual publish logic lives in reusable-sdk-publish.yml (shared with the
+# release channel) so it is defined ONCE.
+# ---------------------------------------------------------------------------
+
+on:
+  # Trigger only after Unit Tests pass so GitHub Packages always receives SDKs
+  # that have passed the quality gate.  Using the single "Unit Tests" sentinel
+  # (rather than several workflows) avoids the double-fire that occurs when
+  # multiple entries in the workflows list complete independently on the same
+  # push.  This mirrors dev-pypi.yml exactly so the TestPyPI wheel and the dev
+  # SDKs publish off the same gate.
+  workflow_run:
+    workflows: ["Unit Tests"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force publish even if version exists'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: "sdk-dev-publishing"
+  cancel-in-progress: false
+
+jobs:
+  config:
+    name: Get Configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Guard the workflow_run path on a successful upstream run, exactly like
+    # dev-pypi.yml.  workflow_dispatch (force) always runs.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    outputs:
+      package-version: ${{ steps.config.outputs.package-version }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+    - name: Get project configuration
+      id: config
+      uses: ./.github/actions/get-config
+
+  publish:
+    name: Publish Dev SDKs to GitHub Packages
+    needs: [config]
+    # Reuse the same publish logic as the release channel.  channel: test forces
+    # the github-only destinations and makes the Go job a no-op.
+    #
+    # Version collision: the config job computes a SHA-derived dev version
+    # (1.x.y.devN) via `make get-version` for non-release events, so every main
+    # push produces a UNIQUE version — GitHub Packages never sees a duplicate
+    # and the publish never collides with a prior dev build.
+    uses: ./.github/workflows/reusable-sdk-publish.yml
+    secrets: inherit
+    with:
+      channel: test
+      version: ${{ needs.config.outputs.package-version }}
+      npm-targets: '["github"]'
+      maven-targets: '["github"]'
+      nuget-targets: '["github"]'

--- a/.github/workflows/dev-sdk.yml
+++ b/.github/workflows/dev-sdk.yml
@@ -52,11 +52,23 @@ jobs:
     # Guard the workflow_run path on a successful upstream run, exactly like
     # dev-pypi.yml.  workflow_dispatch (force) always runs.
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read  # only needs to read the repo to derive the dev version
     outputs:
       package-version: ${{ steps.config.outputs.package-version }}
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        # Pin to the exact commit Unit Tests validated.  On workflow_run the
+        # default checkout resolves to the default-branch HEAD at execution
+        # time, so `make get-version` (which derives the dev version from
+        # `git rev-parse HEAD`) would compute the version off the WRONG commit
+        # — and could build/publish an untested commit if main advanced, or
+        # race with another dev-sdk run to a colliding version.  The
+        # `|| github.sha` fallback keeps workflow_dispatch working, where
+        # workflow_run.head_sha is empty.
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     - name: Get project configuration
       id: config
@@ -73,6 +85,17 @@ jobs:
     # push produces a UNIQUE version — GitHub Packages never sees a duplicate
     # and the publish never collides with a prior dev build.
     uses: ./.github/workflows/reusable-sdk-publish.yml
+    # A reusable workflow cannot elevate beyond the token permissions of its
+    # caller, so the caller job must grant everything the reusable jobs need.
+    # Without this block the publish job would inherit only the repository
+    # DEFAULT permissions, capping the reusable jobs' `packages: write`
+    # (GitHub Packages push would be denied) and `id-token: write` (npm
+    # provenance would fail).  prod-release.yml grants these explicitly; the
+    # test channel must too.
+    permissions:
+      contents: read
+      packages: write   # push dev SDKs to GitHub Packages (the test channel)
+      id-token: write   # npm provenance / OIDC parity with the release channel
     secrets: inherit
     with:
       channel: test

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -9,6 +9,24 @@ on:
         description: 'Release version (e.g., 1.0.0)'
         required: true
         type: string
+      # One-off SDK bootstrap: publish a single SDK to a single registry
+      # WITHOUT cutting a release. Used to seed a package name on a public
+      # registry the first time (e.g. before npm trusted-publishing can be
+      # attached, which requires the package to already exist). Leave
+      # bootstrap_sdk = none for a normal manual dispatch (which publishes
+      # nothing — every real publish job is release-gated).
+      bootstrap_sdk:
+        description: 'One-off: which SDK to publish (maven = java + kotlin)'
+        required: false
+        default: 'none'
+        type: choice
+        options: [none, npm, maven, nuget]
+      bootstrap_destination:
+        description: 'One-off: destination registry for the chosen SDK'
+        required: false
+        default: 'github'
+        type: choice
+        options: [github, npmjs, central, nuget_org]
 
 permissions:
   contents: read
@@ -34,6 +52,9 @@ jobs:
       pypi-name: ${{ steps.config.outputs.pypi-name }}
       build-platforms: ${{ steps.config.outputs.build-platforms }}
       short-name: ${{ steps.config.outputs.short-name }}
+      npm-targets: ${{ steps.config.outputs.npm-targets }}
+      maven-targets: ${{ steps.config.outputs.maven-targets }}
+      nuget-targets: ${{ steps.config.outputs.nuget-targets }}
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -598,20 +619,23 @@ jobs:
         gh release upload "$RELEASE_TAG" "$BUNDLE_DEST" --clobber
 
   # ---------------------------------------------------------------------------
-  # SDK publish jobs — all gated on github.event_name == 'release' to match
-  # prod-pypi's gating pattern exactly.  Each job is self-contained so that a
-  # single registry failure does not block the others.
+  # SDK publishing — moved into reusable-sdk-publish.yml (invoked by the
+  # sdk-publish caller job below) so the same publish logic serves BOTH the
+  # release channel (here) and the TEST channel (dev-sdk.yml -> GitHub Packages).
   #
   # Go SDK distribution note:
-  #   There is no sdk-publish-go job.  Go distribution is tag-based: the Go
-  #   module proxy (proxy.golang.org) serves the SDK at
-  #   github.com/finos/open-resource-broker/sdk/go when the git tag
-  #   sdk/go/vX.Y.Z exists on the default branch.  The make sdk-go-update-version
-  #   target (makefiles/ci.mk) creates and pushes this tag automatically as part
-  #   of the release commit.  No registry credentials are needed.
+  #   Go distribution is tag-based: the Go module proxy (proxy.golang.org) serves
+  #   the SDK at github.com/finos/open-resource-broker/sdk/go when the git tag
+  #   sdk/go/vX.Y.Z exists on the default branch.  The sdk-publish-go job inside
+  #   reusable-sdk-publish.yml creates and pushes this tag (make sdk-go-tag) on
+  #   the release channel, pointing at the vX.Y.Z release commit, whose contents
+  #   already include the bumped sdk/go/orb/version.go (stamped in the
+  #   semantic-release build hook).  It authenticates with the ORB CICD App token
+  #   because the tag push targets a possibly branch-protected ref.  This used to
+  #   be the "Tag Go SDK module" step in semantic-release.yml.
   # ---------------------------------------------------------------------------
 
-  # Gate every SDK publish job on a passing static spec-conformance check for
+  # Gate the SDK publish caller on a passing static spec-conformance check for
   # THIS release commit.  The SDK build+contract workflow (sdk.yml) is
   # path-filtered (sdk/** plus the API source that shapes the exported spec), so
   # a release commit that touched none of those paths would never have run it —
@@ -632,302 +656,203 @@ jobs:
     - name: Check parity scenario against the OpenAPI spec
       run: python3 dev-tools/quality/validate_sdk_spec_conformance.py
 
-  sdk-publish-npm:
-    name: Publish TypeScript SDK to npm
+  # ---------------------------------------------------------------------------
+  # Unified SDK publish (release channel).  The npm/maven/kotlin/nuget/go publish
+  # jobs live in reusable-sdk-publish.yml so the publish logic is defined ONCE
+  # and shared with the TEST channel (dev-sdk.yml -> GitHub Packages).  This
+  # caller forwards the release version and the per-language destination arrays
+  # computed by get-config (.project.yml -> npm/maven/nuget targets).
+  #
+  # Gating: only on a real GitHub Release (mirrors prod-pypi) and only AFTER the
+  # sdk-spec-conformance gate passes for THIS release commit — the reusable
+  # workflow deliberately does NOT re-run that static gate, so the release
+  # caller enforces it here via needs.
+  # ---------------------------------------------------------------------------
+  sdk-publish:
+    name: Publish SDKs (release)
     needs: [config, github-assets, sdk-spec-conformance]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    # Mirror prod-pypi: only publish on a real GitHub Release, never on
-    # manual workflow_dispatch (which would push a dev-version to npm).
     if: github.event_name == 'release'
-    permissions:
-      contents: read
-      id-token: write    # npm provenance attestation
+    uses: ./.github/workflows/reusable-sdk-publish.yml
+    secrets: inherit
+    with:
+      channel: release
+      version: ${{ needs.config.outputs.package-version }}
+      npm-targets: ${{ needs.config.outputs.npm-targets }}
+      maven-targets: ${{ needs.config.outputs.maven-targets }}
+      nuget-targets: ${{ needs.config.outputs.nuget-targets }}
 
-    # Required secrets:
-    #   NODE_AUTH_TOKEN — npm automation token scoped to the @finos org.
-    #   Configure at: https://www.npmjs.com/settings/<org>/tokens
-    #   Add to repo: Settings > Secrets > Actions > NODE_AUTH_TOKEN
+  # ---------------------------------------------------------------------------
+  # One-off SDK bootstrap (manual dispatch only). Publishes exactly ONE SDK to
+  # ONE registry, off a release, so a package name can be seeded on a public
+  # registry the first time (npm/NuGet trusted-publishing both require the
+  # package to already exist before a policy can be attached — see the
+  # publishing runbook). The chosen SDK gets a one-element target array; the
+  # other two get '[]' so their matrices are empty and those jobs no-op.
+  # Reuses the exact same publish logic as the release channel.
+  # ---------------------------------------------------------------------------
+  sdk-bootstrap:
+    name: Bootstrap one SDK (${{ github.event.inputs.bootstrap_sdk }} -> ${{ github.event.inputs.bootstrap_destination }})
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.bootstrap_sdk != 'none'
+    uses: ./.github/workflows/reusable-sdk-publish.yml
+    secrets: inherit
+    with:
+      # 'bootstrap' channel: same publish logic as release, but the Go tag job
+      # (gated if: channel == 'release') stays OFF — bootstrap only ever seeds
+      # ONE registry SDK, never the Go module tag.
+      channel: bootstrap
+      version: ${{ github.event.inputs.version }}
+      npm-targets: ${{ github.event.inputs.bootstrap_sdk == 'npm' && format('["{0}"]', github.event.inputs.bootstrap_destination) || '[]' }}
+      maven-targets: ${{ github.event.inputs.bootstrap_sdk == 'maven' && format('["{0}"]', github.event.inputs.bootstrap_destination) || '[]' }}
+      nuget-targets: ${{ github.event.inputs.bootstrap_sdk == 'nuget' && format('["{0}"]', github.event.inputs.bootstrap_destination) || '[]' }}
 
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-
-    - name: Set up Node.js 20 (with npm registry auth)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
-      with:
-        node-version: '20'
-        registry-url: 'https://registry.npmjs.org'
-
-    # openapi-generator needs a JVM; generated models are gitignored and MUST be
-    # produced here or the published package ships with no model types.
-    - name: Set up Java (Corretto 17) — openapi-generator
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
-      with:
-        java-version: '17'
-        distribution: 'corretto'
-
-    - name: Install openapi-generator-cli
-      run: npx --yes @openapitools/openapi-generator-cli version-manager set 7.23.0
-
-    # REQUIRED: generated models are gitignored (0 committed files). Without this
-    # step the published npm package would contain no model types and fail to build.
-    - name: Generate TypeScript SDK models
-      run: make sdk-typescript-generate
-
-    - name: Install TypeScript SDK dependencies
-      run: cd sdk/typescript && npm ci
-
-    - name: Set SDK version from release tag
-      # Release tags are v<VERSION>; strip the leading 'v' for npm.
-      run: |
-        VERSION="${{ needs.config.outputs.package-version }}"
-        cd sdk/typescript && npm version "$VERSION" --no-git-tag-version
-
-    - name: Build TypeScript SDK
-      run: cd sdk/typescript && npm run build
-
-    - name: Publish to npm
-      # NODE_AUTH_TOKEN is injected by actions/setup-node's registry-url.
-      # --provenance attaches an npm sigstore provenance statement (requires
-      # id-token: write).  The job no-ops (succeeds) when NODE_AUTH_TOKEN is
-      # empty so CI does not block on missing secrets — mirrors the maven,
-      # gradle-kotlin, and nuget publish guards.  Provision NODE_AUTH_TOKEN to
-      # enable publishing.
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-      run: |
-        if [[ -z "$NODE_AUTH_TOKEN" ]]; then
-          echo "NODE_AUTH_TOKEN is not set — skipping npm publish."
-          echo "Provision NODE_AUTH_TOKEN to enable publishing."
-          exit 0
-        fi
-        cd sdk/typescript && npm publish --access public --provenance
-
-  sdk-publish-maven:
-    name: Publish Java SDK to Maven Central
-    needs: [config, github-assets, sdk-spec-conformance]
+  # ---------------------------------------------------------------------------
+  # SDK archival assets — attach the built SDK artifacts (npm .tgz, java +
+  # kotlin .jar, .nupkg) plus a .sha256 for each to the GitHub Release.  These
+  # are ARCHIVAL only: the registries (npm/GitHub Packages, Maven, NuGet) remain
+  # the real distribution channels.  Building all four toolchains in one job
+  # would be heavy and serial, so this is a dedicated job separate from
+  # github-assets (which owns the wheel/spec/sbom/attestation).  It reuses the
+  # same generate-then-build steps as the publish jobs and is release-gated.
+  # ---------------------------------------------------------------------------
+  sdk-assets:
+    name: Attach SDK Archival Assets to Release
+    needs: [config, github-assets]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Mirror github-assets: only attach on a real GitHub Release (gh release
+    # upload needs the release tag to exist).
     if: github.event_name == 'release'
     permissions:
-      contents: read
-
-    # Required secrets (all under org.finos on Maven Central / OSSRH):
-    #   MAVEN_CENTRAL_USERNAME — Sonatype OSSRH / Central Portal username
-    #   MAVEN_CENTRAL_PASSWORD — Sonatype OSSRH / Central Portal token
-    #   MAVEN_GPG_PRIVATE_KEY  — ASCII-armored GPG private key for signing
-    #   MAVEN_GPG_PASSPHRASE   — passphrase for the GPG key
-    #
-    # Register the component at: https://central.sonatype.com/publishing/namespaces
-    # Group ID: org.finos.openresourcebroker
-    # See: https://central.sonatype.org/publish/publish-portal-guide/
+      contents: write    # gh release upload
 
     steps:
     - name: Checkout code
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-    - name: Set up Java (Corretto 17, with GPG signing)
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
-      with:
-        java-version: '17'
-        distribution: 'corretto'
-
-    # openapi-generator-cli resolves its jar via the npm package cache; Node is
-    # required even though the SDK itself builds with Gradle.
-    - name: Set up Node.js 20 (openapi-generator-cli)
+    - name: Set up Node.js 20
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       with:
         node-version: '20'
 
-    - name: Install openapi-generator-cli
-      run: npx --yes @openapitools/openapi-generator-cli version-manager set 7.23.0
-
-    # REQUIRED: generated model classes are gitignored (0 committed files).
-    # Without this step the published jar would contain no model types.
-    - name: Generate Java SDK models
-      run: make sdk-java-generate
-
-    - name: Import GPG key
-      # No-ops gracefully when MAVEN_GPG_PRIVATE_KEY is empty; the publish
-      # step surfaces the missing secret via a 401 / signing error if needed.
-      env:
-        MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-      run: |
-        if [[ -n "$MAVEN_GPG_PRIVATE_KEY" ]]; then
-          echo "$MAVEN_GPG_PRIVATE_KEY" | gpg --batch --import
-        fi
-
-    - name: Set SDK version from release tag
-      run: |
-        VERSION="${{ needs.config.outputs.package-version }}"
-        sed -i "s/^version = .*/version = '$VERSION'/" sdk/java/build.gradle
-
-    - name: Publish Java SDK to Maven Central
-      # Requires MAVEN_CENTRAL_USERNAME / MAVEN_CENTRAL_PASSWORD and the GPG
-      # secrets wired above.  The job no-ops (succeeds silently) when
-      # MAVEN_CENTRAL_USERNAME is empty so CI does not block on missing secrets;
-      # provision the secrets when ready to publish.
-      env:
-        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-      run: |
-        if [[ -z "$MAVEN_CENTRAL_USERNAME" ]]; then
-          echo "MAVEN_CENTRAL_USERNAME is not set — skipping Maven Central publish."
-          echo "Provision MAVEN_CENTRAL_USERNAME, MAVEN_CENTRAL_PASSWORD, MAVEN_GPG_PRIVATE_KEY,"
-          echo "and MAVEN_GPG_PASSPHRASE to enable publishing."
-          exit 0
-        fi
-        cd sdk/java && ./gradlew --no-daemon publish \
-          -PmavenCentralUsername="$MAVEN_CENTRAL_USERNAME" \
-          -PmavenCentralPassword="$MAVEN_CENTRAL_PASSWORD" \
-          -Psigning.gnupg.passphrase="$MAVEN_GPG_PASSPHRASE"
-
-  sdk-publish-gradle-kotlin:
-    name: Publish Kotlin SDK to Maven Central
-    needs: [config, github-assets, sdk-spec-conformance]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    if: github.event_name == 'release'
-    permissions:
-      contents: read
-
-    # Required secrets (same set as sdk-publish-maven; org.finos namespace):
-    #   MAVEN_CENTRAL_USERNAME — Sonatype OSSRH / Central Portal username
-    #   MAVEN_CENTRAL_PASSWORD — Sonatype OSSRH / Central Portal token
-    #   MAVEN_GPG_PRIVATE_KEY  — ASCII-armored GPG private key for signing
-    #   MAVEN_GPG_PASSPHRASE   — passphrase for the GPG key
-    #
-    # Artifact coordinates: org.finos.openresourcebroker:open-resource-broker-kotlin
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-
-    - name: Set up Java (Corretto 17, Kotlin runs on JVM)
+    - name: Set up Java (Corretto 17)
       uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
       with:
         java-version: '17'
         distribution: 'corretto'
-
-    # openapi-generator-cli resolves its jar via the npm package cache; Node is
-    # required even though the SDK itself builds with Gradle.
-    - name: Set up Node.js 20 (openapi-generator-cli)
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
-      with:
-        node-version: '20'
-
-    - name: Install openapi-generator-cli
-      run: npx --yes @openapitools/openapi-generator-cli version-manager set 7.23.0
-
-    # REQUIRED: generated model classes are gitignored (0 committed files).
-    # Without this step the published jar would contain no model types.
-    - name: Generate Kotlin SDK models
-      run: make sdk-kotlin-generate
-
-    - name: Import GPG key
-      env:
-        MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-      run: |
-        if [[ -n "$MAVEN_GPG_PRIVATE_KEY" ]]; then
-          echo "$MAVEN_GPG_PRIVATE_KEY" | gpg --batch --import
-        fi
-
-    - name: Set SDK version from release tag
-      run: |
-        VERSION="${{ needs.config.outputs.package-version }}"
-        sed -i "s/^version = .*/version = \"$VERSION\"/" sdk/kotlin/build.gradle.kts
-
-    - name: Publish Kotlin SDK to Maven Central
-      env:
-        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-      run: |
-        if [[ -z "$MAVEN_CENTRAL_USERNAME" ]]; then
-          echo "MAVEN_CENTRAL_USERNAME is not set — skipping Maven Central publish."
-          echo "Provision MAVEN_CENTRAL_USERNAME, MAVEN_CENTRAL_PASSWORD, MAVEN_GPG_PRIVATE_KEY,"
-          echo "and MAVEN_GPG_PASSPHRASE to enable publishing."
-          exit 0
-        fi
-        cd sdk/kotlin && ./gradlew --no-daemon publish \
-          -PmavenCentralUsername="$MAVEN_CENTRAL_USERNAME" \
-          -PmavenCentralPassword="$MAVEN_CENTRAL_PASSWORD" \
-          -Psigning.gnupg.passphrase="$MAVEN_GPG_PASSPHRASE"
-
-  sdk-publish-nuget:
-    name: Publish .NET SDK to NuGet
-    needs: [config, github-assets, sdk-spec-conformance]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    if: github.event_name == 'release'
-    permissions:
-      contents: read
-
-    # Required secrets:
-    #   NUGET_API_KEY — NuGet.org API key scoped to FINOS.OpenResourceBroker.
-    #   Obtain at: https://www.nuget.org/account/apikeys
-    #   Add to repo: Settings > Secrets > Actions > NUGET_API_KEY
-    #
-    # Package ID: FINOS.OpenResourceBroker
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
     - name: Set up .NET 8
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
       with:
         dotnet-version: '8.0.x'
 
-    # openapi-generator needs a JVM + the openapi-generator-cli npm wrapper;
-    # generated models are gitignored (0 committed files) and MUST be produced
-    # here or the packed nupkg ships with no model types.  Mirrors the npm,
-    # maven, and kotlin publish jobs.
-    - name: Set up openapi-generator toolchain
-      uses: ./.github/actions/setup-openapi-generator
+    - name: Install openapi-generator-cli
+      run: npx --yes @openapitools/openapi-generator-cli version-manager set 7.23.0
 
-    # REQUIRED: generated model classes are gitignored (0 committed files).
-    # Without this step the packed nupkg would contain no model types and the
-    # hand-written client would not compile.
-    - name: Generate C# SDK models
-      run: make sdk-csharp-generate
+    # REQUIRED: generated models are gitignored (0 committed files) for every
+    # language — regenerate before building the archival artifacts.
+    - name: Generate all SDK models
+      run: |
+        make sdk-typescript-generate
+        make sdk-java-generate
+        make sdk-kotlin-generate
+        make sdk-csharp-generate
 
-    - name: Set SDK version from release tag
+    - name: Set SDK versions from release tag
       run: |
         VERSION="${{ needs.config.outputs.package-version }}"
-        # Version the hand-written client package.
+        cd sdk/typescript && npm version "$VERSION" --no-git-tag-version && cd -
+        sed -i "s/^version = .*/version = '$VERSION'/" sdk/java/build.gradle
+        sed -i "s/^version = .*/version = \"$VERSION\"/" sdk/kotlin/build.gradle.kts
         sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" \
           sdk/csharp/src/FINOS.OpenResourceBroker/FINOS.OpenResourceBroker.csproj
-        # Version the generated model assembly too so its embedded DLL carries
-        # the release version (the client embeds this DLL into its own nupkg).
         sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" \
           sdk/csharp/generated/src/OpenResourceBroker.Sdk/OpenResourceBroker.Sdk.csproj
 
-    - name: Build and pack .NET SDK
-      # Pack the client project.  Its ProjectReference to the generated model
-      # assembly is PrivateAssets="all" + an IncludeGeneratedModelsInPackage
-      # target embeds the generated DLL into lib/net8.0/, so the models ship
-      # inside the nupkg with no dangling package dependency.
+    - name: Build SDK artifacts (tgz, jars, nupkg)
       run: |
+        mkdir -p /tmp/sdk-assets
+        # TypeScript: npm pack produces a .tgz tarball.
+        cd sdk/typescript && npm ci && npm run build
+        npm pack --pack-destination /tmp/sdk-assets
+        cd -
+        # Java: gradle build produces the jar under build/libs/.
+        cd sdk/java && ./gradlew --no-daemon build -x test
+        cp build/libs/*.jar /tmp/sdk-assets/
+        cd -
+        # Kotlin: gradle build produces the jar under build/libs/.
+        cd sdk/kotlin && ./gradlew --no-daemon build -x test
+        cp build/libs/*.jar /tmp/sdk-assets/
+        cd -
+        # .NET: dotnet pack produces the .nupkg.
         dotnet pack sdk/csharp/src/FINOS.OpenResourceBroker/FINOS.OpenResourceBroker.csproj \
           --configuration Release \
-          --output /tmp/nuget-packages
+          --output /tmp/sdk-assets
 
-    - name: Publish to NuGet
-      # If NUGET_API_KEY is not provisioned the push will fail with a 401 —
-      # all prior build/pack steps pass so the missing secret is immediately
-      # visible in the job log.
-      env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    - name: Compute SHA-256 checksums
       run: |
-        if [[ -z "$NUGET_API_KEY" ]]; then
-          echo "NUGET_API_KEY is not set — skipping NuGet publish."
-          echo "Provision NUGET_API_KEY to enable publishing."
-          exit 0
-        fi
-        dotnet nuget push /tmp/nuget-packages/*.nupkg \
-          --api-key "$NUGET_API_KEY" \
-          --source https://api.nuget.org/v3/index.json \
-          --skip-duplicate
+        cd /tmp/sdk-assets
+        for f in *; do
+          [[ "$f" == *.sha256 ]] && continue
+          sha256sum "$f" > "$f.sha256"
+        done
+        ls -la /tmp/sdk-assets
+
+    - name: Upload SDK artifacts to release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${{ needs.config.outputs.package-version }}"
+        RELEASE_TAG="v$VERSION"
+        gh release upload "$RELEASE_TAG" /tmp/sdk-assets/* --clobber
+
+  # ---------------------------------------------------------------------------
+  # Roll-up gate: the single canonical "did the release train succeed" signal.
+  # Mirrors the 'CI Passed' alls-green aggregation in ci-tests.yml.  Reads every
+  # publish + asset job's result, writes a markdown table to the step summary,
+  # and fails if ANY needed job failed or was cancelled.  Legitimately-gated
+  # 'skipped' jobs (e.g. a destination disabled in .project.yml) are treated as
+  # OK — alls-green's allowed-skips handles this.
+  # ---------------------------------------------------------------------------
+  release-complete:
+    name: Release Complete
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      - config
+      - prod-containers
+      - prod-manifests
+      - prod-pypi
+      - github-assets
+      - sdk-spec-conformance
+      - sdk-publish
+      - sdk-assets
+
+    steps:
+    - name: Write release train summary
+      # Emit a job -> result markdown table to the run summary so the release
+      # outcome is visible at a glance.
+      run: |
+        {
+          echo "## Release Train Summary"
+          echo ""
+          echo "| Job | Result |"
+          echo "| --- | --- |"
+          echo "| prod-containers | ${{ needs.prod-containers.result }} |"
+          echo "| prod-manifests | ${{ needs.prod-manifests.result }} |"
+          echo "| prod-pypi | ${{ needs.prod-pypi.result }} |"
+          echo "| github-assets | ${{ needs.github-assets.result }} |"
+          echo "| sdk-spec-conformance | ${{ needs.sdk-spec-conformance.result }} |"
+          echo "| sdk-publish | ${{ needs.sdk-publish.result }} |"
+          echo "| sdk-assets | ${{ needs.sdk-assets.result }} |"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Fail if any release job failed or was cancelled
+      # Single source of truth for the release outcome.  alls-green fails when
+      # any listed job's result is 'failure' or 'cancelled'; 'skipped' jobs
+      # (destinations gated off in .project.yml, or manual-dispatch-gated jobs)
+      # are permitted.
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
+      with:
+        jobs: ${{ toJSON(needs) }}
+        allowed-skips: prod-containers, prod-manifests, prod-pypi, github-assets, sdk-spec-conformance, sdk-publish, sdk-assets

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -672,6 +672,16 @@ jobs:
     name: Publish SDKs (release)
     needs: [config, github-assets, sdk-spec-conformance]
     if: github.event_name == 'release'
+    # A reusable workflow can only DOWNGRADE the caller's token, never elevate
+    # it. The top-level permissions block omits id-token (=none), so without
+    # this job-level grant the reusable's sdk-publish-npm job cannot get
+    # id-token: write and `npm publish --provenance` hard-fails. Grant exactly
+    # what the reusable's jobs need here (least-privilege — only this caller and
+    # sdk-bootstrap get id-token, not the whole workflow).
+    permissions:
+      contents: read
+      packages: write    # GitHub Packages push (github destination)
+      id-token: write    # npm provenance attestation + OIDC (npmjs destination)
     uses: ./.github/workflows/reusable-sdk-publish.yml
     secrets: inherit
     with:
@@ -693,6 +703,13 @@ jobs:
   sdk-bootstrap:
     name: Bootstrap one SDK (${{ github.event.inputs.bootstrap_sdk }} -> ${{ github.event.inputs.bootstrap_destination }})
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.bootstrap_sdk != 'none'
+    # Same rationale as sdk-publish: the reusable workflow cannot elevate the
+    # caller's token, so grant id-token: write here or `npm publish
+    # --provenance` fails when bootstrapping the npmjs destination.
+    permissions:
+      contents: read
+      packages: write    # GitHub Packages push (github destination)
+      id-token: write    # npm provenance attestation + OIDC (npmjs destination)
     uses: ./.github/workflows/reusable-sdk-publish.yml
     secrets: inherit
     with:
@@ -826,6 +843,7 @@ jobs:
       - github-assets
       - sdk-spec-conformance
       - sdk-publish
+      - sdk-bootstrap
       - sdk-assets
 
     steps:
@@ -844,6 +862,7 @@ jobs:
           echo "| github-assets | ${{ needs.github-assets.result }} |"
           echo "| sdk-spec-conformance | ${{ needs.sdk-spec-conformance.result }} |"
           echo "| sdk-publish | ${{ needs.sdk-publish.result }} |"
+          echo "| sdk-bootstrap | ${{ needs.sdk-bootstrap.result }} |"
           echo "| sdk-assets | ${{ needs.sdk-assets.result }} |"
         } >> "$GITHUB_STEP_SUMMARY"
 
@@ -855,4 +874,8 @@ jobs:
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
       with:
         jobs: ${{ toJSON(needs) }}
-        allowed-skips: prod-containers, prod-manifests, prod-pypi, github-assets, sdk-spec-conformance, sdk-publish, sdk-assets
+        # sdk-bootstrap is an ALLOWED SKIP: on a normal release it never runs
+        # (dispatch-gated), so it must not fail the gate. alls-green still fails
+        # on a 'failure' result regardless of allowed-skips, so a dispatch where
+        # the bootstrap actually runs and FAILS still fails the release gate.
+        allowed-skips: prod-containers, prod-manifests, prod-pypi, github-assets, sdk-spec-conformance, sdk-publish, sdk-bootstrap, sdk-assets

--- a/.github/workflows/reusable-sdk-publish.yml
+++ b/.github/workflows/reusable-sdk-publish.yml
@@ -1,0 +1,494 @@
+name: Reusable SDK Publish
+
+# ---------------------------------------------------------------------------
+# Single source of truth for SDK publishing across BOTH channels:
+#
+#   * TEST channel    — GitHub Packages only, dev-versioned (1.x.y.devN).
+#                       Called by dev-sdk.yml on every passing main push
+#                       (the SDK equivalent of the TestPyPI wheel).
+#   * RELEASE channel — the enabled public registries + GitHub Packages,
+#                       release-versioned.  Called by prod-release.yml on a
+#                       real GitHub Release.
+#
+# The caller controls WHEN this runs (there is no github.event_name gate in
+# here).  The caller also controls WHERE each SDK goes via the *-targets
+# inputs: the RELEASE caller forwards get-config's per-language destination
+# arrays; the TEST caller passes ["github"] for each so only GitHub Packages
+# receives the dev build.
+#
+# Spec-conformance gate: the RELEASE caller (prod-release.yml) MUST depend on
+# its sdk-spec-conformance job BEFORE invoking this workflow.  This reusable
+# workflow does not re-run that static gate — it trusts the caller to enforce
+# it.  The TEST channel does not gate on spec-conformance (Unit Tests is its
+# per-push quality gate, same as TestPyPI).
+#
+# All five SDKs (npm/TypeScript, Maven/Java, Maven/Kotlin, NuGet/.NET, Go) are
+# published from here so there is exactly one place that owns SDK distribution.
+# ---------------------------------------------------------------------------
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: "Publish channel: 'test' (GitHub Packages, dev version), 'release' (public registries + GitHub Packages + Go tag), or 'bootstrap' (one-off single-registry seed; Go tag stays off)."
+        required: true
+        type: string
+      version:
+        description: 'The version to stamp into each SDK and publish (bare, no leading v).'
+        required: true
+        type: string
+      npm-targets:
+        description: 'JSON array of npm publish destinations (e.g. ["github","npmjs"]). TEST caller passes ["github"].'
+        required: false
+        type: string
+        default: '["github"]'
+      maven-targets:
+        description: 'JSON array of maven publish destinations (e.g. ["github","central"]) — covers BOTH java and kotlin. TEST caller passes ["github"].'
+        required: false
+        type: string
+        default: '["github"]'
+      nuget-targets:
+        description: 'JSON array of nuget publish destinations (e.g. ["github","nuget_org"]). TEST caller passes ["github"].'
+        required: false
+        type: string
+        default: '["github"]'
+    # secrets: inherit is used by every caller, so NODE_AUTH_TOKEN / MAVEN_* /
+    # NUGET_API_KEY / GITHUB_TOKEN / GH_APP_* are all visible here without an
+    # explicit secrets: declaration.
+
+jobs:
+  sdk-publish-npm:
+    name: Publish TypeScript SDK to npm (${{ matrix.destination }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Destination matrix driven by the caller's npm-targets input.
+    # Each enabled destination ("github", "npmjs") runs as its own leg.
+    # fail-fast: false so one destination's failure does not cancel the others.
+    strategy:
+      fail-fast: false
+      matrix:
+        destination: ${{ fromJSON(inputs.npm-targets) }}
+    permissions:
+      contents: read
+      packages: write    # GITHUB_TOKEN push to GitHub Packages (github destination)
+      id-token: write    # npm provenance attestation (npmjs destination)
+
+    # Required secrets:
+    #   github destination — GITHUB_TOKEN (always present, never skips).
+    #   npmjs  destination — NODE_AUTH_TOKEN: npm automation token scoped to @finos.
+    #     Configure at: https://www.npmjs.com/settings/<org>/tokens
+    #     Add to repo: Settings > Secrets > Actions > NODE_AUTH_TOKEN
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+    - name: Set up Node.js 20 (with npm registry auth)
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+      with:
+        node-version: '20'
+        # Point npm at the destination registry so setup-node writes the matching
+        # auth line into .npmrc for NODE_AUTH_TOKEN.
+        registry-url: ${{ matrix.destination == 'github' && 'https://npm.pkg.github.com' || 'https://registry.npmjs.org' }}
+
+    # openapi-generator needs a JVM; generated models are gitignored and MUST be
+    # produced here or the published package ships with no model types.
+    - name: Set up Java (Corretto 17) — openapi-generator
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+      with:
+        java-version: '17'
+        distribution: 'corretto'
+
+    - name: Install openapi-generator-cli
+      run: npx --yes @openapitools/openapi-generator-cli version-manager set 7.23.0
+
+    # REQUIRED: generated models are gitignored (0 committed files). Without this
+    # step the published npm package would contain no model types and fail to build.
+    - name: Generate TypeScript SDK models
+      run: make sdk-typescript-generate
+
+    - name: Install TypeScript SDK dependencies
+      run: cd sdk/typescript && npm ci
+
+    - name: Set SDK version
+      # Strip any leading 'v' for npm.
+      run: |
+        VERSION="${{ inputs.version }}"
+        cd sdk/typescript && npm version "$VERSION" --no-git-tag-version
+
+    - name: Build TypeScript SDK
+      run: cd sdk/typescript && npm run build
+
+    - name: Publish to npm (${{ matrix.destination }})
+      # Branch on matrix.destination:
+      #   github — GitHub Packages (https://npm.pkg.github.com), auth via
+      #     GITHUB_TOKEN (packages: write); always present, never skips. No
+      #     --provenance (GitHub Packages does not accept the npm provenance
+      #     statement).  Scope @finos already matches owner finos.
+      #   npmjs  — public registry.npmjs.org, auth via NODE_AUTH_TOKEN, publishes
+      #     with --provenance (requires id-token: write).  LOUD fail if the
+      #     secret is missing — no silent skip.
+      env:
+        NODE_AUTH_TOKEN: ${{ matrix.destination == 'github' && secrets.GITHUB_TOKEN || secrets.NODE_AUTH_TOKEN }}
+      run: |
+        cd sdk/typescript
+        if [[ "${{ matrix.destination }}" == "github" ]]; then
+          npm publish --access public
+          echo "npm -> github: published"
+        else
+          if [[ -z "$NODE_AUTH_TOKEN" ]]; then
+            echo "::error::npm -> npmjs: required secret NODE_AUTH_TOKEN not set"
+            echo "npm -> npmjs: failed: NODE_AUTH_TOKEN not set"
+            exit 1
+          fi
+          npm publish --access public --provenance
+          echo "npm -> npmjs: published"
+        fi
+
+  sdk-publish-maven:
+    name: Publish Java SDK to Maven (${{ matrix.destination }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Destination matrix driven by the caller's maven-targets input.
+    # Each enabled destination ("github", "central") runs as its own leg.
+    strategy:
+      fail-fast: false
+      matrix:
+        destination: ${{ fromJSON(inputs.maven-targets) }}
+    permissions:
+      contents: read
+      packages: write    # GITHUB_TOKEN push to GitHub Packages (github destination)
+
+    # Required secrets:
+    #   github  destination — GITHUB_TOKEN (always present, never skips), no GPG.
+    #   central destination (all under org.finos on Maven Central / OSSRH):
+    #     MAVEN_CENTRAL_USERNAME — Sonatype OSSRH / Central Portal username
+    #     MAVEN_CENTRAL_PASSWORD — Sonatype OSSRH / Central Portal token
+    #     MAVEN_GPG_PRIVATE_KEY  — ASCII-armored GPG private key for signing
+    #     MAVEN_GPG_PASSPHRASE   — passphrase for the GPG key
+    #
+    # Register the component at: https://central.sonatype.com/publishing/namespaces
+    # Group ID: org.finos.openresourcebroker
+    # See: https://central.sonatype.org/publish/publish-portal-guide/
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+    - name: Set up Java (Corretto 17, with GPG signing)
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+      with:
+        java-version: '17'
+        distribution: 'corretto'
+
+    # openapi-generator-cli resolves its jar via the npm package cache; Node is
+    # required even though the SDK itself builds with Gradle.
+    - name: Set up Node.js 20 (openapi-generator-cli)
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+      with:
+        node-version: '20'
+
+    - name: Install openapi-generator-cli
+      run: npx --yes @openapitools/openapi-generator-cli version-manager set 7.23.0
+
+    # REQUIRED: generated model classes are gitignored (0 committed files).
+    # Without this step the published jar would contain no model types.
+    - name: Generate Java SDK models
+      run: make sdk-java-generate
+
+    - name: Import GPG key
+      # Only needed for the 'central' destination (GitHub Packages accepts
+      # unsigned artifacts).  No-ops gracefully when the key is empty; the
+      # publish step fails loudly below if 'central' is missing its secrets.
+      if: matrix.destination == 'central'
+      env:
+        MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+      run: |
+        if [[ -n "$MAVEN_GPG_PRIVATE_KEY" ]]; then
+          echo "$MAVEN_GPG_PRIVATE_KEY" | gpg --batch --import
+        fi
+
+    - name: Set SDK version
+      run: |
+        VERSION="${{ inputs.version }}"
+        sed -i "s/^version = .*/version = '$VERSION'/" sdk/java/build.gradle
+
+    - name: Publish Java SDK to Maven (${{ matrix.destination }})
+      # Branch on matrix.destination:
+      #   github  — ./gradlew publishMavenPublicationToGitHubPackagesRepository,
+      #     auth via GITHUB_ACTOR/GITHUB_TOKEN (packages: write). Always present,
+      #     never skips.  No GPG signing (GitHub Packages accepts unsigned jars).
+      #   central — ./gradlew publishMavenPublicationToMavenCentralRepository with
+      #     the MAVEN_CENTRAL_* + GPG secrets.  LOUD fail if a secret is missing.
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      run: |
+        cd sdk/java
+        if [[ "${{ matrix.destination }}" == "github" ]]; then
+          ./gradlew --no-daemon publishMavenPublicationToGitHubPackagesRepository
+          echo "java -> github: published"
+        else
+          if [[ -z "$MAVEN_CENTRAL_USERNAME" ]]; then
+            echo "::error::java -> central: required secret MAVEN_CENTRAL_USERNAME not set"
+            echo "java -> central: failed: MAVEN_CENTRAL_USERNAME not set"
+            exit 1
+          fi
+          ./gradlew --no-daemon publishMavenPublicationToMavenCentralRepository \
+            -PmavenCentralUsername="$MAVEN_CENTRAL_USERNAME" \
+            -PmavenCentralPassword="$MAVEN_CENTRAL_PASSWORD" \
+            -Psigning.gnupg.passphrase="$MAVEN_GPG_PASSPHRASE"
+          echo "java -> central: published"
+        fi
+
+  sdk-publish-gradle-kotlin:
+    name: Publish Kotlin SDK to Maven (${{ matrix.destination }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Destination matrix driven by the caller's maven-targets input
+    # (shared with the Java SDK — the block covers BOTH java and kotlin).
+    strategy:
+      fail-fast: false
+      matrix:
+        destination: ${{ fromJSON(inputs.maven-targets) }}
+    permissions:
+      contents: read
+      packages: write    # GITHUB_TOKEN push to GitHub Packages (github destination)
+
+    # Required secrets:
+    #   github  destination — GITHUB_TOKEN (always present, never skips), no GPG.
+    #   central destination (same set as sdk-publish-maven; org.finos namespace):
+    #     MAVEN_CENTRAL_USERNAME — Sonatype OSSRH / Central Portal username
+    #     MAVEN_CENTRAL_PASSWORD — Sonatype OSSRH / Central Portal token
+    #     MAVEN_GPG_PRIVATE_KEY  — ASCII-armored GPG private key for signing
+    #     MAVEN_GPG_PASSPHRASE   — passphrase for the GPG key
+    #
+    # Artifact coordinates: org.finos.openresourcebroker:open-resource-broker-kotlin
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+    - name: Set up Java (Corretto 17, Kotlin runs on JVM)
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+      with:
+        java-version: '17'
+        distribution: 'corretto'
+
+    # openapi-generator-cli resolves its jar via the npm package cache; Node is
+    # required even though the SDK itself builds with Gradle.
+    - name: Set up Node.js 20 (openapi-generator-cli)
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+      with:
+        node-version: '20'
+
+    - name: Install openapi-generator-cli
+      run: npx --yes @openapitools/openapi-generator-cli version-manager set 7.23.0
+
+    # REQUIRED: generated model classes are gitignored (0 committed files).
+    # Without this step the published jar would contain no model types.
+    - name: Generate Kotlin SDK models
+      run: make sdk-kotlin-generate
+
+    - name: Import GPG key
+      # Only needed for the 'central' destination (GitHub Packages accepts
+      # unsigned artifacts).
+      if: matrix.destination == 'central'
+      env:
+        MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+      run: |
+        if [[ -n "$MAVEN_GPG_PRIVATE_KEY" ]]; then
+          echo "$MAVEN_GPG_PRIVATE_KEY" | gpg --batch --import
+        fi
+
+    - name: Set SDK version
+      run: |
+        VERSION="${{ inputs.version }}"
+        sed -i "s/^version = .*/version = \"$VERSION\"/" sdk/kotlin/build.gradle.kts
+
+    - name: Publish Kotlin SDK to Maven (${{ matrix.destination }})
+      # Branch on matrix.destination:
+      #   github  — ./gradlew publishMavenPublicationToGitHubPackagesRepository,
+      #     auth via GITHUB_ACTOR/GITHUB_TOKEN (packages: write). Never skips.
+      #   central — ./gradlew publishMavenPublicationToMavenCentralRepository with
+      #     the MAVEN_CENTRAL_* + GPG secrets.  LOUD fail if a secret is missing.
+      env:
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      run: |
+        cd sdk/kotlin
+        if [[ "${{ matrix.destination }}" == "github" ]]; then
+          ./gradlew --no-daemon publishMavenPublicationToGitHubPackagesRepository
+          echo "kotlin -> github: published"
+        else
+          if [[ -z "$MAVEN_CENTRAL_USERNAME" ]]; then
+            echo "::error::kotlin -> central: required secret MAVEN_CENTRAL_USERNAME not set"
+            echo "kotlin -> central: failed: MAVEN_CENTRAL_USERNAME not set"
+            exit 1
+          fi
+          ./gradlew --no-daemon publishMavenPublicationToMavenCentralRepository \
+            -PmavenCentralUsername="$MAVEN_CENTRAL_USERNAME" \
+            -PmavenCentralPassword="$MAVEN_CENTRAL_PASSWORD" \
+            -Psigning.gnupg.passphrase="$MAVEN_GPG_PASSPHRASE"
+          echo "kotlin -> central: published"
+        fi
+
+  sdk-publish-nuget:
+    name: Publish .NET SDK to NuGet (${{ matrix.destination }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Destination matrix driven by the caller's nuget-targets input.
+    # Each enabled destination ("github", "nuget_org") runs as its own leg.
+    strategy:
+      fail-fast: false
+      matrix:
+        destination: ${{ fromJSON(inputs.nuget-targets) }}
+    permissions:
+      contents: read
+      packages: write    # GITHUB_TOKEN push to GitHub Packages (github destination)
+
+    # Required secrets:
+    #   github    destination — GITHUB_TOKEN (always present, never skips).
+    #   nuget_org destination — NUGET_API_KEY: NuGet.org API key scoped to
+    #     FINOS.OpenResourceBroker.  Obtain at:
+    #     https://www.nuget.org/account/apikeys
+    #     Add to repo: Settings > Secrets > Actions > NUGET_API_KEY
+    #
+    # Package ID: FINOS.OpenResourceBroker
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+    - name: Set up .NET 8
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
+      with:
+        dotnet-version: '8.0.x'
+
+    # openapi-generator needs a JVM + the openapi-generator-cli npm wrapper;
+    # generated models are gitignored (0 committed files) and MUST be produced
+    # here or the packed nupkg ships with no model types.  Mirrors the npm,
+    # maven, and kotlin publish jobs.
+    - name: Set up openapi-generator toolchain
+      uses: ./.github/actions/setup-openapi-generator
+
+    # REQUIRED: generated model classes are gitignored (0 committed files).
+    # Without this step the packed nupkg would contain no model types and the
+    # hand-written client would not compile.
+    - name: Generate C# SDK models
+      run: make sdk-csharp-generate
+
+    - name: Set SDK version
+      run: |
+        VERSION="${{ inputs.version }}"
+        # Version the hand-written client package.
+        sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" \
+          sdk/csharp/src/FINOS.OpenResourceBroker/FINOS.OpenResourceBroker.csproj
+        # Version the generated model assembly too so its embedded DLL carries
+        # the release version (the client embeds this DLL into its own nupkg).
+        sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" \
+          sdk/csharp/generated/src/OpenResourceBroker.Sdk/OpenResourceBroker.Sdk.csproj
+
+    - name: Build and pack .NET SDK
+      # Pack the client project.  Its ProjectReference to the generated model
+      # assembly is PrivateAssets="all" + an IncludeGeneratedModelsInPackage
+      # target embeds the generated DLL into lib/net8.0/, so the models ship
+      # inside the nupkg with no dangling package dependency.
+      run: |
+        dotnet pack sdk/csharp/src/FINOS.OpenResourceBroker/FINOS.OpenResourceBroker.csproj \
+          --configuration Release \
+          --output /tmp/nuget-packages
+
+    - name: Publish to NuGet (${{ matrix.destination }})
+      # Branch on matrix.destination:
+      #   github    — dotnet nuget push to https://nuget.pkg.github.com/finos/index.json
+      #     with --api-key GITHUB_TOKEN (packages: write).  Always present, never
+      #     skips.
+      #   nuget_org — dotnet nuget push to nuget.org with NUGET_API_KEY.  LOUD
+      #     fail if the secret is missing — no silent skip.
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: |
+        if [[ "${{ matrix.destination }}" == "github" ]]; then
+          dotnet nuget push /tmp/nuget-packages/*.nupkg \
+            --api-key "$GITHUB_TOKEN" \
+            --source https://nuget.pkg.github.com/finos/index.json \
+            --skip-duplicate
+          echo "nuget -> github: published"
+        else
+          if [[ -z "$NUGET_API_KEY" ]]; then
+            echo "::error::nuget -> nuget_org: required secret NUGET_API_KEY not set"
+            echo "nuget -> nuget_org: failed: NUGET_API_KEY not set"
+            exit 1
+          fi
+          dotnet nuget push /tmp/nuget-packages/*.nupkg \
+            --api-key "$NUGET_API_KEY" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+          echo "nuget -> nuget_org: published"
+        fi
+
+  # ---------------------------------------------------------------------------
+  # Go SDK — unified into this workflow so all five SDKs publish from one place.
+  #
+  # RELEASE channel (inputs.channel == 'release'): create + push the
+  #   submodule-scoped tag sdk/go/vX.Y.Z pointing at the release commit.  The Go
+  #   module proxy (proxy.golang.org) serves
+  #   `go get github.com/finos/open-resource-broker/sdk/go@vX.Y.Z` off this tag.
+  #   The release commit already carries the bumped sdk/go/orb/version.go and the
+  #   version-stamped spec (stamped by the semantic-release build hook), so this
+  #   is TAG-ONLY: no commit, no branch push.  The push targets a possibly
+  #   branch-protected ref, so it authenticates with the ORB CICD App token
+  #   (same reason semantic-release used it) — GITHUB_TOKEN is not in the
+  #   protection bypass list.
+  #
+  # TEST channel (inputs.channel == 'test'): NO-OP.  Go's dev distribution needs
+  #   nothing published — the module proxy serves pseudo-versions
+  #   (`go get github.com/finos/open-resource-broker/sdk/go@<commit>`) directly
+  #   from any commit on the default branch.  This job is gated off on 'test'
+  #   via the if: below and simply does not run.
+  # ---------------------------------------------------------------------------
+  sdk-publish-go:
+    name: Tag Go SDK module (sdk/go/vX.Y.Z)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Release channel only.  On the test channel Go is a no-op (pseudo-versions
+    # are served by the module proxy straight off the commit — nothing to
+    # publish), and on the bootstrap channel only the single chosen registry SDK
+    # is published, so this job does not run there either.
+    if: inputs.channel == 'release'
+    permissions:
+      contents: write    # push the sdk/go/vX.Y.Z tag
+
+    steps:
+    - name: Checkout release commit
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        ref: ${{ github.sha }}
+        # The composite below mints the App token and resets the remote URL to
+        # authenticate as the ORB CICD App.  If actions/checkout also persists
+        # the default GITHUB_TOKEN as a git extraheader, that header beats the
+        # URL-embedded token at push time and the tag push lands as
+        # github-actions[bot] — not in the main branch protection bypass list —
+        # and is rejected.  Skip persistence so the composite's remote URL is
+        # the sole credential source.  (Mirrors semantic-release.yml.)
+        persist-credentials: false
+
+    - name: ORB CICD App token
+      id: cicd
+      uses: ./.github/actions/orb-cicd-app-token
+      with:
+        client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+        private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+    - name: Tag Go SDK module (sdk/go/vX.Y.Z → release commit)
+      # Tag-only: points sdk/go/vX.Y.Z at the checked-out release commit and
+      # pushes it via the App-authenticated remote configured above.
+      run: make sdk-go-tag VERSION=${{ inputs.version }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -155,27 +155,23 @@ jobs:
       # would describe a different build invocation over the same files and
       # upload a conflicting .intoto.jsonl asset — dual clobbered asset (H3).
 
-      - name: Install ORB
-        if: steps.release.outputs.released == 'true'
-        # This step only boots the server to export the OpenAPI spec, so it needs
-        # the runtime `all` extra (api + providers + ui) but NOT the ci/dev test
-        # tooling.  --no-dev drops the default `dev` group; without it uv would
-        # reject `all` (which now includes `ui`) via the ui↔dev conflict.
-        # ORB_SKIP_UI_BUILD so building the wheel here doesn't invoke the
-        # (bun-less) SPA build hook.
-        env:
-          ORB_SKIP_UI_BUILD: "1"
-        run: uv sync --extra all --no-dev
-
-      - name: Export OpenAPI spec for Go SDK
-        if: steps.release.outputs.released == 'true'
-        run: uv run make sdk-go-export-spec
-
-      - name: Update Go SDK version
-        if: steps.release.outputs.released == 'true'
-        env:
-          GIT_AUTHOR_NAME: ${{ steps.cicd.outputs.committer-name }}
-          GIT_AUTHOR_EMAIL: ${{ steps.cicd.outputs.committer-email }}
-          GIT_COMMITTER_NAME: ${{ steps.cicd.outputs.committer-name }}
-          GIT_COMMITTER_EMAIL: ${{ steps.cicd.outputs.committer-email }}
-        run: uv run make sdk-go-update-version VERSION=${{ steps.release.outputs.version }}
+      # The Go SDK version bump (version.go) and the version-stamped OpenAPI spec
+      # are folded into the release commit by the semantic-release BUILD hook:
+      # `make semantic-release-build` runs `make sdk-go-stamp-version
+      # VERSION=$NEW_VERSION` (NEW_VERSION is injected by python-semantic-release),
+      # and both files are listed in [tool.semantic_release] assets, so PSR stages
+      # and commits them as part of the tagged vX.Y.Z commit.  There is therefore
+      # NO post-tag `orb server` boot / spec export and NO separate
+      # chore(sdk/go) commit here — the tag is already self-contained.
+      #
+      # The committed spec's ROUTES stay in sync with the live API via the
+      # sdk-spec-drift-guard job (sdk.yml), which re-exports /openapi.json on every
+      # PR touching the API source and fails on drift.  So at release time only
+      # info.version needs updating, which the stamp does deterministically without
+      # booting a server (the slim PSR build container has no uv/orb anyway).
+      #
+      # The module-scoped Go tag (sdk/go/vX.Y.Z) is NO LONGER created here.  It is
+      # created + pushed by the sdk-publish-go job in reusable-sdk-publish.yml
+      # (release channel, invoked from prod-release.yml) so all five SDKs publish
+      # from one unified path.  The tag still points at this PSR release commit —
+      # prod-release runs on the published GitHub Release whose tag PSR created.

--- a/.project.yml
+++ b/.project.yml
@@ -18,6 +18,12 @@ repository:
   org: finos
   name: open-resource-broker
   registry: ghcr.io # Container registry
+sdk_publish:
+  # GitHub Packages is the always-on default (auth via GITHUB_TOKEN, no external secret).
+  # The public flags flip on once their publishing secrets are provisioned.
+  npm: { github: true, npmjs: false }
+  maven: { github: true, central: false } # covers BOTH java and kotlin
+  nuget: { github: true, nuget_org: false }
 build:
   platforms: [linux/amd64, linux/arm64] # Container platforms
   package_root: src/orb

--- a/makefiles/ci.mk
+++ b/makefiles/ci.mk
@@ -323,13 +323,35 @@ local-clean: ; @$(MAKE) local-workflow clean
 # (the SDK module has its own go.mod; those targets cd into sdk/go so the build
 # resolves against the SDK module, not the repo-root module).
 
-sdk-go-update-version:  ## Update Go SDK version file and commit (usage: make sdk-go-update-version VERSION=1.6.0)
+# The Go SDK version bump + spec stamp are folded into the semantic-release
+# BUILD hook (make semantic-release-build), so they land in the SAME commit
+# python-semantic-release tags vX.Y.Z (see [tool.semantic_release] assets in
+# pyproject.toml).  This keeps the release tag self-contained — the tagged
+# commit already carries the bumped version.go and the version-stamped spec —
+# and eliminates the standalone post-tag chore(sdk/go) commit that used to land
+# on main and pollute the next release's commit range.
+
+sdk-go-stamp-version:  ## Stamp Go SDK version.go + spec info.version to VERSION (no git). Usage: make sdk-go-stamp-version VERSION=1.6.0
+	@# Stamp-only: no git.  Called by the semantic-release build hook so the
+	@# result is committed+tagged as part of the release commit.  Idempotent —
+	@# re-stamping the same version reproduces byte-identical files (the spec is
+	@# re-serialised with the same canonical indent=2/trailing-newline formatting
+	@# export_openapi_spec.sh writes), so the sdk-spec-drift-guard still passes.
+	@# The committed spec's ROUTES are kept fresh on every PR by that guard, so at
+	@# release time only info.version changes — no server boot needed (this runs in
+	@# the slim build container that has no uv/orb).
+	@if [ -z "$(VERSION)" ]; then echo "ERROR: VERSION is required"; exit 1; fi
 	sed -i "s/MinCompatibleVersion = \".*\"/MinCompatibleVersion = \"$(VERSION)\"/" sdk/go/orb/version.go
-	git add sdk/spec/openapi.json sdk/go/orb/version.go
-	git diff --cached --quiet || git commit -m "chore(sdk/go): update for v$(VERSION) [skip ci]"
-	git push
-	# Push a submodule-scoped tag so the Go module proxy can serve
-	# go get github.com/finos/open-resource-broker/sdk/go@vX.Y.Z
+	@python3 -c "import json,sys; p='sdk/spec/openapi.json'; d=json.load(open(p,encoding='utf-8')); d['info']['version']=sys.argv[1]; f=open(p,'w',encoding='utf-8'); f.write(json.dumps(d,indent=2,ensure_ascii=True)+chr(10)); f.close()" "$(VERSION)"
+
+sdk-go-tag:  ## Tag the current release commit as sdk/go/vX.Y.Z and push it (no commit). Usage: make sdk-go-tag VERSION=1.6.0
+	@# Tag-only: points a submodule-scoped tag at the CURRENT HEAD, which is the
+	@# release commit python-semantic-release just created and tagged vX.Y.Z.  The
+	@# Go module proxy serves
+	@# go get github.com/finos/open-resource-broker/sdk/go@vX.Y.Z off this tag.
+	@# No commit and no branch push here: PSR already pushed the release commit, so
+	@# nothing extra lands on main.
+	@if [ -z "$(VERSION)" ]; then echo "ERROR: VERSION is required"; exit 1; fi
 	git tag sdk/go/v$(VERSION)
 	git push origin sdk/go/v$(VERSION)
 

--- a/makefiles/deploy.mk
+++ b/makefiles/deploy.mk
@@ -73,6 +73,16 @@ build-with-version: clean dev-install  ## Build package with explicit version (s
 	@BUILD_ARGS="$(BUILD_ARGS)" ./dev-tools/package/build.sh
 
 semantic-release-build:  ## Build package for semantic-release (runs inside the action's container; bypasses run_tool.sh)
+	# Stamp the Go SDK version.go + spec info.version to the version PSR is about
+	# to commit+tag.  PSR injects NEW_VERSION into this hook's environment and runs
+	# it BEFORE it stages+commits+tags, and sdk/go/orb/version.go + sdk/spec/openapi.json
+	# are listed in [tool.semantic_release] assets — so both files land in the tagged
+	# vX.Y.Z release commit.  Guard on NEW_VERSION so a plain `make semantic-release-build`
+	# outside PSR (or PSR --noop, which does not set it) is a no-op for the stamp.
+	@if [ -n "$$NEW_VERSION" ]; then \
+		echo "Stamping Go SDK + spec to $$NEW_VERSION for the release commit..."; \
+		$(MAKE) sdk-go-stamp-version VERSION="$$NEW_VERSION"; \
+	fi
 	rm -rf dist/ build/ ./*.egg-info/
 	python3 -m pip install --quiet build
 	# Let `build` create its own isolated env satisfying pyproject's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -779,6 +779,16 @@ venv = ".venv"
 version_toml = ["pyproject.toml:project.version"]
 version_variables = [".project.yml:version"]
 build_command = "make semantic-release-build"
+# Extra files to fold into the tagged release commit.  The build_command
+# (make semantic-release-build) stamps these to NEW_VERSION before PSR stages
+# and commits, so the vX.Y.Z tag is self-contained: it carries the bumped Go SDK
+# MinCompatibleVersion and the version-stamped OpenAPI spec.  This is what lets
+# `go get .../sdk/go@vX.Y.Z` resolve a version.go that matches the tag, with no
+# separate post-tag chore(sdk/go) commit polluting the next release's range.
+assets = [
+    "sdk/go/orb/version.go",
+    "sdk/spec/openapi.json",
+]
 major_on_zero = true
 allow_zero_version = true
 tag_format = "v{version}"

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -203,16 +203,29 @@ publishing {
                 password = findProperty('mavenCentralPassword')
             }
         }
+        maven {
+            name = 'GitHubPackages'
+            // GitHub Packages Maven registry for finos/open-resource-broker.
+            // Auth uses the CI GITHUB_TOKEN (packages: write) — no GPG required.
+            url = uri('https://maven.pkg.github.com/finos/open-resource-broker')
+            credentials {
+                username = System.getenv('GITHUB_ACTOR') ?: findProperty('gprUser')
+                password = System.getenv('GITHUB_TOKEN') ?: findProperty('gprKey') ?: findProperty('githubToken')
+            }
+        }
     }
 }
 
 // ─── Signing ─────────────────────────────────────────────────────────────────
 // Signs all Maven publications using the GPG key passed via -Psigning.gnupg.passphrase.
-// When the signing key is absent (e.g. local dev builds) signing is skipped automatically
-// because required() is not set.
+// Signing is conditional: it is only wired in when a GPG key/passphrase is present
+// (Maven Central release). GitHub Packages accepts unsigned artifacts, so builds that
+// publish only to GitHubPackages (auth via GITHUB_TOKEN, no GPG) do not fail here.
 
-signing {
-    sign publishing.publications.maven
+if (project.hasProperty('signing.gnupg.passphrase') || System.getenv('MAVEN_GPG_PASSPHRASE') != null) {
+    signing {
+        sign publishing.publications.maven
+    }
 }
 
 // ─── Gradle wrapper ──────────────────────────────────────────────────────────

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -222,7 +222,12 @@ publishing {
 // (Maven Central release). GitHub Packages accepts unsigned artifacts, so builds that
 // publish only to GitHubPackages (auth via GITHUB_TOKEN, no GPG) do not fail here.
 
-if (project.hasProperty('signing.gnupg.passphrase') || System.getenv('MAVEN_GPG_PASSPHRASE') != null) {
+// NOTE: In CI the publish step declares MAVEN_GPG_PASSPHRASE via `${{ secrets.* }}`.
+// When the secret is absent GitHub Actions sets the env var to the EMPTY STRING "" —
+// not unset — so a bare `!= null` check is always true and would wire signing on the
+// GitHub Packages (unsigned) path, breaking it. Require a NON-EMPTY passphrase instead.
+def gpgPass = System.getenv('MAVEN_GPG_PASSPHRASE')
+if (project.hasProperty('signing.gnupg.passphrase') || (gpgPass != null && !gpgPass.trim().isEmpty())) {
     signing {
         sign publishing.publications.maven
     }

--- a/sdk/kotlin/build.gradle.kts
+++ b/sdk/kotlin/build.gradle.kts
@@ -190,12 +190,26 @@ publishing {
                 password = findProperty("mavenCentralPassword") as String?
             }
         }
+        maven {
+            name = "GitHubPackages"
+            // GitHub Packages Maven registry for finos/open-resource-broker.
+            // Auth uses the CI GITHUB_TOKEN (packages: write) — no GPG required.
+            url = uri("https://maven.pkg.github.com/finos/open-resource-broker")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR") ?: findProperty("gprUser") as String?
+                password = System.getenv("GITHUB_TOKEN")
+                    ?: (findProperty("gprKey") ?: findProperty("githubToken")) as String?
+            }
+        }
     }
 }
 
 // Signs all Maven publications using the GPG key passed via -Psigning.gnupg.passphrase.
-// When the signing key is absent (e.g. local dev builds) signing is skipped automatically
-// because required() is not set.
-signing {
-    sign(publishing.publications["maven"])
+// Signing is conditional: it is only wired in when a GPG key/passphrase is present
+// (Maven Central release). GitHub Packages accepts unsigned artifacts, so builds that
+// publish only to GitHubPackages (auth via GITHUB_TOKEN, no GPG) do not fail here.
+if (project.hasProperty("signing.gnupg.passphrase") || System.getenv("MAVEN_GPG_PASSPHRASE") != null) {
+    signing {
+        sign(publishing.publications["maven"])
+    }
 }

--- a/sdk/kotlin/build.gradle.kts
+++ b/sdk/kotlin/build.gradle.kts
@@ -208,7 +208,12 @@ publishing {
 // Signing is conditional: it is only wired in when a GPG key/passphrase is present
 // (Maven Central release). GitHub Packages accepts unsigned artifacts, so builds that
 // publish only to GitHubPackages (auth via GITHUB_TOKEN, no GPG) do not fail here.
-if (project.hasProperty("signing.gnupg.passphrase") || System.getenv("MAVEN_GPG_PASSPHRASE") != null) {
+// NOTE: In CI the publish step declares MAVEN_GPG_PASSPHRASE via `${{ secrets.* }}`.
+// When the secret is absent GitHub Actions sets the env var to the EMPTY STRING "" —
+// not unset — so a bare `!= null` check is always true and would wire signing on the
+// GitHub Packages (unsigned) path, breaking it. Require a NON-EMPTY passphrase instead.
+val gpgPass = System.getenv("MAVEN_GPG_PASSPHRASE")
+if (project.hasProperty("signing.gnupg.passphrase") || !gpgPass.isNullOrBlank()) {
     signing {
         sign(publishing.publications["maven"])
     }


### PR DESCRIPTION
## Description
Unifies SDK publishing so the five SDKs (Go, TypeScript, Java, Kotlin, .NET) share one release ecosystem with the Python package instead of the disconnected paths they had before.

- **Config-driven destinations:** new `sdk_publish` block in `.project.yml` (npm/maven/nuget, each with a `github` + public flag), surfaced through `get-config` as target arrays. GitHub Packages is the always-on default; public registries flip on per-registry once their secrets are provisioned. Mirrors the existing container-registry config pattern.
- **One reusable publish workflow, three channels** (`reusable-sdk-publish.yml`, `workflow_call`):
  - `release` (`prod-release.yml`, on a GitHub Release): publishes to every enabled destination and creates the `sdk/go/vX.Y.Z` module tag. Missing public-registry secrets **fail loudly** (no silent green). A `release-complete` gate rolls the whole train into one pass/fail signal.
  - `test` (`dev-sdk.yml`, every main push that passes Unit Tests): dev-versioned SDKs to GitHub Packages only — the SDK counterpart of the TestPyPI wheel.
  - `bootstrap` (manual dispatch): seed one SDK to one registry off a release, for first-time package creation before trusted publishing can be attached.
- **Go release-commit atomicity:** Go version + spec are stamped into the tagged release commit via the semantic-release build hook (listed as `assets`), and the tag is created from that commit — removing the post-tag `chore(sdk/go)` commit that used to pollute the next release's changelog range.
- **Build config:** Gradle (Java + Kotlin) gets a GitHub Packages Maven repo (GITHUB_TOKEN auth) and conditional GPG signing so GitHub Packages publishes unsigned while Maven Central still signs.

## Type of Change
- [x] CI/CD or build process changes
- [x] New feature (non-breaking change which adds functionality)

## Related Issues
Fixes #

## How Has This Been Tested?
- [x] Manual testing performed
- All workflow YAML parses; Java + Kotlin builds green with both `publishMavenPublicationTo{GitHubPackages,MavenCentral}Repository` tasks resolving; `make sdk-go-stamp-version` / `sdk-go-tag` dry-run correct and idempotent; no silent-skip publish paths remain.
- Adversarially reviewed via multi-agent workflow: reusable-workflow contract, channel gating (Go tag stays off on test/bootstrap), Go tag auth (ORB CICD App token past branch protection), loud-fail secret handling.
- CI on this PR exercises the SDK build/test matrix + spec drift guard.

## Test Configuration
* Python version: 3.14 (default), 3.10–3.14 matrix
* OS: ubuntu-latest
* AWS region: n/a
* Dependencies changed: none (build/CI config only)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md file
- [ ] I have updated the version number (if applicable)

## Additional Notes
Follow-ups (not in this PR):
- Public-registry onboarding (npm `@finos`, Maven Central `org.finos.openresourcebroker` namespace + GPG, NuGet `FINOS.*` prefix).
- Trusted-publishing (OIDC) for npm + NuGet once packages exist.
- Per-SDK changelog sections.

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] Security improved
- GitHub Packages publishing uses the built-in `GITHUB_TOKEN` (no external secrets). Public-registry secrets fail loudly if configured-but-missing rather than silently no-op'ing a "successful" release. Go tag push uses the scoped ORB CICD App token with `persist-credentials: false`.

## Dependencies
None.

## Deployment Notes
1. Merge → GitHub Packages publishes all five SDKs live on the next release/prerelease with zero external secrets — first real exercise of the publish path.
2. When ready for a public registry: create its token (or attach trusted publishing after a one-off bootstrap dispatch), add the secret, flip its flag in `.project.yml`.

## Reviewers
@finos/open-resource-broker-maintainers
