### PR TITLE
refactor(providers): unify release_hosts signature; CLI multi-provider regression test

### DIFF
--- a/src/orb/providers/aws/infrastructure/adapters/aws_provisioning_adapter.py
+++ b/src/orb/providers/aws/infrastructure/adapters/aws_provisioning_adapter.py
@@ -296,8 +296,9 @@ class AWSProvisioningAdapter(ResourceProvisioningPort):
         # Call handler's release_hosts method for all provider APIs
         try:
             handler.release_hosts(
-                machine_ids, resource_mapping=resource_mapping, request_id=request_id
-            )  # type: ignore[call-arg]
+                machine_ids,
+                {"resource_mapping": resource_mapping, "request_id": request_id},
+            )
 
         except Exception as e:
             self._logger.error(

--- a/src/orb/providers/aws/infrastructure/handlers/asg/handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/asg/handler.py
@@ -321,16 +321,18 @@ class ASGHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
     def release_hosts(
         self,
         machine_ids: list[str],
-        resource_mapping: Optional[dict[str, tuple[Optional[str], int]]] = None,
-        request_id: str = "",
+        context: Optional[dict[str, Any]] = None,
     ) -> None:
         """Release hosts across multiple ASGs by detecting ASG membership.
 
         Args:
             machine_ids: List of instance IDs to terminate
-            resource_mapping: Dict mapping instance_id to (resource_id or None, desired_capacity) for intelligent resource management
-            request_id: Original provisioning request ID (unused by ASG handler — recovered from ASG name)
+            context: Neutral release context; ``resource_mapping`` maps
+                instance_id to (resource_id or None, desired_capacity) for
+                intelligent resource management.  ``request_id`` is unused by
+                the ASG handler — it is recovered from the ASG name.
         """
+        resource_mapping, _request_id = self._unpack_release_context(context)
         try:
             if not machine_ids:
                 self._logger.warning("No instance IDs provided for ASG termination")

--- a/src/orb/providers/aws/infrastructure/handlers/base_handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/base_handler.py
@@ -270,22 +270,38 @@ class AWSHandler(ProviderHandlerBase, ABC):
     def release_hosts(
         self,
         machine_ids: list[str],
-        resource_mapping: Optional[dict[str, tuple[Optional[str], int]]] = None,
-        request_id: str = "",
+        context: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Release hosts by instance ID.
 
         Args:
             machine_ids: List of instance IDs to terminate
-            resource_mapping: Optional mapping of instance_id to (resource_id, desired_capacity)
-                              for intelligent resource management (e.g. ASG/fleet capacity reduction)
-            request_id: Original provisioning request ID, used for launch template cleanup
+            context: Neutral per-release context dict carrying provider-specific
+                release inputs.  AWS handlers read two optional keys:
+                ``resource_mapping`` — mapping of instance_id to
+                (resource_id, desired_capacity) for intelligent resource
+                management (e.g. ASG/fleet capacity reduction); and
+                ``request_id`` — original provisioning request ID, used for
+                launch template cleanup.
 
         Raises:
             AWSEntityNotFoundError: If the AWS resource is not found
             InfrastructureError: For other AWS API errors
         """
+
+    @staticmethod
+    def _unpack_release_context(
+        context: Optional[dict[str, Any]],
+    ) -> tuple[Optional[dict[str, tuple[Optional[str], int]]], str]:
+        """Extract the AWS release inputs from the neutral ``context`` dict.
+
+        Returns the ``(resource_mapping, request_id)`` pair every AWS handler
+        needs, applying the historical defaults (``None`` mapping, empty
+        request ID) when the keys are absent or ``context`` is ``None``.
+        """
+        context = context or {}
+        return context.get("resource_mapping"), context.get("request_id", "")
 
     @abstractmethod
     def cancel_resource(self, resource_id: str, request_id: str) -> dict[str, Any]:

--- a/src/orb/providers/aws/infrastructure/handlers/ec2_fleet/handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/ec2_fleet/handler.py
@@ -696,16 +696,18 @@ class EC2FleetHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
     def release_hosts(
         self,
         machine_ids: list[str],
-        resource_mapping: Optional[dict[str, tuple[Optional[str], int]]] = None,
-        request_id: str = "",
+        context: Optional[dict[str, Any]] = None,
     ) -> None:
         """Release hosts across multiple EC2 Fleets by detecting fleet membership.
 
         Args:
             machine_ids: List of instance IDs to terminate
-            resource_mapping: Dict mapping instance_id to (resource_id or None, desired_capacity)
-            request_id: Original provisioning request ID (unused by EC2Fleet handler — recovered from fleet tag)
+            context: Neutral release context; ``resource_mapping`` maps
+                instance_id to (resource_id or None, desired_capacity).
+                ``request_id`` is unused by the EC2Fleet handler — it is
+                recovered from the fleet tag.
         """
+        resource_mapping, _request_id = self._unpack_release_context(context)
         try:
             if not machine_ids:
                 self._logger.warning("No instance IDs provided for EC2 Fleet termination")

--- a/src/orb/providers/aws/infrastructure/handlers/microvm/handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/microvm/handler.py
@@ -352,10 +352,15 @@ class MicroVMHandler(AWSHandler):
     def release_hosts(
         self,
         machine_ids: list[str],
-        resource_mapping: Optional[dict[str, tuple[Optional[str], int]]] = None,
-        request_id: str = "",
+        context: Optional[dict[str, Any]] = None,
     ) -> None:
-        """Terminate MicroVMs in parallel."""
+        """Terminate MicroVMs in parallel.
+
+        Args:
+            machine_ids: MicroVM identifiers to terminate.
+            context: Neutral release context; unused by the MicroVM handler,
+                accepted for signature parity with the provider contract.
+        """
         if not machine_ids:
             self._logger.warning("No MicroVM IDs provided for termination")
             return

--- a/src/orb/providers/aws/infrastructure/handlers/run_instances/handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/run_instances/handler.py
@@ -678,17 +678,19 @@ class RunInstancesHandler(AWSHandler, BaseContextMixin):
     def release_hosts(
         self,
         machine_ids: list[str],
-        resource_mapping: Optional[dict[str, tuple[Optional[str], int]]] = None,
-        request_id: str = "",
+        context: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Release hosts created by RunInstances.
 
         Args:
             machine_ids: List of instance IDs to terminate
-            resource_mapping: Dict mapping instance_id to (resource_id or None, desired_capacity)
-            request_id: Original provisioning request ID, used for launch template cleanup
+            context: Neutral release context; ``resource_mapping`` maps
+                instance_id to (resource_id or None, desired_capacity) and
+                ``request_id`` is the original provisioning request ID used
+                for launch template cleanup.
         """
+        _resource_mapping, request_id = self._unpack_release_context(context)
         try:
             if not machine_ids:
                 self._logger.warning("No instance IDs provided for RunInstances termination")

--- a/src/orb/providers/aws/infrastructure/handlers/spot_fleet/handler.py
+++ b/src/orb/providers/aws/infrastructure/handlers/spot_fleet/handler.py
@@ -520,16 +520,18 @@ class SpotFleetHandler(AWSHandler, BaseContextMixin, FleetGroupingMixin):
     def release_hosts(
         self,
         machine_ids: list[str],
-        resource_mapping: Optional[dict[str, tuple[Optional[str], int]]] = None,
-        request_id: str = "",
+        context: Optional[dict[str, Any]] = None,
     ) -> None:
         """Release hosts across multiple Spot Fleets by detecting fleet membership.
 
         Args:
             machine_ids: List of instance IDs to terminate
-            resource_mapping: Dict mapping instance_id to (resource_id or None, desired_capacity)
-            request_id: Original provisioning request ID (unused by SpotFleet handler — recovered from fleet tag)
+            context: Neutral release context; ``resource_mapping`` maps
+                instance_id to (resource_id or None, desired_capacity).
+                ``request_id`` is unused by the SpotFleet handler — it is
+                recovered from the fleet tag.
         """
+        resource_mapping, _request_id = self._unpack_release_context(context)
         try:
             if not machine_ids:
                 self._logger.warning("No instance IDs provided for Spot Fleet termination")

--- a/src/orb/providers/k8s/infrastructure/handlers/base_handler.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/base_handler.py
@@ -775,16 +775,17 @@ class K8sHandlerBase(ProviderHandlerBase, ABC):
     async def release_hosts(
         self,
         machine_ids: list[str],
-        provider_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
     ) -> None:
         """Delete the pods/workloads identified by ``machine_ids``.
 
-        ``provider_data`` is the dict stored on the Request aggregate at
-        acquire time.  It carries ``namespace`` (and for controller-based
-        handlers ``deployment_name`` / ``job_name`` / ``statefulset_name``)
-        so the handler can resolve context without needing the full Request
-        aggregate.  The dict is the same object that was stamped under
-        ``Request.provider_data`` by ``acquire_hosts``.
+        ``context`` is the neutral per-release context dict.  For Kubernetes
+        handlers it is the ``provider_data`` dict stored on the Request
+        aggregate at acquire time: it carries ``namespace`` (and for
+        controller-based handlers ``deployment_name`` / ``job_name`` /
+        ``statefulset_name``) so the handler can resolve context without
+        needing the full Request aggregate.  The dict is the same object that
+        was stamped under ``Request.provider_data`` by ``acquire_hosts``.
         """
 
     @classmethod

--- a/src/orb/providers/k8s/infrastructure/handlers/deployment_handler.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/deployment_handler.py
@@ -248,7 +248,7 @@ class K8sDeploymentHandler(K8sHandlerBase):
     async def release_hosts(
         self,
         machine_ids: list[str],
-        provider_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
     ) -> None:
         """Selective or full release using pod-deletion-cost + replicas patch.
 
@@ -267,11 +267,12 @@ class K8sDeploymentHandler(K8sHandlerBase):
 
         Args:
             machine_ids: Pod names the caller wants to release.
-            provider_data: The ``provider_data`` dict stamped onto the
-                Request aggregate at acquire time.  Carries ``namespace``
-                and ``deployment_name`` (falls back to deterministic
-                defaults when absent).
+            context: The ``provider_data`` dict stamped onto the Request
+                aggregate at acquire time.  Carries ``namespace`` and
+                ``deployment_name`` (falls back to deterministic defaults
+                when absent).
         """
+        provider_data = context or {}
         request_id = provider_data.get("request_id", "unknown")
         if not machine_ids:
             self._logger.debug(

--- a/src/orb/providers/k8s/infrastructure/handlers/job_handler.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/job_handler.py
@@ -212,7 +212,7 @@ class K8sJobHandler(K8sHandlerBase):
     async def release_hosts(
         self,
         machine_ids: list[str],
-        provider_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
     ) -> None:
         """Delete the whole Job (cascade-deletes pods).
 
@@ -239,8 +239,8 @@ class K8sJobHandler(K8sHandlerBase):
                 If the live Job cannot be read and parallelism is still
                 unknown, the release is refused — we cannot confirm the
                 caller is releasing the whole Job.
-            provider_data: The ``provider_data`` dict stamped onto the
-                Request aggregate at acquire time.  Carries ``namespace``,
+            context: The ``provider_data`` dict stamped onto the Request
+                aggregate at acquire time.  Carries ``namespace``,
                 ``job_name`` and optionally ``parallelism``.
 
         Raises:
@@ -249,6 +249,7 @@ class K8sJobHandler(K8sHandlerBase):
                 determined (absent in ``provider_data`` and live Job
                 read fails).
         """
+        provider_data = context or {}
         request_id = provider_data.get("request_id", "unknown")
         if not machine_ids:
             self._logger.debug(

--- a/src/orb/providers/k8s/infrastructure/handlers/pod_handler.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/pod_handler.py
@@ -363,7 +363,7 @@ class K8sPodHandler(K8sHandlerBase):
     async def release_hosts(
         self,
         machine_ids: list[str],
-        provider_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
         """Delete the named pods concurrently; 404s are best-effort.
 
@@ -381,11 +381,11 @@ class K8sPodHandler(K8sHandlerBase):
         Args:
             machine_ids: Pod names to delete.  For the Pod handler the
                 machine_id IS the pod name (1 ORB unit = 1 pod).
-            provider_data: The ``provider_data`` dict stamped onto the
-                Request aggregate at acquire time.  Carries
-                ``namespace`` (falls back to the provider default when
-                absent).
+            context: The ``provider_data`` dict stamped onto the Request
+                aggregate at acquire time.  Carries ``namespace`` (falls
+                back to the provider default when absent).
         """
+        provider_data = context or {}
         request_id = provider_data.get("request_id", "unknown")
         if not machine_ids:
             self._logger.debug(

--- a/src/orb/providers/k8s/infrastructure/handlers/statefulset_handler.py
+++ b/src/orb/providers/k8s/infrastructure/handlers/statefulset_handler.py
@@ -235,7 +235,7 @@ class K8sStatefulSetHandler(K8sHandlerBase):
     async def release_hosts(
         self,
         machine_ids: list[str],
-        provider_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
     ) -> None:
         """Selective or full release using ordinal-aware scale-down.
 
@@ -268,11 +268,12 @@ class K8sStatefulSetHandler(K8sHandlerBase):
 
         Args:
             machine_ids: Pod names the caller wants to release.
-            provider_data: The ``provider_data`` dict stamped onto the
-                Request aggregate at acquire time.  Carries ``namespace``
-                and ``statefulset_name`` (falls back to deterministic
-                defaults when absent).
+            context: The ``provider_data`` dict stamped onto the Request
+                aggregate at acquire time.  Carries ``namespace`` and
+                ``statefulset_name`` (falls back to deterministic defaults
+                when absent).
         """
+        provider_data = context or {}
         request_id = provider_data.get("request_id", "unknown")
         if not machine_ids:
             self._logger.debug(

--- a/tests/providers/aws/mocked/test_error_paths.py
+++ b/tests/providers/aws/mocked/test_error_paths.py
@@ -379,7 +379,7 @@ class TestEC2FleetHandlerEdgeCases:
         resource_mapping = {iid: (fleet_id, 1) for iid in fake_instance_ids}
 
         try:
-            handler.release_hosts(fake_instance_ids, resource_mapping=resource_mapping)
+            handler.release_hosts(fake_instance_ids, {"resource_mapping": resource_mapping})
         except Exception as exc:
             assert "InvalidInstanceID" in str(exc) or "does not exist" in str(exc).lower()
 
@@ -468,7 +468,7 @@ class TestSpotFleetHandlerEdgeCases:
         }
 
         try:
-            h.release_hosts(fake_instance_ids, resource_mapping=resource_mapping)
+            h.release_hosts(fake_instance_ids, {"resource_mapping": resource_mapping})
         except Exception:
             pass
 

--- a/tests/providers/aws/mocked/test_partial_return.py
+++ b/tests/providers/aws/mocked/test_partial_return.py
@@ -461,7 +461,7 @@ class TestPartialReturnCapacityReduction:
         resource_mapping = {
             instance_ids[0]: (asg_name, 2),
         }
-        handler.release_hosts([instance_ids[0]], resource_mapping=resource_mapping)
+        handler.release_hosts([instance_ids[0]], {"resource_mapping": resource_mapping})
 
         resp = asg.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
         assert resp["AutoScalingGroups"], "ASG should still exist after partial release"

--- a/tests/providers/aws/unit/handlers/test_base_handler_circuit_breaker_config.py
+++ b/tests/providers/aws/unit/handlers/test_base_handler_circuit_breaker_config.py
@@ -16,7 +16,7 @@ class _ConcreteHandler(AWSHandler):
     def check_hosts_status(self, request):  # type: ignore[override]
         return []
 
-    def release_hosts(self, machine_ids, resource_mapping=None, request_id=""):  # type: ignore[override]
+    def release_hosts(self, machine_ids, context=None):  # type: ignore[override]
         pass
 
     def cancel_resource(self, resource_id, request_id):  # type: ignore[override]

--- a/tests/providers/aws/unit/test_aws_error_propagation.py
+++ b/tests/providers/aws/unit/test_aws_error_propagation.py
@@ -55,7 +55,7 @@ def _make_handler():
         def check_hosts_status(self, request):
             pass  # type: ignore[return]
 
-        def release_hosts(self, machine_ids, resource_mapping=None, request_id=""):
+        def release_hosts(self, machine_ids, context=None):
             pass
 
         def cancel_resource(self, resource_id, request_id):

--- a/tests/providers/aws/unit/test_aws_handlers.py
+++ b/tests/providers/aws/unit/test_aws_handlers.py
@@ -666,7 +666,7 @@ class TestEC2FleetHandler:
         }
 
         # Test release_hosts with resource mapping
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that terminate_instances_with_fallback was called
         assert aws_ops.terminate_instances_with_fallback.called
@@ -709,7 +709,7 @@ class TestEC2FleetHandler:
         }
 
         # Test release_hosts with mixed instances
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that terminate_instances_with_fallback was called
         assert aws_ops.terminate_instances_with_fallback.called
@@ -796,7 +796,7 @@ class TestEC2FleetHandler:
 
         # Test release_hosts with incomplete resource mapping
         # The handler should process all instances, even with incomplete mapping
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that the handler processes the instances correctly
         assert aws_ops.terminate_instances_with_fallback.called, "Expected termination to be called"
@@ -903,7 +903,7 @@ class TestEC2FleetHandler:
         )
 
         # Test release_hosts with maintain fleet instances
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that terminate_instances_with_fallback was called
         assert aws_ops.terminate_instances_with_fallback.called
@@ -1106,7 +1106,7 @@ class TestASGHandler:
         }
 
         # Test release_hosts with resource mapping
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that terminate_instances_with_fallback was called
         # (The exact number of calls depends on how instances are grouped)
@@ -1152,7 +1152,7 @@ class TestASGHandler:
         }
 
         # Test release_hosts with mixed instances
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that terminate_instances_with_fallback was called
         # Should be called multiple times for different groups
@@ -1243,7 +1243,7 @@ class TestASGHandler:
 
         # Test release_hosts with incomplete resource mapping
         # The handler should process all instances, even with incomplete mapping
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that the handler processes the instances correctly
         assert aws_ops.terminate_instances_with_fallback.called, "Expected termination to be called"
@@ -1591,7 +1591,7 @@ class TestSpotFleetHandler:
         }
 
         # Test release_hosts with resource mapping
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that terminate_instances_with_fallback was called
         assert aws_ops.terminate_instances_with_fallback.called
@@ -1667,7 +1667,7 @@ class TestSpotFleetHandler:
         )
 
         # Test release_hosts with mixed instances
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that terminate_instances_with_fallback was called
         assert aws_ops.terminate_instances_with_fallback.called
@@ -1777,7 +1777,7 @@ class TestSpotFleetHandler:
 
         # Test release_hosts with incomplete resource mapping
         # The handler should process all instances, even with incomplete mapping
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that the handler processes the instances correctly
         assert aws_ops.terminate_instances_with_fallback.called, "Expected termination to be called"
@@ -1942,7 +1942,7 @@ class TestSpotFleetHandler:
         resource_mapping = {}
 
         # Test release_hosts with empty instance list (should trigger fleet cancellation logic)
-        handler.release_hosts([], resource_mapping)
+        handler.release_hosts([], {"resource_mapping": resource_mapping})
 
         # This should trigger early return due to empty machine_ids
         # Verify that no termination calls were made
@@ -2172,7 +2172,7 @@ class TestRunInstancesHandler:
         }
 
         # Test release_hosts with resource mapping
-        handler.release_hosts(instance_ids, resource_mapping)
+        handler.release_hosts(instance_ids, {"resource_mapping": resource_mapping})
 
         # Verify that terminate_instances_with_fallback was called
         # RunInstances handler should ignore resource_mapping and just terminate all instances

--- a/tests/providers/k8s/unit/handlers/test_job_release_reject.py
+++ b/tests/providers/k8s/unit/handlers/test_job_release_reject.py
@@ -49,7 +49,7 @@ async def test_release_rejected_when_subset_of_parallelism() -> None:
     with pytest.raises(K8sError, match="Job selective release refused"):
         await handler.release_hosts(
             machine_ids=["pod-1", "pod-2"],
-            provider_data={
+            context={
                 "request_id": "req-test",
                 "namespace": "ns",
                 "job_name": "orb-job",
@@ -64,7 +64,7 @@ async def test_release_accepted_when_full_parallelism() -> None:
     handler = _make_handler()
     await handler.release_hosts(
         machine_ids=["pod-1", "pod-2", "pod-3"],
-        provider_data={
+        context={
             "request_id": "req-test",
             "namespace": "ns",
             "job_name": "orb-job",
@@ -79,7 +79,7 @@ async def test_release_noop_when_empty_machine_ids() -> None:
     handler = _make_handler()
     await handler.release_hosts(
         machine_ids=[],
-        provider_data={
+        context={
             "request_id": "req-test",
             "namespace": "ns",
             "job_name": "orb-job",
@@ -102,7 +102,7 @@ async def test_release_resolves_parallelism_from_live_job_when_absent() -> None:
     handler = _make_handler(live_parallelism=2)
     await handler.release_hosts(
         machine_ids=["pod-1", "pod-2"],
-        provider_data={
+        context={
             "request_id": "req-test",
             "namespace": "ns",
             "job_name": "orb-job",
@@ -125,7 +125,7 @@ async def test_release_refuses_subset_when_parallelism_resolved_from_live_job() 
     with pytest.raises(K8sError, match="selective release refused"):
         await handler.release_hosts(
             machine_ids=["pod-1", "pod-2"],
-            provider_data={
+            context={
                 "request_id": "req-test",
                 "namespace": "ns",
                 "job_name": "orb-job",
@@ -149,7 +149,7 @@ async def test_release_refused_when_live_read_unavailable_unknown_parallelism() 
     with pytest.raises(K8sError, match="missing 'parallelism'"):
         await handler.release_hosts(
             machine_ids=["pod-1", "pod-2"],
-            provider_data={
+            context={
                 "request_id": "req-test",
                 "namespace": "ns",
                 "job_name": "orb-job",
@@ -174,7 +174,7 @@ async def test_release_refused_when_parallelism_absent_and_live_read_fails() -> 
     with pytest.raises(K8sError, match="missing 'parallelism'"):
         await handler.release_hosts(
             machine_ids=["pod-1"],
-            provider_data={
+            context={
                 "request_id": "req-test",
                 "namespace": "ns",
                 "job_name": "orb-job",

--- a/tests/unit/cli/test_common_args.py
+++ b/tests/unit/cli/test_common_args.py
@@ -263,9 +263,7 @@ def _leaf_subparser(
     Walks the two levels of ``_SubParsersAction`` (resource → action) so a test
     can introspect the exact parser that composes the shared parent parsers.
     """
-    resource_action = next(
-        a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
-    )
+    resource_action = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
     resource_parser = resource_action.choices[resource]
     action_action = next(
         a for a in resource_parser._actions if isinstance(a, argparse._SubParsersAction)

--- a/tests/unit/cli/test_common_args.py
+++ b/tests/unit/cli/test_common_args.py
@@ -250,6 +250,120 @@ class TestBuildParserNoConflict:
 
 
 # ---------------------------------------------------------------------------
+# Regression guard: --provider-type is defined ONCE and survives a second
+# provider registering
+# ---------------------------------------------------------------------------
+
+
+def _leaf_subparser(
+    parser: argparse.ArgumentParser, resource: str, action: str
+) -> argparse.ArgumentParser:
+    """Return the leaf sub-parser for ``<resource> <action>`` from a built parser.
+
+    Walks the two levels of ``_SubParsersAction`` (resource → action) so a test
+    can introspect the exact parser that composes the shared parent parsers.
+    """
+    resource_action = next(
+        a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
+    )
+    resource_parser = resource_action.choices[resource]
+    action_action = next(
+        a for a in resource_parser._actions if isinstance(a, argparse._SubParsersAction)
+    )
+    return action_action.choices[action]
+
+
+def _provider_type_actions(parser: argparse.ArgumentParser) -> list[argparse.Action]:
+    """Return every action on *parser* whose option strings include --provider-type."""
+    return [a for a in parser._actions if "--provider-type" in getattr(a, "option_strings", [])]
+
+
+class TestMultiProviderNoConflict:
+    """--provider-type is inherited once and never collides when providers grow.
+
+    The global arguments (including --provider-type) live on a single shared
+    parent parser that every leaf sub-parser composes via parents=[...].  This
+    is the property that keeps the CLI stable as new provider types
+    (Azure/GCP/OCI) come online: because the flag is declared once and merely
+    inherited, registering additional providers only widens its ``choices`` —
+    it never adds a second --provider-type action that argparse would reject
+    with a "conflicting option string" error.
+    """
+
+    def test_provider_type_declared_once_per_leaf_subparser(self):
+        """Every leaf sub-parser inherits exactly one --provider-type action."""
+        from orb.cli.args import build_parser
+
+        parser, _ = build_parser()
+
+        for resource, action in [
+            ("machines", "list"),
+            ("templates", "list"),
+            ("requests", "list"),
+            ("providers", "list"),
+        ]:
+            leaf = _leaf_subparser(parser, resource, action)
+            actions = _provider_type_actions(leaf)
+            assert len(actions) == 1, (
+                f"{resource} {action} has {len(actions)} --provider-type actions; "
+                "the flag must be inherited exactly once from the shared parent parser."
+            )
+
+    def test_second_provider_registering_causes_no_conflict(self):
+        """Simulate a second/extra provider type; build_parser must not conflict.
+
+        Injects a synthetic spec into the CLI spec registry (as a real provider
+        plugin would) and drives the full build_parser() pipeline.  A duplicate
+        --provider-type registration would surface here as ValueError/SystemExit
+        at build time; a single inherited flag simply gains a new valid choice.
+        """
+        from orb.cli.args import build_parser
+        from orb.infrastructure.registry.cli_spec_registry import CLISpecRegistry
+
+        class _FakeProviderCLISpec:
+            def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+                parser.add_argument("--fake-region", dest="fake_region", help="fake")
+
+            def extract_config(self, args):
+                return {}
+
+            def extract_partial_config(self, args):
+                return {}
+
+            def validate_add(self, args):
+                return []
+
+            def generate_name(self, args):
+                return "fake-instance"
+
+            def format_display(self, config):
+                return []
+
+        original_specs = dict(CLISpecRegistry._store)
+        try:
+            CLISpecRegistry._store["fake-cloud"] = _FakeProviderCLISpec()  # type: ignore[assignment]
+
+            try:
+                parser, _ = build_parser()
+            except (ValueError, SystemExit) as exc:
+                pytest.fail(
+                    f"build_parser() raised {type(exc).__name__} with a second provider "
+                    f"registered: {exc}. --provider-type must be inherited once, not re-added."
+                )
+
+            # Still exactly one --provider-type action per leaf.
+            leaf = _leaf_subparser(parser, "machines", "list")
+            assert len(_provider_type_actions(leaf)) == 1
+
+            # The new provider type is a valid choice on every command that
+            # inherits the provider-scope parent.
+            ns = parser.parse_args(["machines", "list", "--provider-type", "fake-cloud"])
+            assert ns.provider_type == "fake-cloud"
+        finally:
+            CLISpecRegistry._store = original_specs
+
+
+# ---------------------------------------------------------------------------
 # _registered_provider_types helper
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description
Completes the remaining provider-onboarding-prep scope so the multi-provider merge train is unblocked.

- **Unified `release_hosts` signature** — AWS used `(machine_ids, resource_mapping, request_id)` while k8s used `(machine_ids, provider_data)`. Both now satisfy one contract: `(machine_ids, context)` with a neutral `context` dict. AWS unpacks `resource_mapping`/`request_id` via a shared `AWSHandler._unpack_release_context` helper; k8s reads `context` as its `provider_data`. Callers and tests updated; behaviour unchanged.
- **CLI regression coverage** — the shared parent-parser refactor (so `--provider-type` registers once) was already in place; added a regression test that injects a synthetic provider CLI spec and drives the full `build_parser()` pipeline, asserting exactly one `--provider-type` action per leaf subparser and no argparse conflict when a second provider registers.

The provider base-class consolidations and the parent-parser refactor named in the original scope were already present on main and adopted by both providers; only the release_hosts parity and the missing regression test remained.

## Type of Change
- [x] Code cleanup or refactor
- [x] CI/CD or build process changes

## Related Issues
Fixes #

## How Has This Been Tested?
- [x] Unit tests added/updated
- pyright: 0 errors on all changed files. Provider release tests pass; the AWS handler suite runs under `--run-aws` with `resource_mapping` correctly reaching each handler through the new context shape. CLI suite passes (482 tests).

## Test Configuration
* OS: ubuntu-latest
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Security Considerations
- [x] No security implications

## Reviewers
@finos/open-resource-broker-maintainers
