### PR TITLE
refactor: AWS auth config DRY, deprecation signals, resilience dependency inversion, CLI provider-type guard

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -46,13 +46,11 @@ allow_indirect_imports = True
 #   A2 — same fix as A1
 #   A3 — MetricsCollector now injected via MetricsPort
 #
-# One pre-existing violation remains and is deliberately ignored below: the
-# provisioning orchestration service still reaches for the circuit-breaker
-# resilience concretes.  Inverting this requires a domain-level
-# CircuitBreakerError base + a resilience port, tracked by the outstanding
-# application→infrastructure ports work.  It is ignored (not silently allowed)
-# so this contract stays honest — a green result here means "no NEW app→infra
-# leaks", and any additional violation will still break the build.
+# The circuit-breaker resilience leak has also been inverted: the orchestration
+# service now depends on orb.application.ports.resilience_port (a
+# CircuitBreakerPort protocol + CircuitBreakerOpenError base) and the
+# infrastructure strategy/exception are wired in via the DI bootstrap.  No
+# app→infra resilience import remains, so no ignore is needed.
 # ---------------------------------------------------------------------------
 [importlinter:contract:application-no-infra-concretes]
 name = Application layer does not import infrastructure concretes
@@ -63,9 +61,6 @@ forbidden_modules =
     orb.providers
     orb.monitoring
 allow_indirect_imports = True
-ignore_imports =
-    orb.application.services.provisioning_orchestration_service -> orb.infrastructure.resilience.exceptions
-    orb.application.services.provisioning_orchestration_service -> orb.infrastructure.resilience.strategy.circuit_breaker
 
 
 # ---------------------------------------------------------------------------

--- a/src/orb/application/ports/__init__.py
+++ b/src/orb/application/ports/__init__.py
@@ -9,6 +9,7 @@ from orb.application.ports.command_bus_port import CommandBusPort
 from orb.application.ports.error_response_port import ErrorResponsePort
 from orb.application.ports.query_bus_port import QueryBusPort
 from orb.application.ports.registry_port import RegistryPort
+from orb.application.ports.resilience_port import CircuitBreakerOpenError, CircuitBreakerPort
 from orb.application.ports.scheduler_port import (
     SchedulerEnvironmentPort,
     SchedulerFormattingPort,
@@ -21,6 +22,8 @@ from orb.application.ports.template_dto_port import TemplateDTOPort
 
 __all__ = [
     "CacheServicePort",
+    "CircuitBreakerOpenError",
+    "CircuitBreakerPort",
     "CommandBusPort",
     "ErrorResponsePort",
     "QueryBusPort",

--- a/src/orb/application/ports/resilience_port.py
+++ b/src/orb/application/ports/resilience_port.py
@@ -1,0 +1,40 @@
+"""Application port for circuit-breaker resilience primitives.
+
+Lets the application layer depend on an abstraction for circuit-breaker
+behaviour instead of an infrastructure concrete.  Infrastructure supplies a
+concrete circuit-breaker factory (wired in the DI bootstrap) that satisfies
+:class:`CircuitBreakerPort`, and raises its open-circuit signal as a subclass
+of :class:`CircuitBreakerOpenError` so the orchestration layer can catch it
+without importing infrastructure.
+"""
+
+from typing import Protocol, runtime_checkable
+
+
+class CircuitBreakerOpenError(Exception):
+    """Raised when a circuit breaker is open and failing fast.
+
+    Application-level base that infrastructure circuit-breaker implementations
+    subclass.  The orchestration service catches this type so it stays free of
+    infrastructure imports; infrastructure adds provider-specific detail fields
+    on its concrete subclass.
+    """
+
+
+@runtime_checkable
+class CircuitBreakerPort(Protocol):
+    """Circuit-breaker operations the application layer relies on.
+
+    A concrete strategy satisfies this port structurally — no explicit
+    inheritance required.
+    """
+
+    def has_state(self, service_name: str) -> bool:
+        """Return True if a circuit state entry exists for ``service_name``."""
+        raise NotImplementedError
+
+    def record_success(self) -> None:
+        """Record a successful operation, resetting failure state."""
+
+    def record_failure(self, current_time: float) -> None:
+        """Record a failed operation, opening the circuit at threshold."""

--- a/src/orb/application/services/provisioning_orchestration_service.py
+++ b/src/orb/application/services/provisioning_orchestration_service.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, Callable, assert_never
 
 if TYPE_CHECKING:
     from orb.domain.base.ports.provider_selection_port import ProviderSelectionPort
-    from orb.infrastructure.resilience.strategy.circuit_breaker import CircuitBreakerStrategy
 
+from orb.application.ports.resilience_port import CircuitBreakerOpenError, CircuitBreakerPort
 from orb.domain.base.exceptions import QuotaError
 from orb.domain.base.operation_outcome import (
     Accepted,
@@ -26,7 +26,6 @@ from orb.domain.request.fulfilment_state_machine import (
 )
 from orb.domain.request.request_types import RequestStatus
 from orb.domain.template.template_aggregate import Template
-from orb.infrastructure.resilience.exceptions import CircuitBreakerOpenError
 
 # Default grace period used only when no FulfilmentStateMachine is injected.
 _DEFAULT_GRACE_PERIOD_SECONDS = 3600
@@ -129,7 +128,7 @@ class ProvisioningOrchestrationService:
         provider_selection_port: "ProviderSelectionPort",
         provider_config_port: ProviderConfigPort,
         config_port: ConfigurationPort,
-        circuit_breaker_factory: Callable[[str], "CircuitBreakerStrategy"],
+        circuit_breaker_factory: Callable[[str], CircuitBreakerPort],
         state_machine: "FulfilmentStateMachine | None" = None,
     ):
         self._container = container

--- a/src/orb/infrastructure/resilience/exceptions.py
+++ b/src/orb/infrastructure/resilience/exceptions.py
@@ -1,5 +1,9 @@
 """Retry-specific exceptions."""
 
+from orb.application.ports.resilience_port import (
+    CircuitBreakerOpenError as CircuitBreakerOpenPortError,
+)
+
 
 class RetryError(Exception):
     """Base exception for retry-related errors."""
@@ -41,8 +45,13 @@ class RetryConfigurationError(RetryError):
     """Exception raised when retry configuration is invalid."""
 
 
-class CircuitBreakerOpenError(RetryError):
-    """Exception raised when circuit breaker is in OPEN state."""
+class CircuitBreakerOpenError(RetryError, CircuitBreakerOpenPortError):
+    """Exception raised when circuit breaker is in OPEN state.
+
+    Subclasses the application-layer ``CircuitBreakerOpenError`` port base so
+    the orchestration service can catch open-circuit failures without importing
+    this infrastructure module.
+    """
 
     def __init__(self, service_name: str, failure_count: int, last_failure_time: float) -> None:
         """

--- a/src/orb/providers/aws/auth/cognito_strategy.py
+++ b/src/orb/providers/aws/auth/cognito_strategy.py
@@ -13,15 +13,8 @@ from typing import TYPE_CHECKING, Any, Optional
 import boto3
 import jwt
 import requests
-from botocore.config import Config
 from botocore.exceptions import ClientError
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
-
-_DEFAULT_CONFIG = Config(
-    connect_timeout=10,
-    read_timeout=30,
-    retries={"max_attempts": 3},
-)
 
 from orb.domain.base.ports import LoggingPort
 from orb.infrastructure.adapters.ports.auth import (
@@ -32,6 +25,9 @@ from orb.infrastructure.adapters.ports.auth import (
 )
 from orb.infrastructure.auth.token_denylist import InMemoryTokenDenylist, TokenDenylistPort
 from orb.infrastructure.di.injectable import injectable
+from orb.providers.aws.utilities.boto_config import get_boto3_config
+
+_DEFAULT_CONFIG = get_boto3_config()
 
 if TYPE_CHECKING:
     pass

--- a/src/orb/providers/aws/auth/iam_strategy.py
+++ b/src/orb/providers/aws/auth/iam_strategy.py
@@ -6,7 +6,6 @@ import asyncio
 import os
 from typing import TYPE_CHECKING, Any, Optional
 
-from botocore.config import Config
 from botocore.exceptions import ClientError, NoCredentialsError
 
 from orb.domain.base.ports import LoggingPort
@@ -18,15 +17,12 @@ from orb.infrastructure.adapters.ports.auth import (
 )
 from orb.infrastructure.di.injectable import injectable
 from orb.providers.aws.session_factory import AWSSessionFactory
+from orb.providers.aws.utilities.boto_config import get_boto3_config
 
 if TYPE_CHECKING:
     pass
 
-_DEFAULT_CONFIG = Config(
-    connect_timeout=10,
-    read_timeout=30,
-    retries={"max_attempts": 3},
-)
+_DEFAULT_CONFIG = get_boto3_config()
 
 
 @injectable

--- a/src/orb/providers/aws/configuration/config.py
+++ b/src/orb/providers/aws/configuration/config.py
@@ -1,6 +1,7 @@
 """AWS provider configuration - single source of truth."""
 
 import json
+import logging
 from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
@@ -11,6 +12,8 @@ from orb.providers.aws.configuration.batch_sizes_config import AWSBatchSizesConf
 from orb.providers.aws.configuration.naming_config import AWSNamingConfig
 from orb.providers.aws.domain.template.value_objects import ProviderApi
 from orb.providers.aws.storage.config import AWSStorageConfig
+
+logger = logging.getLogger(__name__)
 
 
 class HandlerCapabilityConfig(BaseModel):
@@ -254,13 +257,26 @@ class AWSProviderConfig(BaseSettings, BaseProviderConfig):  # type: ignore[misc]
             return data
 
         raw_timeout = None
+        legacy_key = None
         if "aws_connection_timeout" in data:
             raw_timeout = data.get("aws_connection_timeout")
+            legacy_key = "aws_connection_timeout"
         elif "connection_timeout_ms" in data:
             raw_timeout = data.get("connection_timeout_ms")
+            legacy_key = "connection_timeout_ms"
 
         if raw_timeout is None:
             return data
+
+        # Operator-facing config-key deprecation (see docs deprecation.md Pattern 2):
+        # this runs on a deserialised config dict, so the signal must reach
+        # operators via logger.warning — a DeprecationWarning is filtered in
+        # production and never surfaces.
+        logger.warning(
+            "AWS provider config key '%s' is deprecated; use 'aws_connect_timeout' "
+            "(seconds) instead.",
+            legacy_key,
+        )
 
         updated = dict(data)
         try:

--- a/src/orb/providers/aws/session_factory.py
+++ b/src/orb/providers/aws/session_factory.py
@@ -3,14 +3,11 @@
 from typing import Optional
 
 import boto3
-from botocore.config import Config
+
+from orb.providers.aws.utilities.boto_config import get_boto3_config
 
 # Default timeout config for one-off clients created outside of AWSClient
-_DEFAULT_CONFIG = Config(
-    connect_timeout=10,
-    read_timeout=30,
-    retries={"max_attempts": 3},
-)
+_DEFAULT_CONFIG = get_boto3_config()
 
 
 class AWSSessionFactory:

--- a/src/orb/providers/k8s/configuration/config.py
+++ b/src/orb/providers/k8s/configuration/config.py
@@ -679,6 +679,15 @@ class K8sProviderConfig(BaseSettings, BaseProviderConfig):  # type: ignore[misc]
         updated = dict(data)
         for legacy, canonical in _LEGACY_FIELD_MAP.items():
             if legacy in updated:
+                # Operator-facing config-key deprecation (see docs deprecation.md
+                # Pattern 2): this runs on a deserialised config dict, so the
+                # signal must reach operators via logger.warning — a
+                # DeprecationWarning is filtered in production and never surfaces.
+                _get_logger().warning(
+                    "K8s provider config key '%s' is deprecated; use '%s' instead.",
+                    legacy,
+                    canonical,
+                )
                 if canonical not in updated:
                     updated[canonical] = updated.pop(legacy)
                 else:

--- a/src/orb/providers/k8s/configuration/template_extension.py
+++ b/src/orb/providers/k8s/configuration/template_extension.py
@@ -18,11 +18,14 @@ Shadow fields removed — generic concepts read from the parent ``Template``:
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 
 from orb.providers.base.template_extension import ProviderTemplateExtensionBase
+
+logger = logging.getLogger(__name__)
 
 
 class K8sTemplateExtensionConfig(ProviderTemplateExtensionBase):
@@ -85,7 +88,9 @@ class K8sTemplateExtensionConfig(ProviderTemplateExtensionBase):
     # Container environment / mounts
     # Field name is ``env`` (matching K8sTemplate.env).  The legacy name
     # ``environment_variables`` is accepted as a back-compat alias so
-    # existing operator YAML using the old spelling still parses.
+    # existing operator YAML using the old spelling still parses.  The
+    # ``_warn_deprecated_field_names`` validator below surfaces the deprecation
+    # to operators; ``AliasChoices`` alone accepts the old key silently.
     env: Optional[dict[str, str]] = Field(
         None,
         validation_alias=AliasChoices("env", "environment_variables"),
@@ -146,6 +151,23 @@ class K8sTemplateExtensionConfig(ProviderTemplateExtensionBase):
     active_deadline_seconds: Optional[int] = Field(
         None, description="Default ``activeDeadlineSeconds`` for the Job handler."
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_deprecated_field_names(cls, data: Any) -> Any:
+        """Emit an operator-facing warning for the deprecated ``environment_variables`` key.
+
+        This is operator config surface (deserialised from provider YAML/JSON),
+        so the signal must reach operators via ``logger.warning`` — a
+        ``DeprecationWarning`` is filtered in production and never surfaces.
+        Runs on the raw input before ``AliasChoices`` maps the old key.
+        """
+        if isinstance(data, dict) and "environment_variables" in data and "env" not in data:
+            logger.warning(
+                "K8s template config field 'environment_variables' is deprecated; "
+                "use 'env' instead."
+            )
+        return data
 
     @field_validator("namespace")
     @classmethod

--- a/src/orb/providers/k8s/domain/template/k8s_template_dto_config.py
+++ b/src/orb/providers/k8s/domain/template/k8s_template_dto_config.py
@@ -17,11 +17,14 @@ home on the parent :class:`Template` are not duplicated:
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 
 from orb.providers.base.template_extension import ProviderTemplateExtensionBase
+
+logger = logging.getLogger(__name__)
 
 
 class K8sTemplateDTOConfig(ProviderTemplateExtensionBase):
@@ -81,7 +84,9 @@ class K8sTemplateDTOConfig(ProviderTemplateExtensionBase):
     # Container environment / mounts
     # Field name is ``env`` (matching K8sTemplate.env).  The legacy name
     # ``environment_variables`` is accepted as a back-compat alias so
-    # existing operator YAML and serialised TemplateDTO dicts still parse.
+    # existing operator YAML and serialised TemplateDTO dicts still parse.  The
+    # ``_warn_deprecated_field_names`` validator below surfaces the deprecation
+    # to operators; ``AliasChoices`` alone accepts the old key silently.
     env: Optional[dict[str, str]] = Field(
         None,
         validation_alias=AliasChoices("env", "environment_variables"),
@@ -183,6 +188,23 @@ class K8sTemplateDTOConfig(ProviderTemplateExtensionBase):
             "configured native_spec_base_path."
         ),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_deprecated_field_names(cls, data: Any) -> Any:
+        """Emit an operator-facing warning for the deprecated ``environment_variables`` key.
+
+        This is operator config surface (deserialised from provider YAML/JSON),
+        so the signal must reach operators via ``logger.warning`` — a
+        ``DeprecationWarning`` is filtered in production and never surfaces.
+        Runs on the raw input before ``AliasChoices`` maps the old key.
+        """
+        if isinstance(data, dict) and "environment_variables" in data and "env" not in data:
+            logger.warning(
+                "K8s template config field 'environment_variables' is deprecated; "
+                "use 'env' instead."
+            )
+        return data
 
     @field_validator("env", mode="before")
     @classmethod

--- a/tests/unit/cli/test_common_args.py
+++ b/tests/unit/cli/test_common_args.py
@@ -273,3 +273,115 @@ class TestRegisteredProviderTypes:
             assert result == []
         finally:
             CLISpecRegistry._store = original
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: --provider-type is defined ONCE and survives a second
+# provider registering
+# ---------------------------------------------------------------------------
+
+
+def _leaf_subparser(
+    parser: argparse.ArgumentParser, resource: str, action: str
+) -> argparse.ArgumentParser:
+    """Return the leaf sub-parser for ``<resource> <action>`` from a built parser.
+
+    Walks the two levels of ``_SubParsersAction`` (resource → action) so a test
+    can introspect the exact parser that composes the shared parent parsers.
+    """
+    resource_action = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
+    resource_parser = resource_action.choices[resource]
+    action_action = next(
+        a for a in resource_parser._actions if isinstance(a, argparse._SubParsersAction)
+    )
+    return action_action.choices[action]
+
+
+def _provider_type_actions(parser: argparse.ArgumentParser) -> list[argparse.Action]:
+    """Return every action on *parser* whose option strings include --provider-type."""
+    return [a for a in parser._actions if "--provider-type" in getattr(a, "option_strings", [])]
+
+
+class TestMultiProviderNoConflict:
+    """--provider-type is inherited once and never collides when providers grow.
+
+    The global arguments (including --provider-type) live on a single shared
+    parent parser that every leaf sub-parser composes via parents=[...].  This
+    is the property that keeps the CLI stable as new provider types
+    (Azure/GCP/OCI) come online: because the flag is declared once and merely
+    inherited, registering additional providers only widens its ``choices`` —
+    it never adds a second --provider-type action that argparse would reject
+    with a "conflicting option string" error.
+    """
+
+    def test_provider_type_declared_once_per_leaf_subparser(self):
+        """Every leaf sub-parser inherits exactly one --provider-type action."""
+        from orb.cli.args import build_parser
+
+        parser, _ = build_parser()
+
+        for resource, action in [
+            ("machines", "list"),
+            ("templates", "list"),
+            ("requests", "list"),
+            ("providers", "list"),
+        ]:
+            leaf = _leaf_subparser(parser, resource, action)
+            actions = _provider_type_actions(leaf)
+            assert len(actions) == 1, (
+                f"{resource} {action} has {len(actions)} --provider-type actions; "
+                "the flag must be inherited exactly once from the shared parent parser."
+            )
+
+    def test_second_provider_registering_causes_no_conflict(self):
+        """Simulate a second/extra provider type; build_parser must not conflict.
+
+        Injects a synthetic spec into the CLI spec registry (as a real provider
+        plugin would) and drives the full build_parser() pipeline.  A duplicate
+        --provider-type registration would surface here as ValueError/SystemExit
+        at build time; a single inherited flag simply gains a new valid choice.
+        """
+        from orb.cli.args import build_parser
+        from orb.infrastructure.registry.cli_spec_registry import CLISpecRegistry
+
+        class _FakeProviderCLISpec:
+            def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+                parser.add_argument("--fake-region", dest="fake_region", help="fake")
+
+            def extract_config(self, args):
+                return {}
+
+            def extract_partial_config(self, args):
+                return {}
+
+            def validate_add(self, args):
+                return []
+
+            def generate_name(self, args):
+                return "fake-instance"
+
+            def format_display(self, config):
+                return []
+
+        original_specs = dict(CLISpecRegistry._store)
+        try:
+            CLISpecRegistry._store["fake-cloud"] = _FakeProviderCLISpec()  # type: ignore[assignment]
+
+            try:
+                parser, _ = build_parser()
+            except (ValueError, SystemExit) as exc:
+                pytest.fail(
+                    f"build_parser() raised {type(exc).__name__} with a second provider "
+                    f"registered: {exc}. --provider-type must be inherited once, not re-added."
+                )
+
+            # Still exactly one --provider-type action per leaf.
+            leaf = _leaf_subparser(parser, "machines", "list")
+            assert len(_provider_type_actions(leaf)) == 1
+
+            # The new provider type is a valid choice on every command that
+            # inherits the provider-scope parent.
+            ns = parser.parse_args(["machines", "list", "--provider-type", "fake-cloud"])
+            assert ns.provider_type == "fake-cloud"
+        finally:
+            CLISpecRegistry._store = original_specs


### PR DESCRIPTION
## Description
Finishes several lingering quality/architecture cleanups.

- **AWS auth config DRY** — the IAM, Cognito, and session-factory clients each built their own botocore `Config` with identical timeouts and retry count. They now route through the shared `get_boto3_config()` helper (one source of truth), which also brings their retry mode in line with every other client in the codebase (adaptive; the inline configs had left it at the implicit legacy default).
- **Deprecation signals** — several operator-facing config surfaces accepted legacy keys silently (k8s + k8s-DTO `env` alias, AWS connect-timeout key remap, k8s Symphony-era key remap). Each now emits a `logger.warning`, matching the house standard: operator surfaces warn via the logger, developer/SDK surfaces via `DeprecationWarning`.
- **Resilience dependency inversion** — the provisioning orchestration service imported a concrete circuit-breaker error from infrastructure, an inward layer-boundary violation held open by an import-linter exception. A resilience port (a `CircuitBreakerPort` protocol + `CircuitBreakerOpenError` base) now lives in the application layer; the service depends on that, and the import-linter exception is removed.
- **CLI provider-type guard** — a regression test asserting `--provider-type` is declared exactly once per leaf sub-parser (inherited from the shared parent parser) and that registering an additional provider spec merely widens its `choices` rather than adding a second conflicting option string. Keeps the CLI stable as new provider types come online.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup or refactor

## How Has This Been Tested?
- [x] Unit tests added/updated
- pyright: 0 errors on all changed files. import-linter: 3 contracts kept, 0 broken — "Application layer does not import infrastructure concretes" passes with the exception removed. Targeted pytest subsets (boto/config/iam/cognito/session; deprecation/alias/config/sdk; CLI provider-type) pass.

## Test Configuration
* OS: ubuntu-latest
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Security Considerations
- [x] No security implications

## Additional Notes
The AWS auth clients' retry mode moves from the implicit legacy default to adaptive as a side effect of the config consolidation — a strictly better throttling policy for STS/IAM/Cognito, consistent with the rest of the codebase; no timeout or attempt-count values change.

## Reviewers
@finos/open-resource-broker-maintainers