### PR TITLE
feat(sdk): publish SDKs to public registries with trusted publishing + PR dry-run

### DIFF
--- a/.github/workflows/dev-sdk.yml
+++ b/.github/workflows/dev-sdk.yml
@@ -85,17 +85,13 @@ jobs:
     # push produces a UNIQUE version — GitHub Packages never sees a duplicate
     # and the publish never collides with a prior dev build.
     uses: ./.github/workflows/reusable-sdk-publish.yml
-    # A reusable workflow cannot elevate beyond the token permissions of its
-    # caller, so the caller job must grant everything the reusable jobs need.
-    # Without this block the publish job would inherit only the repository
-    # DEFAULT permissions, capping the reusable jobs' `packages: write`
-    # (GitHub Packages push would be denied) and `id-token: write` (npm
-    # provenance would fail).  prod-release.yml grants these explicitly; the
-    # test channel must too.
+    # Must cover every permission the reusable jobs declare — a reusable workflow
+    # can only reduce the caller's token, never elevate it, and this ceiling is
+    # checked at compile time regardless of which jobs actually run.
     permissions:
-      contents: read
-      packages: write   # push dev SDKs to GitHub Packages (the test channel)
-      id-token: write   # npm provenance / OIDC parity with the release channel
+      contents: write   # sdk-publish-go declares contents: write (skipped on test, but the ceiling must still cover it)
+      packages: write   # GitHub Packages push
+      id-token: write   # npm provenance / OIDC
     secrets: inherit
     with:
       channel: test

--- a/.github/workflows/pr-sdk-dryrun.yml
+++ b/.github/workflows/pr-sdk-dryrun.yml
@@ -1,0 +1,53 @@
+name: PR SDK Publish Dry-Run
+
+# Exercise the full SDK publish pipeline on pull requests — generate models,
+# build, package, and validate the publish command for every SDK — without
+# pushing anything. Catches publish-path regressions (build breaks, packaging
+# errors, workflow-compile issues) on the PR that introduces them instead of
+# only at release time.
+
+on:
+  pull_request:
+    paths:
+      - 'sdk/**'
+      - '.github/workflows/reusable-sdk-publish.yml'
+      - '.github/workflows/pr-sdk-dryrun.yml'
+      - 'makefiles/sdk.mk'
+  workflow_dispatch:
+
+concurrency:
+  group: pr-sdk-dryrun-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  config:
+    name: Get Configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      package-version: ${{ steps.config.outputs.package-version }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+    - name: Get project configuration
+      id: config
+      uses: ./.github/actions/get-config
+
+  dry-run:
+    name: SDK Publish Dry-Run
+    needs: [config]
+    permissions:
+      contents: write   # ceiling must cover the reusable Go-tag job's declared permission (validated at compile time even though that job is skipped on dry-run)
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/reusable-sdk-publish.yml
+    with:
+      channel: test
+      version: ${{ needs.config.outputs.package-version }}
+      npm-targets: '["github"]'
+      maven-targets: '["github"]'
+      nuget-targets: '["github"]'
+      dry-run: true

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -27,11 +27,24 @@ on:
         default: 'github'
         type: choice
         options: [github, npmjs, central, nuget_org]
+      auth_mode:
+        # Bootstrap's main use is the one-off token seed: npm/NuGet trusted
+        # publishing both require the package to already exist before a
+        # trusted-publisher policy can be attached, so the FIRST publish must use
+        # a token. Defaults to 'token' for that reason; pick 'trusted' to bootstrap
+        # via OIDC once a policy exists. Applies to npm + NuGet only (maven is
+        # always token+GPG).
+        description: 'One-off: publishing auth for the chosen SDK (npm/NuGet only)'
+        required: false
+        default: 'token'
+        type: choice
+        options: [trusted, token]
 
 permissions:
-  contents: read
+  contents: write   # sdk-publish-go pushes the sdk/go/vX.Y.Z tag via the reusable workflow
   packages: write
   pages: write
+  id-token: write   # npm provenance + NuGet OIDC trusted publishing
 
 concurrency:
   group: production-release-${{ github.event.release.tag_name || inputs.version }}
@@ -457,6 +470,7 @@ jobs:
   prod-docs:
     name: Deploy Production Documentation
     needs: config
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:
@@ -672,16 +686,6 @@ jobs:
     name: Publish SDKs (release)
     needs: [config, github-assets, sdk-spec-conformance]
     if: github.event_name == 'release'
-    # A reusable workflow can only DOWNGRADE the caller's token, never elevate
-    # it. The top-level permissions block omits id-token (=none), so without
-    # this job-level grant the reusable's sdk-publish-npm job cannot get
-    # id-token: write and `npm publish --provenance` hard-fails. Grant exactly
-    # what the reusable's jobs need here (least-privilege — only this caller and
-    # sdk-bootstrap get id-token, not the whole workflow).
-    permissions:
-      contents: read
-      packages: write    # GitHub Packages push (github destination)
-      id-token: write    # npm provenance attestation + OIDC (npmjs destination)
     uses: ./.github/workflows/reusable-sdk-publish.yml
     secrets: inherit
     with:
@@ -690,6 +694,9 @@ jobs:
       npm-targets: ${{ needs.config.outputs.npm-targets }}
       maven-targets: ${{ needs.config.outputs.maven-targets }}
       nuget-targets: ${{ needs.config.outputs.nuget-targets }}
+      # The automatic release always publishes npm/NuGet via OIDC trusted
+      # publishing (explicit — not relying on the reusable's default).
+      auth-mode: trusted
 
   # ---------------------------------------------------------------------------
   # One-off SDK bootstrap (manual dispatch only). Publishes exactly ONE SDK to
@@ -703,13 +710,6 @@ jobs:
   sdk-bootstrap:
     name: Bootstrap one SDK (${{ github.event.inputs.bootstrap_sdk }} -> ${{ github.event.inputs.bootstrap_destination }})
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.bootstrap_sdk != 'none'
-    # Same rationale as sdk-publish: the reusable workflow cannot elevate the
-    # caller's token, so grant id-token: write here or `npm publish
-    # --provenance` fails when bootstrapping the npmjs destination.
-    permissions:
-      contents: read
-      packages: write    # GitHub Packages push (github destination)
-      id-token: write    # npm provenance attestation + OIDC (npmjs destination)
     uses: ./.github/workflows/reusable-sdk-publish.yml
     secrets: inherit
     with:
@@ -721,6 +721,10 @@ jobs:
       npm-targets: ${{ github.event.inputs.bootstrap_sdk == 'npm' && format('["{0}"]', github.event.inputs.bootstrap_destination) || '[]' }}
       maven-targets: ${{ github.event.inputs.bootstrap_sdk == 'maven' && format('["{0}"]', github.event.inputs.bootstrap_destination) || '[]' }}
       nuget-targets: ${{ github.event.inputs.bootstrap_sdk == 'nuget' && format('["{0}"]', github.event.inputs.bootstrap_destination) || '[]' }}
+      # Bootstrap chooses auth explicitly via the dispatch input (default 'token'
+      # for the seed; 'trusted' once a trusted-publisher policy exists). Irrelevant
+      # to maven (always token+GPG).
+      auth-mode: ${{ github.event.inputs.auth_mode }}
 
   # ---------------------------------------------------------------------------
   # SDK archival assets — attach the built SDK artifacts (npm .tgz, java +
@@ -840,11 +844,13 @@ jobs:
       - prod-containers
       - prod-manifests
       - prod-pypi
+      - prod-docs
       - github-assets
       - sdk-spec-conformance
       - sdk-publish
       - sdk-bootstrap
       - sdk-assets
+      - container-cleanup
 
     steps:
     - name: Write release train summary
@@ -859,11 +865,13 @@ jobs:
           echo "| prod-containers | ${{ needs.prod-containers.result }} |"
           echo "| prod-manifests | ${{ needs.prod-manifests.result }} |"
           echo "| prod-pypi | ${{ needs.prod-pypi.result }} |"
+          echo "| prod-docs | ${{ needs.prod-docs.result }} |"
           echo "| github-assets | ${{ needs.github-assets.result }} |"
           echo "| sdk-spec-conformance | ${{ needs.sdk-spec-conformance.result }} |"
           echo "| sdk-publish | ${{ needs.sdk-publish.result }} |"
           echo "| sdk-bootstrap | ${{ needs.sdk-bootstrap.result }} |"
           echo "| sdk-assets | ${{ needs.sdk-assets.result }} |"
+          echo "| container-cleanup | ${{ needs.container-cleanup.result }} |"
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Fail if any release job failed or was cancelled
@@ -878,4 +886,4 @@ jobs:
         # (dispatch-gated), so it must not fail the gate. alls-green still fails
         # on a 'failure' result regardless of allowed-skips, so a dispatch where
         # the bootstrap actually runs and FAILS still fails the release gate.
-        allowed-skips: prod-containers, prod-manifests, prod-pypi, github-assets, sdk-spec-conformance, sdk-publish, sdk-bootstrap, sdk-assets
+        allowed-skips: prod-containers, prod-manifests, prod-pypi, prod-docs, github-assets, sdk-spec-conformance, sdk-publish, sdk-bootstrap, sdk-assets, container-cleanup

--- a/.github/workflows/reusable-sdk-publish.yml
+++ b/.github/workflows/reusable-sdk-publish.yml
@@ -52,6 +52,16 @@ on:
         required: false
         type: string
         default: '["github"]'
+      dry-run:
+        description: "When true, run the full generate/build/package path and validate the publish, but push nothing (npm publish --dry-run, dotnet pack without push, gradle publishToMavenLocal, no Go tag). Used on pull requests to exercise the pipeline without shipping."
+        required: false
+        type: boolean
+        default: false
+      auth-mode:
+        description: "'trusted' (OIDC trusted publishing, default, used by automatic releases) or 'token' (use the registry's API-key/token secret — for the one-off manual bootstrap seed before a trusted-publisher policy exists). Applies to npm + NuGet only; Maven Central always uses token+GPG."
+        required: false
+        type: string
+        default: 'trusted'
     # secrets: inherit is used by every caller, so NODE_AUTH_TOKEN / MAVEN_* /
     # NUGET_API_KEY / GITHUB_TOKEN / GH_APP_* are all visible here without an
     # explicit secrets: declaration.
@@ -61,13 +71,16 @@ jobs:
     name: Publish TypeScript SDK to npm (${{ matrix.destination }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Destination matrix driven by the caller's npm-targets input.
-    # Each enabled destination ("github", "npmjs") runs as its own leg.
-    # fail-fast: false so one destination's failure does not cancel the others.
+    # Scope the public leg to the npmjs environment; the github leg and the
+    # sentinel leg resolve to null (no environment).
+    environment: ${{ matrix.destination == 'npmjs' && 'npmjs' || null }}
+    # Skip when there are no npm destinations. An empty matrix is a compile-time
+    # error, so the matrix falls back to a single sentinel value the if: skips.
+    if: inputs.npm-targets != '[]' && inputs.npm-targets != ''
     strategy:
       fail-fast: false
       matrix:
-        destination: ${{ fromJSON(inputs.npm-targets) }}
+        destination: ${{ (inputs.npm-targets != '[]' && inputs.npm-targets != '') && fromJSON(inputs.npm-targets) || fromJSON('["__none__"]') }}
     permissions:
       contents: read
       packages: write    # GITHUB_TOKEN push to GitHub Packages (github destination)
@@ -89,7 +102,15 @@ jobs:
         node-version: '20'
         # Point npm at the destination registry so setup-node writes the matching
         # auth line into .npmrc for NODE_AUTH_TOKEN.
-        registry-url: ${{ matrix.destination == 'github' && 'https://npm.pkg.github.com' || 'https://registry.npmjs.org' }}
+        #   github            -> npm.pkg.github.com  (GITHUB_TOKEN auth)
+        #   npmjs + token     -> registry.npmjs.org  (NODE_AUTH_TOKEN auth line)
+        #   npmjs + trusted   -> registry-url OMITTED (empty). setup-node only
+        #     writes the `//registry/:_authToken=${NODE_AUTH_TOKEN}` line when a
+        #     registry-url is given; on the OIDC trusted path we must NOT have
+        #     that line — an empty _authToken (NODE_AUTH_TOKEN unset on trusted)
+        #     breaks OIDC trusted publishing. registry.npmjs.org is npm's default
+        #     publish registry anyway, so `npm publish` still targets it.
+        registry-url: ${{ matrix.destination == 'github' && 'https://npm.pkg.github.com' || (inputs.auth-mode == 'token' && 'https://registry.npmjs.org' || '') }}
 
     # openapi-generator needs a JVM; generated models are gitignored and MUST be
     # produced here or the published package ships with no model types.
@@ -111,50 +132,80 @@ jobs:
       run: cd sdk/typescript && npm ci
 
     - name: Set SDK version
-      # Strip any leading 'v' for npm.
+      # The version may be a PEP 440 dev build (e.g. 1.8.3.dev850) on the test
+      # channel; npm/SemVer requires a hyphenated prerelease (1.8.3-dev.850).
+      # Release versions (X.Y.Z) pass through unchanged.
       run: |
-        VERSION="${{ inputs.version }}"
+        VERSION=$(echo "${{ inputs.version }}" | sed -E 's/\.dev([0-9]+)$/-dev.\1/')
         cd sdk/typescript && npm version "$VERSION" --no-git-tag-version
 
     - name: Build TypeScript SDK
       run: cd sdk/typescript && npm run build
 
+    - name: Upgrade npm CLI for OIDC trusted publishing (>= 11.5.1)
+      # OIDC trusted publishing to registry.npmjs.org requires npm CLI >= 11.5.1;
+      # the Node 20 runner ships an older npm (10.x), so upgrade before publish.
+      # Only needed on the npmjs + trusted path (github uses GITHUB_TOKEN, and
+      # the npmjs + token path uses the NODE_AUTH_TOKEN auth line, neither of
+      # which needs the newer OIDC-capable npm).
+      if: matrix.destination != 'github' && inputs.auth-mode != 'token'
+      run: npm install -g npm@^11.5.1
+
     - name: Publish to npm (${{ matrix.destination }})
-      # Branch on matrix.destination:
+      # Branch on matrix.destination, then (for npmjs) on inputs.auth-mode:
       #   github — GitHub Packages (https://npm.pkg.github.com), auth via
       #     GITHUB_TOKEN (packages: write); always present, never skips. No
       #     --provenance (GitHub Packages does not accept the npm provenance
-      #     statement).  Scope @finos already matches owner finos.
-      #   npmjs  — public registry.npmjs.org, auth via NODE_AUTH_TOKEN, publishes
-      #     with --provenance (requires id-token: write).  LOUD fail if the
-      #     secret is missing — no silent skip.
+      #     statement).  Scope @finos already matches owner finos. Unchanged.
+      #   npmjs + token   — public registry.npmjs.org, auth via NODE_AUTH_TOKEN
+      #     (the operator explicitly chose token, e.g. the one-off bootstrap seed
+      #     before a trusted-publisher policy can be attached).  LOUD fail if the
+      #     secret is empty — no silent skip.
+      #   npmjs + trusted — public registry.npmjs.org via OIDC trusted publishing
+      #     (default; automatic releases). NO token in env — id-token: write is
+      #     granted on this job and setup-node wrote no .npmrc auth line on this
+      #     path (registry-url omitted above), so the auth context is clean.
+      # On the trusted path NODE_AUTH_TOKEN is deliberately left UNSET: an empty
+      # _authToken can break OIDC trusted publishing.
       env:
-        NODE_AUTH_TOKEN: ${{ matrix.destination == 'github' && secrets.GITHUB_TOKEN || secrets.NODE_AUTH_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ matrix.destination == 'github' && secrets.GITHUB_TOKEN || (inputs.auth-mode == 'token' && secrets.NODE_AUTH_TOKEN || '') }}
       run: |
         cd sdk/typescript
+        if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+          npm publish --access public --dry-run
+          echo "npm -> ${{ matrix.destination }}: dry-run OK (nothing published)"
+          exit 0
+        fi
         if [[ "${{ matrix.destination }}" == "github" ]]; then
           npm publish --access public
           echo "npm -> github: published"
-        else
+        elif [[ "${{ inputs.auth-mode }}" == "token" ]]; then
           if [[ -z "$NODE_AUTH_TOKEN" ]]; then
-            echo "::error::npm -> npmjs: required secret NODE_AUTH_TOKEN not set"
+            echo "::error::npm -> npmjs: auth-mode=token but required secret NODE_AUTH_TOKEN is not set"
             echo "npm -> npmjs: failed: NODE_AUTH_TOKEN not set"
             exit 1
           fi
           npm publish --access public --provenance
-          echo "npm -> npmjs: published"
+          echo "npm -> npmjs: published (token)"
+        else
+          # Trusted publishing (OIDC). No token in env; npm CLI >= 11.5.1
+          # (upgraded above) performs the OIDC exchange with registry.npmjs.org.
+          npm publish --access public --provenance
+          echo "npm -> npmjs: published (OIDC trusted publishing)"
         fi
 
   sdk-publish-maven:
     name: Publish Java SDK to Maven (${{ matrix.destination }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Destination matrix driven by the caller's maven-targets input.
-    # Each enabled destination ("github", "central") runs as its own leg.
+    # Scope the public leg to the maven-central environment; other legs resolve
+    # to null (no environment).
+    environment: ${{ matrix.destination == 'central' && 'maven-central' || null }}
+    if: inputs.maven-targets != '[]' && inputs.maven-targets != ''
     strategy:
       fail-fast: false
       matrix:
-        destination: ${{ fromJSON(inputs.maven-targets) }}
+        destination: ${{ (inputs.maven-targets != '[]' && inputs.maven-targets != '') && fromJSON(inputs.maven-targets) || fromJSON('["__none__"]') }}
     permissions:
       contents: read
       packages: write    # GITHUB_TOKEN push to GitHub Packages (github destination)
@@ -209,8 +260,10 @@ jobs:
         fi
 
     - name: Set SDK version
+      # Normalize a PEP 440 dev build (1.8.3.dev850) to a SemVer prerelease
+      # (1.8.3-dev.850) for Maven; release versions pass through unchanged.
       run: |
-        VERSION="${{ inputs.version }}"
+        VERSION=$(echo "${{ inputs.version }}" | sed -E 's/\.dev([0-9]+)$/-dev.\1/')
         sed -i "s/^version = .*/version = '$VERSION'/" sdk/java/build.gradle
 
     - name: Publish Java SDK to Maven (${{ matrix.destination }})
@@ -228,6 +281,11 @@ jobs:
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       run: |
         cd sdk/java
+        if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+          ./gradlew --no-daemon publishMavenPublicationToMavenLocal
+          echo "java -> ${{ matrix.destination }}: dry-run OK (published to local repo only)"
+          exit 0
+        fi
         if [[ "${{ matrix.destination }}" == "github" ]]; then
           ./gradlew --no-daemon publishMavenPublicationToGitHubPackagesRepository
           echo "java -> github: published"
@@ -248,12 +306,14 @@ jobs:
     name: Publish Kotlin SDK to Maven (${{ matrix.destination }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Destination matrix driven by the caller's maven-targets input
-    # (shared with the Java SDK — the block covers BOTH java and kotlin).
+    # Scope the public leg to the maven-central environment; other legs resolve
+    # to null (no environment).
+    environment: ${{ matrix.destination == 'central' && 'maven-central' || null }}
+    if: inputs.maven-targets != '[]' && inputs.maven-targets != ''
     strategy:
       fail-fast: false
       matrix:
-        destination: ${{ fromJSON(inputs.maven-targets) }}
+        destination: ${{ (inputs.maven-targets != '[]' && inputs.maven-targets != '') && fromJSON(inputs.maven-targets) || fromJSON('["__none__"]') }}
     permissions:
       contents: read
       packages: write    # GITHUB_TOKEN push to GitHub Packages (github destination)
@@ -305,8 +365,10 @@ jobs:
         fi
 
     - name: Set SDK version
+      # Normalize a PEP 440 dev build (1.8.3.dev850) to a SemVer prerelease
+      # (1.8.3-dev.850) for Maven; release versions pass through unchanged.
       run: |
-        VERSION="${{ inputs.version }}"
+        VERSION=$(echo "${{ inputs.version }}" | sed -E 's/\.dev([0-9]+)$/-dev.\1/')
         sed -i "s/^version = .*/version = \"$VERSION\"/" sdk/kotlin/build.gradle.kts
 
     - name: Publish Kotlin SDK to Maven (${{ matrix.destination }})
@@ -323,6 +385,11 @@ jobs:
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       run: |
         cd sdk/kotlin
+        if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+          ./gradlew --no-daemon publishMavenPublicationToMavenLocal
+          echo "kotlin -> ${{ matrix.destination }}: dry-run OK (published to local repo only)"
+          exit 0
+        fi
         if [[ "${{ matrix.destination }}" == "github" ]]; then
           ./gradlew --no-daemon publishMavenPublicationToGitHubPackagesRepository
           echo "kotlin -> github: published"
@@ -343,15 +410,18 @@ jobs:
     name: Publish .NET SDK to NuGet (${{ matrix.destination }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Destination matrix driven by the caller's nuget-targets input.
-    # Each enabled destination ("github", "nuget_org") runs as its own leg.
+    # Scope the public leg to the nuget environment; other legs resolve to null
+    # (no environment).
+    environment: ${{ matrix.destination == 'nuget_org' && 'nuget' || null }}
+    if: inputs.nuget-targets != '[]' && inputs.nuget-targets != ''
     strategy:
       fail-fast: false
       matrix:
-        destination: ${{ fromJSON(inputs.nuget-targets) }}
+        destination: ${{ (inputs.nuget-targets != '[]' && inputs.nuget-targets != '') && fromJSON(inputs.nuget-targets) || fromJSON('["__none__"]') }}
     permissions:
       contents: read
       packages: write    # GITHUB_TOKEN push to GitHub Packages (github destination)
+      id-token: write    # OIDC token exchange for NuGet trusted publishing (nuget_org, trusted)
 
     # Required secrets:
     #   github    destination — GITHUB_TOKEN (always present, never skips).
@@ -385,8 +455,10 @@ jobs:
       run: make sdk-csharp-generate
 
     - name: Set SDK version
+      # Normalize a PEP 440 dev build (1.8.3.dev850) to a NuGet-valid prerelease
+      # (1.8.3-dev.850); release versions pass through unchanged.
       run: |
-        VERSION="${{ inputs.version }}"
+        VERSION=$(echo "${{ inputs.version }}" | sed -E 's/\.dev([0-9]+)$/-dev.\1/')
         # Version the hand-written client package.
         sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|" \
           sdk/csharp/src/FINOS.OpenResourceBroker/FINOS.OpenResourceBroker.csproj
@@ -405,26 +477,51 @@ jobs:
           --configuration Release \
           --output /tmp/nuget-packages
 
+    - name: NuGet trusted-publishing login (OIDC)
+      # nuget_org + trusted only (the default path; automatic releases). Exchanges
+      # the GitHub Actions OIDC token (id-token: write) for a short-lived NuGet API
+      # key, exposed as steps.nuget-login.outputs.NUGET_API_KEY. Skipped on the
+      # github destination and on the nuget_org + token path (which uses the
+      # long-lived NUGET_API_KEY secret instead).
+      #   user: the nuget.org account username that owns the trusted-publisher
+      #   policy for FINOS.OpenResourceBroker (set as the NUGET_USER repo secret).
+      # SHA-pinned to NuGet/login v1.2.0 (v1 tag -> 8d19675 at time of writing).
+      if: matrix.destination == 'nuget_org' && inputs.auth-mode != 'token' && inputs.dry-run != true
+      id: nuget-login
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1.2.0
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Publish to NuGet (${{ matrix.destination }})
-      # Branch on matrix.destination:
-      #   github    — dotnet nuget push to https://nuget.pkg.github.com/finos/index.json
-      #     with --api-key GITHUB_TOKEN (packages: write).  Always present, never
-      #     skips.
-      #   nuget_org — dotnet nuget push to nuget.org with NUGET_API_KEY.  LOUD
-      #     fail if the secret is missing — no silent skip.
+      # Branch on matrix.destination, then (for nuget_org) on inputs.auth-mode:
+      #   github          — dotnet nuget push to
+      #     https://nuget.pkg.github.com/finos/index.json with --api-key
+      #     GITHUB_TOKEN (packages: write). Always present, never skips. Unchanged.
+      #   nuget_org + token   — dotnet nuget push to nuget.org with the long-lived
+      #     NUGET_API_KEY secret (operator explicitly chose token, e.g. the
+      #     bootstrap seed). LOUD fail if the secret is empty — no silent skip.
+      #   nuget_org + trusted — dotnet nuget push to nuget.org with the temporary
+      #     OIDC key minted by the NuGet/login step above (default; automatic
+      #     releases). nuget.org trusted publishing is already configured.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUGET_OIDC_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       run: |
+        if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+          ls -la /tmp/nuget-packages/*.nupkg
+          echo "nuget -> ${{ matrix.destination }}: dry-run OK (packed, nothing pushed)"
+          exit 0
+        fi
         if [[ "${{ matrix.destination }}" == "github" ]]; then
           dotnet nuget push /tmp/nuget-packages/*.nupkg \
             --api-key "$GITHUB_TOKEN" \
             --source https://nuget.pkg.github.com/finos/index.json \
             --skip-duplicate
           echo "nuget -> github: published"
-        else
+        elif [[ "${{ inputs.auth-mode }}" == "token" ]]; then
           if [[ -z "$NUGET_API_KEY" ]]; then
-            echo "::error::nuget -> nuget_org: required secret NUGET_API_KEY not set"
+            echo "::error::nuget -> nuget_org: auth-mode=token but required secret NUGET_API_KEY is not set"
             echo "nuget -> nuget_org: failed: NUGET_API_KEY not set"
             exit 1
           fi
@@ -432,7 +529,14 @@ jobs:
             --api-key "$NUGET_API_KEY" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
-          echo "nuget -> nuget_org: published"
+          echo "nuget -> nuget_org: published (token)"
+        else
+          # Trusted publishing (OIDC): use the temporary key from NuGet/login.
+          dotnet nuget push /tmp/nuget-packages/*.nupkg \
+            --api-key "$NUGET_OIDC_API_KEY" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+          echo "nuget -> nuget_org: published (OIDC trusted publishing)"
         fi
 
   # ---------------------------------------------------------------------------
@@ -463,7 +567,7 @@ jobs:
     # are served by the module proxy straight off the commit — nothing to
     # publish), and on the bootstrap channel only the single chosen registry SDK
     # is published, so this job does not run there either.
-    if: inputs.channel == 'release'
+    if: inputs.channel == 'release' && inputs.dry-run != true
     permissions:
       contents: write    # push the sdk/go/vX.Y.Z tag
 

--- a/.project.yml
+++ b/.project.yml
@@ -19,11 +19,16 @@ repository:
   name: open-resource-broker
   registry: ghcr.io # Container registry
 sdk_publish:
-  # GitHub Packages is the always-on default (auth via GITHUB_TOKEN, no external secret).
-  # The public flags flip on once their publishing secrets are provisioned.
-  npm: { github: true, npmjs: false }
-  maven: { github: true, central: false } # covers BOTH java and kotlin
-  nuget: { github: true, nuget_org: false }
+  # github (GitHub Packages) is always on — auth via GITHUB_TOKEN, no external secret.
+  # The public flags below control WHETHER a public registry is published to.
+  # HOW each public registry authenticates is decided at publish time by secret
+  # presence, not config: if the registry's token secret is set the job uses it,
+  # otherwise it falls back to OIDC trusted publishing (npm/NuGet). To move a
+  # registry from token to trusted publishing, delete its secret — no code change.
+  # Maven Central has no OIDC and always uses MAVEN_CENTRAL_* + GPG.
+  npm: { github: true, npmjs: true }
+  maven: { github: true, central: true } # covers BOTH java and kotlin
+  nuget: { github: true, nuget_org: true }
 build:
   platforms: [linux/amd64, linux/arm64] # Container platforms
   package_root: src/orb


### PR DESCRIPTION
## Description
Publishes the five SDKs (Go, TypeScript, Java, Kotlin, .NET) to their public registries on a release, alongside the existing GitHub Packages publishing, and exercises the whole publish pipeline on pull requests so regressions surface before release instead of at release time.

- **Public registries enabled** (`.project.yml`): npmjs, Maven Central, and NuGet destinations turned on.
- **Trusted publishing by default** (`reusable-sdk-publish.yml`): npm and NuGet publish via OIDC trusted publishing; a token path remains for the one-off bootstrap seed (a trusted-publisher policy can only attach to a package that already exists). Maven Central uses its token + GPG (no OIDC exists for Central).
- **Per-registry environments**: each public publish leg is scoped to its deployment environment (`npmjs`, `maven-central`, `nuget`) so publish secrets/OIDC policies aren't repo-wide.
- **PR dry-run** (`pr-sdk-dryrun.yml`): on PRs touching the SDKs, the pipeline runs in dry-run mode — `npm publish --dry-run`, `dotnet pack`, `gradle publishToMavenLocal` — building and validating every package without pushing anything or creating a Go tag.
- **Dev test channel** (`dev-sdk.yml`): dev-versioned SDKs publish to GitHub Packages on every passing main push, pinned to the tested commit (the SDK counterpart of the TestPyPI wheel).
- **Release roll-up**: docs deploy and container cleanup are now included in the `release-complete` gate, so a failed deploy fails the single release-outcome signal.

### Defects fixed along the way (each caught by the new dry-run / bootstrap validation, not at release)
- **`startup_failure` on every publish run**: the reusable Go-tag job declared `contents: write`, exceeding the callers' `contents: read` ceiling — a reusable workflow can only reduce, never elevate, the caller's token, and this is validated at compile time before any `if:`. Fixed by granting `contents: write` at the caller workflow level.
- **Empty-matrix `startup_failure`**: an empty destination array produced a zero-combination matrix (a fatal compile error). Guarded with a skip `if:` plus a sentinel fallback.
- **Dev-version rejected by npm/NuGet/Maven**: the PEP 440 `1.8.3.dev850` build metadata is invalid for SemVer registries; normalized to `1.8.3-dev.850`.
- **`prod-docs` ran on non-release dispatches** and failed; now release-gated.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [x] Manual testing performed
- PR dry-run run: all five SDKs build/pack/validate with nothing pushed; Go tag skipped.
- Bootstrap dispatch: `@finos/open-resource-broker` published to GitHub Packages; release-only jobs skipped cleanly.
- `actionlint` clean on all workflows.

## Test Configuration
* OS: ubuntu-latest
* Dependencies changed: adds `NuGet/login` action (SHA-pinned)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Security Considerations
- [x] Security improved
- Automatic releases use OIDC trusted publishing for npm + NuGet (no long-lived tokens). Publish secrets are scoped to per-registry environments rather than repo-wide. Token auth is an explicit, dispatch-only opt-in for bootstrapping.

## Additional Notes
Requires per-environment secrets: `npmjs` → `NODE_AUTH_TOKEN` (bootstrap seed), `maven-central` → `MAVEN_CENTRAL_USERNAME`/`PASSWORD`/`MAVEN_GPG_PRIVATE_KEY`/`PASSPHRASE`, `nuget` → `NUGET_USER` (nuget.org account owning the trusted-publisher policy). All configured.

Rollout after merge: seed npm to npmjs via bootstrap dispatch (`bootstrap_sdk=npm`, `bootstrap_destination=npmjs`, `auth_mode=token`) → attach the npm trusted-publisher policy → subsequent automatic releases publish npm via OIDC. NuGet trusted publishing and Maven Central token+GPG work on the first release; Go and PyPI are already handled.

## Reviewers
@finos/open-resource-broker-maintainers
