### PR TITLE
fix(release): intent-gated releases + repair the SDK/container publish pipeline

### DIFF
--- a/.github/workflows/dev-pypi.yml
+++ b/.github/workflows/dev-pypi.yml
@@ -62,11 +62,13 @@ jobs:
     name: Quality Checks Gate
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Same guard as config: skip when the sentinel Unit Tests run did not
-    # succeed.  For manual workflow_dispatch there is no upstream run to
-    # inspect, so the API step below is skipped and this job passes as a
-    # deliberate no-op (manual publish is an authorized override).
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Skip when the sentinel Unit Tests run did not succeed, and never run off a
+    # schedule/cron-originated upstream run — nightly Unit Tests must not drive
+    # dev publishing. Manual workflow_dispatch has no upstream run, so the API
+    # step below is skipped and this job passes as a deliberate no-op.
+    if: |
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     permissions:
       actions: read   # read the Quality Checks workflow run conclusion
       contents: read

--- a/.github/workflows/reusable-sdk-publish.yml
+++ b/.github/workflows/reusable-sdk-publish.yml
@@ -488,6 +488,10 @@ jobs:
       # long-lived NUGET_API_KEY secret instead).
       #   user: the nuget.org account username that owns the trusted-publisher
       #   policy for FINOS.OpenResourceBroker (set as the NUGET_USER repo secret).
+      # The nuget.org (and npm) trusted-publisher policy must name the workflow
+      # file that ACTUALLY runs this job — the OIDC job_workflow_ref claim is this
+      # reusable workflow, so the policy's workflow must be
+      # 'reusable-sdk-publish.yml', NOT the caller 'prod-release.yml'.
       # SHA-pinned to NuGet/login v1.2.0 (v1 tag -> 8d19675 at time of writing).
       if: matrix.destination == 'nuget_org' && inputs.auth-mode != 'token' && inputs.dry-run != true
       id: nuget-login

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -43,13 +43,16 @@ jobs:
       contents: write
       packages: write
       id-token: write
-    # Only release from main: guard workflow_dispatch against feature-branch runs.
-    # No release: commit-message filter — python-semantic-release does not emit
-    # such commits, so the gate would be dead; the release-approval environment
-    # on the release job is the human gate.
+    # Release only on explicit intent: a manual dispatch from main, or a push
+    # whose commit message contains 'release:'. The workflow_run path must be a
+    # push-originated upstream run (never a schedule/cron run) that succeeded and
+    # carried a 'release:' commit — so nightly Unit Tests never drive a release.
     if: |
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      (github.event_name == 'workflow_run'
+        && github.event.workflow_run.conclusion == 'success'
+        && github.event.workflow_run.event == 'push'
+        && contains(github.event.workflow_run.head_commit.message, 'release:'))
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.trivyignore
+++ b/.trivyignore
@@ -68,3 +68,8 @@ CVE-2026-48962
 CVE-2026-42496
 CVE-2026-42497
 CVE-2026-9538
+#
+# perl-base — CVE-2026-57433 (CRITICAL)
+# Storable signed integer overflow deserializing a crafted SX_HOOK record.
+# No fixed package in Debian 13.
+CVE-2026-57433

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -822,7 +822,10 @@ output_format = "md"
 [tool.semantic_release.commit_parser_options]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
-major_tags = ["release"]
+# Major bumps come from a "!" or a BREAKING CHANGE footer (conventional-commit
+# rule). The conventional parser has no major_tags option; a "release:" commit
+# is a trigger marker only and contributes nothing to the computed bump — the
+# size is decided by the feat/fix/breaking commits in the range.
 default_bump_level = 2
 
 [tool.semantic_release.remote]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,6 +256,7 @@ dev = [
     "joserfc>=1.6.1",
     "werkzeug>=3.1.6",
     "nltk>=3.9.3",
+    "gitpython>=3.1.52",
     "watchdog",
     "tenacity",
     "pg8000",
@@ -375,6 +376,10 @@ test = [
     "werkzeug>=3.1.6",
     # Security override for safety's vulnerable nltk dependency (GHSA-7p94-766c-hgjp)
     "nltk>=3.9.3",
+    # Security override for python-semantic-release's vulnerable gitpython
+    # (GHSA-956x-8gvw-wg5v, GHSA-2f96-g7mh-g2hx, GHSA-v396-v7q4-x2qj argument
+    # injection; GHSA-rwj8-pgh3-r573 os.path.expandvars in polish_url)
+    "gitpython>=3.1.52",
     # k8s-legacy extra deps — required for tests/integration/k8s_legacy/
     "kubernetes",
     "watchdog",

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -229,6 +229,11 @@ publishing {
 def gpgPass = System.getenv('MAVEN_GPG_PASSPHRASE')
 if (project.hasProperty('signing.gnupg.passphrase') || (gpgPass != null && !gpgPass.trim().isEmpty())) {
     signing {
+        // Use the gpg command-line signatory so the GPG key imported into the
+        // agent (and -Psigning.gnupg.passphrase) is used; without useGpgCmd()
+        // gradle expects an in-memory key (signing.keyId/secretKeyRingFile) and
+        // fails with "no configured signatory".
+        useGpgCmd()
         sign publishing.publications.maven
     }
 }

--- a/sdk/kotlin/build.gradle.kts
+++ b/sdk/kotlin/build.gradle.kts
@@ -215,6 +215,10 @@ publishing {
 val gpgPass = System.getenv("MAVEN_GPG_PASSPHRASE")
 if (project.hasProperty("signing.gnupg.passphrase") || !gpgPass.isNullOrBlank()) {
     signing {
+        // Use the gpg command-line signatory so the imported GPG key (and
+        // -Psigning.gnupg.passphrase) is used; without useGpgCmd() gradle
+        // expects an in-memory key and fails with "no configured signatory".
+        useGpgCmd()
         sign(publishing.publications["maven"])
     }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1294,14 +1294,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
 ]
 
 [[package]]
@@ -3204,7 +3204,7 @@ wheels = [
 
 [[package]]
 name = "orb-py"
-version = "1.8.3"
+version = "1.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -3278,6 +3278,7 @@ dev = [
     { name = "cyclonedx-bom" },
     { name = "fastapi" },
     { name = "git-changelog" },
+    { name = "gitpython" },
     { name = "httpx" },
     { name = "import-linter" },
     { name = "ipdb" },
@@ -3436,6 +3437,7 @@ ci = [
     { name = "coverage" },
     { name = "cyclonedx-bom" },
     { name = "fastapi" },
+    { name = "gitpython" },
     { name = "httpx" },
     { name = "import-linter" },
     { name = "jinja2" },
@@ -3503,6 +3505,7 @@ dev = [
     { name = "cyclonedx-bom" },
     { name = "fastapi" },
     { name = "git-changelog" },
+    { name = "gitpython" },
     { name = "httpx" },
     { name = "import-linter" },
     { name = "ipdb" },
@@ -3600,6 +3603,7 @@ test = [
     { name = "alembic" },
     { name = "coverage" },
     { name = "fastapi" },
+    { name = "gitpython" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "joserfc" },
@@ -3663,6 +3667,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'k8s-legacy'", specifier = ">=0.128.0" },
     { name = "filelock", specifier = ">=3.20.1" },
     { name = "git-changelog", marker = "extra == 'dev'", specifier = ">=2.6.0,<3.0.0" },
+    { name = "gitpython", marker = "extra == 'dev'", specifier = ">=3.1.52" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.0,<3.0.0" },
     { name = "ipdb", marker = "extra == 'dev'", specifier = ">=0.13.13,<1.0.0" },
@@ -3785,6 +3790,7 @@ ci = [
     { name = "coverage", specifier = ">=7.3.2,<8.0.0" },
     { name = "cyclonedx-bom", specifier = ">=4.0.0,<8.0.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
+    { name = "gitpython", specifier = ">=3.1.52" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "import-linter", specifier = ">=2.0,<3.0.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
@@ -3851,6 +3857,7 @@ dev = [
     { name = "cyclonedx-bom", specifier = ">=4.0.0,<8.0.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "git-changelog", specifier = ">=2.6.0,<3.0.0" },
+    { name = "gitpython", specifier = ">=3.1.52" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "import-linter", specifier = ">=2.0,<3.0.0" },
     { name = "ipdb", specifier = ">=0.13.13,<1.0.0" },
@@ -3947,6 +3954,7 @@ test = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "coverage", specifier = ">=7.3.2,<8.0.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
+    { name = "gitpython", specifier = ">=3.1.52" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "joserfc", specifier = ">=1.6.1" },


### PR DESCRIPTION
## Description
Makes releases fire only on intent, and repairs the SDK/container publish pipeline.

### Release triggers — gate on intent, not tests/cron
The release job was reachable by the nightly `Unit Tests` cron and by any successful push, because the chain (`Unit Tests → TestPyPI → Semantic Release`) gated only on upstream success — no intent check, no schedule guard.
- **semantic-release.yml** — the release job runs only on a manual dispatch from main, or a **push** (not a scheduled run) whose commit message contains **`release:`**.
- **dev-pypi.yml** — skips schedule-originated upstream runs, so the nightly cron no longer drives dev publishing. Nightly `Unit Tests` still run for rot detection.
- Removed a `major_tags = ["release"]` entry that the conventional commit parser does not support: a `release:` commit is a trigger marker only and contributes nothing to the computed bump — the size comes from the `feat`/`fix`/breaking commits in the range.

### Publish-pipeline fixes
- **Trivy gate** — bump `gitpython` to ≥3.1.52 (clears four HIGH GitPython advisories pulled in transitively by python-semantic-release) and suppress the unfixable perl-base `CVE-2026-57433` (CRITICAL, no Debian fix) in `.trivyignore`. Eliminating perl-base via a base-image change is tracked as a follow-up.
- **Maven signing** — add `useGpgCmd()` to the Java and Kotlin signing blocks. Publishing failed with "no configured signatory": without it, gradle expects an in-memory PGP key instead of the gpg-agent key imported in CI.
- **Trusted-publishing docs** — the npm/NuGet trusted-publisher policies must name `reusable-sdk-publish.yml` (the workflow that actually runs the publish job, whose ref is in the OIDC `job_workflow_ref` claim), not the `prod-release.yml` caller.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [x] Manual testing performed
- `actionlint` clean on all changed workflows. The `release:`/no-bump parser behaviour was verified against the installed python-semantic-release. gitpython resolves to 3.1.55 in the lock; the dev optional-dependency shim stays in sync with the dev dependency-group.

## Test Configuration
* OS: ubuntu-latest
* Dependencies changed: gitpython bumped to ≥3.1.52 (security)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Security Considerations
- [x] Security improved
- Releases require explicit `release:`/manual intent instead of firing off cron/tests. gitpython bumped off vulnerable versions. The remaining perl-base CRITICAL is an unfixable Debian base-image CVE outside orb's attack surface (no untrusted Storable deserialization), suppressed pending a base-image change.

## Additional Notes
Public SDK publishing requires the npm and NuGet trusted-publisher policies to reference `reusable-sdk-publish.yml`. The npm package `@finos/open-resource-broker` is already seeded so its policy can be attached.

## Reviewers
@finos/open-resource-broker-maintainers
