### PR TITLE
chore: quality sweep — 404 not-found fix, security hardening, boto DRY, dead-code + test + docs cleanup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,7 +39,6 @@ Fixes #
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published
-- [ ] I have updated the CHANGELOG.md file
 - [ ] I have updated the version number (if applicable)
 
 ## Additional Notes

--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -67,34 +67,7 @@ jobs:
     - name: Validate changelog format
       run: |
         make changelog-validate
-    
-    - name: Check changelog is up to date
-      if: github.event_name == 'pull_request'
-      run: |
-        echo "Checking if changelog needs updates..."
-        
-        # Get base branch
-        BASE_SHA="${{ github.event.pull_request.base.sha }}"
-        HEAD_SHA="${{ github.sha }}"
-        
-        # Check if there are commits that should be in changelog
-        COMMIT_COUNT=$(git rev-list --count "${BASE_SHA}..${HEAD_SHA}")
-        
-        if [ "$COMMIT_COUNT" -gt 0 ]; then
-          echo "Found $COMMIT_COUNT new commits"
-          
-          # Check if changelog was modified
-          if git diff --name-only "${BASE_SHA}..${HEAD_SHA}" | grep -q "CHANGELOG.md"; then
-            echo "Changelog was updated"
-          else
-            echo "WARNING: New commits found but changelog not updated"
-            echo "Consider running: make changelog-preview"
-            # Don't fail - just warn
-          fi
-        else
-          echo "No new commits to check"
-        fi
-    
+
     - name: Preview changelog changes
       if: github.event_name == 'pull_request'
       run: |

--- a/src/orb/api/routers/requests.py
+++ b/src/orb/api/routers/requests.py
@@ -35,6 +35,7 @@ from orb.application.services.orchestration.dtos import (
     ListReturnRequestsInput,
 )
 from orb.domain.base import UnitOfWorkFactory
+from orb.domain.base.exceptions import EntityNotFoundError
 from orb.domain.request.request_types import RequestStatus
 from orb.infrastructure.error.decorators import handle_rest_exceptions
 from orb.interface.catalog import OPERATION_CATALOG, Interface
@@ -42,6 +43,22 @@ from orb.interface.catalog import OPERATION_CATALOG, Interface
 router = APIRouter(prefix="/requests", tags=["Requests"])
 
 _logger = _logging.getLogger(__name__)
+
+
+def _is_not_found_marker(entry: dict) -> bool:
+    """Return True when ``entry`` is the orchestrator's synthetic not-found marker.
+
+    When a per-ID lookup raises EntityNotFoundError (e.g. RequestNotFoundError)
+    the orchestrator swallows it into a synthetic dict carrying an explicit
+    ``"not_found": True`` flag so batch callers can report partial failures. Any
+    OTHER per-ID error (a request that exists but whose provider sync failed,
+    e.g. ProviderContractError) produces an ``"error"`` entry WITHOUT that flag.
+    A real request DTO never carries a "not_found" key, so the flag is an
+    unambiguous discriminator: only entries explicitly marked not_found mean the
+    request does not exist and should surface a 404.
+    """
+    return bool(entry.get("not_found"))
+
 
 # Module-level dependency variables to avoid B008 warnings
 STATUS_ORCHESTRATOR = Depends(get_request_status_orchestrator)
@@ -184,6 +201,16 @@ async def get_request(
     result = await orchestrator.execute(
         GetRequestStatusInput(request_ids=[request_id], verbose=verbose)
     )
+    # The orchestrator tags a genuinely non-existent request with an explicit
+    # "not_found" flag (EntityNotFoundError swallowed for batch partial-failure
+    # reporting). Only that flag means the request does not exist, so surface a
+    # 404. An existing request whose provider sync errored comes back as an
+    # error entry WITHOUT the flag and must be returned as 200 — as must a real
+    # request that failed provisioning (status="failed" with an error block).
+    if not result.requests or (
+        len(result.requests) == 1 and _is_not_found_marker(result.requests[0])
+    ):
+        raise EntityNotFoundError("Request", request_id)
     entry = OPERATION_CATALOG["get_request_status"]
     return JSONResponse(content=entry.renderer_for(Interface.REST)(formatter, result).data)
 
@@ -212,6 +239,16 @@ async def get_request_status(
     result = await orchestrator.execute(
         GetRequestStatusInput(request_ids=[request_id], verbose=verbose)
     )
+    # The orchestrator tags a genuinely non-existent request with an explicit
+    # "not_found" flag (EntityNotFoundError swallowed for batch partial-failure
+    # reporting). Only that flag means the request does not exist, so surface a
+    # 404. An existing request whose provider sync errored comes back as an
+    # error entry WITHOUT the flag and must be returned as 200 — as must a real
+    # request that failed provisioning (status="failed" with an error block).
+    if not result.requests or (
+        len(result.requests) == 1 and _is_not_found_marker(result.requests[0])
+    ):
+        raise EntityNotFoundError("Request", request_id)
     entry = OPERATION_CATALOG["get_request_status"]
     return JSONResponse(content=entry.renderer_for(Interface.REST)(formatter, result).data)
 

--- a/src/orb/api/server.py
+++ b/src/orb/api/server.py
@@ -328,9 +328,18 @@ def create_fastapi_app(server_config: Any) -> Any:
     )
     logger.info("Security headers middleware enabled")
 
-    # Add trusted host middleware only when an explicit allowlist is provided.
-    # The default is [] (disabled), so omitting this in config is safe.
-    if server_config.trusted_hosts:
+    # Add trusted host middleware only when a restrictive allowlist is provided.
+    # An empty list or a wildcard ('*') disables Host-header validation entirely,
+    # so warn the operator that this protection has been turned off.
+    if not server_config.trusted_hosts or "*" in server_config.trusted_hosts:
+        logger.warning(
+            "SECURITY WARNING: trusted_hosts is %s — Host-header protection is "
+            "effectively DISABLED. The server will accept requests with any Host "
+            "header, exposing it to DNS-rebinding and Host-header spoofing attacks. "
+            "Set server.trusted_hosts to an explicit list of expected hostnames.",
+            "empty" if not server_config.trusted_hosts else "['*']",
+        )
+    else:
         app.add_middleware(TrustedHostMiddleware, allowed_hosts=server_config.trusted_hosts)  # type: ignore[arg-type]
 
     # Add read-only mode middleware (runs before CORS so preflight OPTIONS still pass freely)

--- a/src/orb/application/services/orchestration/get_request_status.py
+++ b/src/orb/application/services/orchestration/get_request_status.py
@@ -11,6 +11,7 @@ from orb.application.services.orchestration.dtos import (
     GetRequestStatusOutput,
     Paginated,
 )
+from orb.domain.base.exceptions import EntityNotFoundError
 from orb.domain.base.ports.logging_port import LoggingPort
 
 
@@ -51,7 +52,22 @@ class GetRequestStatusOrchestrator(OrchestratorBase[GetRequestStatusInput, GetRe
                 )
                 result = await self._query_bus.execute(query)
                 request_dicts.append(self._to_dict(result))
+            except EntityNotFoundError as exc:
+                # A genuinely non-existent request. Tag it with an explicit
+                # ``not_found`` flag so single-ID callers can distinguish it
+                # from an existing request that merely errored during sync.
+                # A real RequestDTO never carries a "not_found" key, so this
+                # flag is an unambiguous synthetic-only discriminator.
+                self._logger.info("Request %s not found: %s", request_id, exc)
+                request_dicts.append(
+                    {"request_id": request_id, "not_found": True, "error": str(exc)}
+                )
             except Exception as exc:
+                # The request may well exist but its provider sync failed
+                # (e.g. ProviderContractError, infra error). Emit an error
+                # entry WITHOUT the not_found flag so batch callers still see
+                # a per-ID partial failure and single-ID callers do not 404 a
+                # request that actually exists.
                 self._logger.error("Failed to get status for %s: %s", request_id, exc)
                 request_dicts.append({"request_id": request_id, "error": str(exc)})
 

--- a/src/orb/bootstrap/port_registrations.py
+++ b/src/orb/bootstrap/port_registrations.py
@@ -51,7 +51,7 @@ def register_port_adapters(container):
     container.register_singleton(LoggingPort, lambda c: LoggingAdapter("application"))
 
     # Register container port adapter using factory to avoid circular dependency
-    container.register_singleton(ContainerPort, lambda c: ContainerAdapterFactory.create_adapter(c))
+    container.register_singleton(ContainerPort, ContainerAdapterFactory.create_adapter)
 
     # Register error handling port adapter
     container.register_singleton(ErrorHandlingAdapter, lambda c: ErrorHandlingAdapter())

--- a/src/orb/bootstrap/telemetry.py
+++ b/src/orb/bootstrap/telemetry.py
@@ -171,7 +171,7 @@ def _resolve_telemetry_file_dir(configured: Optional[str]) -> Path:
     return Path(tempfile.mkdtemp(prefix="orb-telemetry-"))
 
 
-def configure_telemetry(container: "DIContainer") -> None:  # noqa: C901
+def configure_telemetry(container: DIContainer) -> None:
     """Initialise the OTel SDK from the container's OtelConfig.
 
     This function is a complete no-op in any of the following situations:
@@ -202,7 +202,7 @@ def configure_telemetry(container: "DIContainer") -> None:  # noqa: C901
 
     # --- guard: SDK may not be installed ---
     try:
-        from opentelemetry import metrics, trace  # noqa: F401 (availability probe)
+        from opentelemetry import metrics, trace
         from opentelemetry.sdk.metrics import MeterProvider
         from opentelemetry.sdk.resources import SERVICE_NAME, Resource
         from opentelemetry.sdk.trace import TracerProvider
@@ -296,9 +296,7 @@ def configure_telemetry(container: "DIContainer") -> None:  # noqa: C901
                 # it deterministically, preventing a resource leak.
                 from opentelemetry.sdk.metrics.export import ConsoleMetricExporter
 
-                _metrics_fh = open(  # noqa: SIM115,WPS515
-                    metrics_path, "a", encoding="utf-8"
-                )
+                _metrics_fh = open(metrics_path, "a", encoding="utf-8")
                 try:
                     _metric_file_exporter = ConsoleMetricExporter(
                         out=_metrics_fh,
@@ -367,9 +365,7 @@ def configure_telemetry(container: "DIContainer") -> None:  # noqa: C901
                 # it deterministically, preventing a resource leak.
                 from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 
-                _traces_fh = open(  # noqa: SIM115,WPS515
-                    traces_path, "a", encoding="utf-8"
-                )
+                _traces_fh = open(traces_path, "a", encoding="utf-8")
                 try:
                     _span_file_exporter = ConsoleSpanExporter(
                         out=_traces_fh,

--- a/src/orb/config/managers/provider_manager.py
+++ b/src/orb/config/managers/provider_manager.py
@@ -33,19 +33,23 @@ class ProviderConfigManager:
 
     def get_provider_type(self) -> str:
         """Get provider type from configuration."""
-        # Get first available provider as default
-        default_provider = "aws"  # Keep as fallback
-        try:
-            from orb.providers.registry import get_provider_registry
+        # Prefer the explicitly configured provider type.
+        configured_type = self._get_nested_value("provider.type", None)
+        if configured_type:
+            return configured_type
 
-            registry = get_provider_registry()
-            registered_types = registry.get_registered_providers()
-            if registered_types:
-                default_provider = registered_types[0]
-        except Exception as e:
-            logger.debug(f"Failed to get default provider: {e}")  # Use fallback
+        # Fall back to the provider registry so the default stays
+        # provider-agnostic instead of assuming a specific provider.
+        from orb.providers.registry import get_provider_registry
 
-        return self._get_nested_value("provider.type", default_provider)
+        registered_types = get_provider_registry().get_registered_providers()
+        if registered_types:
+            return registered_types[0]
+
+        raise ConfigurationError(
+            "Cannot determine provider type: 'provider.type' is not configured and "
+            "no providers are registered. Run 'orb init' to configure a provider."
+        )
 
     def get_provider_config(self) -> Optional["ProviderConfig"]:
         """Get provider configuration."""

--- a/src/orb/config/schemas/app_schema.py
+++ b/src/orb/config/schemas/app_schema.py
@@ -82,7 +82,13 @@ class AppConfig(BaseModel):
         active_providers = self.provider.get_active_providers()
         if active_providers:
             return active_providers[0].type
-        return "aws"  # Ultimate fallback
+
+        from orb.domain.base.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            "Cannot determine provider type: no active provider is configured. "
+            "Run 'orb init' to configure a provider."
+        )
 
     @field_validator("environment")
     @classmethod

--- a/src/orb/domain/request/request_metadata.py
+++ b/src/orb/domain/request/request_metadata.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from pydantic import Field, field_validator, model_validator
 
@@ -387,87 +387,3 @@ class LaunchTemplateInfo(ValueObject):
     def get_display_name(self) -> str:
         """Get a display-friendly name."""
         return self.template_name or self.template_id
-
-
-class RequestHistoryEvent(ValueObject):
-    """
-    Event that occurred during request processing.
-
-    This represents significant events in the request lifecycle,
-    such as status changes, errors, or completion milestones.
-
-    Attributes:
-        event_type: Type of event (e.g., 'status_change', 'error', 'completion')
-        timestamp: When the event occurred
-        message: Human-readable event message
-        details: Additional event details
-        source: Source of the event (e.g., 'system', 'user', 'provider')
-    """
-
-    event_type: str
-    timestamp: str  # ISO format datetime string
-    message: str
-    details: dict[str, Any] = Field(default_factory=dict)
-    source: str = "system"
-
-    @field_validator("event_type")
-    @classmethod
-    def validate_event_type(cls, v: str) -> str:
-        """Validate event type format."""
-        if not v or not isinstance(v, str):
-            raise ValueError("Event type must be a non-empty string")
-
-        # Normalize to lowercase with underscores
-        normalized = v.lower().replace("-", "_").replace(" ", "_")
-        return normalized
-
-    @field_validator("timestamp")
-    @classmethod
-    def validate_timestamp(cls, v: str) -> str:
-        """Validate timestamp format."""
-        if not v or not isinstance(v, str):
-            raise ValueError("Timestamp must be a non-empty string")
-
-        # Basic ISO format validation
-        try:
-            datetime.fromisoformat(v.replace("Z", "+00:00"))
-        except ValueError:
-            raise ValueError("Timestamp must be in ISO format")
-
-        return v
-
-    @field_validator("message")
-    @classmethod
-    def validate_message(cls, v: str) -> str:
-        """Validate event message format."""
-        if not v or not isinstance(v, str):
-            raise ValueError("Event message must be a non-empty string")
-        return v.strip()
-
-    def __str__(self) -> str:
-        return f"[{self.timestamp}] {self.event_type}: {self.message}"
-
-    @classmethod
-    def create(
-        cls,
-        event_type: str,
-        message: str,
-        details: Optional[Dict[str, Any]] = None,
-        source: str = "system",
-    ) -> RequestHistoryEvent:
-        """Create a new event with current timestamp."""
-        return cls(
-            event_type=event_type,
-            timestamp=datetime.now(timezone.utc).isoformat(),
-            message=message,
-            details=details or {},
-            source=source,
-        )
-
-    def is_error_event(self) -> bool:
-        """Check if this is an error event."""
-        return self.event_type in ["error", "failure", "exception"]
-
-    def is_status_change_event(self) -> bool:
-        """Check if this is a status change event."""
-        return self.event_type in ["status_change", "state_change"]

--- a/src/orb/infrastructure/storage/components/lock_manager.py
+++ b/src/orb/infrastructure/storage/components/lock_manager.py
@@ -13,6 +13,14 @@ class ReaderWriterLock:
 
     Allows multiple readers to access the resource simultaneously,
     but only one writer at a time, with no readers present.
+
+    IN-PROCESS ONLY: this lock is built on ``threading`` primitives, so it
+    serializes readers/writers only among threads of the *same* process. It
+    provides no guarantee across separate processes or hosts — a second
+    process holds its own independent lock instance and will not observe this
+    one. For cross-process write serialization the storage backend itself must
+    provide it (the JSON backend uses ``fcntl.flock`` on a sibling lock file;
+    SQLite relies on its built-in database-level file locking).
     """
 
     def __init__(self) -> None:
@@ -80,6 +88,19 @@ class LockManager:
     High-level locking manager for storage operations.
 
     Provides different locking strategies based on storage type and requirements.
+
+    IN-PROCESS ONLY: every strategy exposed here (``reader_writer``, ``simple``,
+    ``none``) is backed by ``threading`` primitives. The acquired locks
+    serialize writes among threads WITHIN a single process; they do NOT
+    serialize across processes or hosts. Cross-process safety must come from
+    the underlying storage backend, not from this manager:
+
+    * JSON backend — wraps its read-modify-write cycle in an ``fcntl.flock``
+      exclusive lock on a sibling ``.lock`` file (single-host only).
+    * SQLite backend — relies on SQLite's built-in database-level file locking,
+      which already serializes writers across processes on the same host.
+    * PostgreSQL / MySQL backend — the database server serializes concurrent
+      writers; this manager only reduces contention among in-process threads.
     """
 
     def __init__(self, lock_type: str = "reader_writer") -> None:

--- a/src/orb/infrastructure/storage/components/sql_connection_manager.py
+++ b/src/orb/infrastructure/storage/components/sql_connection_manager.py
@@ -97,6 +97,25 @@ class SQLConnectionManager(ResourceManager):
                 connection_string = f"sqlite:///{db_path}"
                 timeout = self.config.get("connection_timeout", 30)
 
+                # Cross-process write serialization for SQLite
+                # ---------------------------------------------
+                # Unlike the JSON backend (which must reimplement cross-process
+                # write serialization with an fcntl.flock on a sibling .lock
+                # file), SQLite provides this natively. Its built-in
+                # database-level file locking escalates a writer to a RESERVED
+                # then EXCLUSIVE lock, so at most one process writes at a time
+                # on the same host; other writers block until it commits. The
+                # LockManager("simple") on the SQL strategy only serializes
+                # threads within THIS process — SQLite's own file locking is
+                # what serializes writers ACROSS processes.
+                #
+                # ``timeout`` (default 30s) sets SQLite's busy-timeout so a
+                # writer waiting on another process's lock retries rather than
+                # failing immediately with "database is locked". WAL mode is
+                # deliberately not forced here: the default rollback-journal
+                # mode already serializes cross-process writes correctly, and
+                # the in-memory (":memory:") databases used in tests do not
+                # support a persistent WAL file.
                 self.engine = create_engine(
                     connection_string,
                     echo=self.config.get("echo", False),

--- a/src/orb/interface/machine_command_handlers.py
+++ b/src/orb/interface/machine_command_handlers.py
@@ -16,7 +16,7 @@ async def handle_get_machine_status(
     args: "argparse.Namespace",
 ) -> dict[str, Any] | InterfaceResponse:
     """
-    Handle get machine status operations for multiple machine IDs.
+    Get status details for specific machines by ID, or all machines with --all.
 
     Args:
         args: Argument namespace with machine_ids
@@ -95,7 +95,7 @@ async def handle_list_machines(
     args: "argparse.Namespace",
 ) -> dict[str, Any] | InterfaceResponse:
     """
-    Handle list machines operations with scheduler-aware formatting.
+    List machines, optionally filtered by status, request ID, or provider, with pagination.
 
     Args:
         args: Argument namespace with filtering options
@@ -135,7 +135,7 @@ async def handle_stop_machines(
     args: "argparse.Namespace",
 ) -> dict[str, Any] | InterfaceResponse:
     """
-    Handle stop machines operations.
+    Stop machines by ID, or all machines with --all --force.
 
     Args:
         args: Argument namespace with machine_ids, all, and force flags
@@ -204,7 +204,7 @@ async def handle_start_machines(
     args: "argparse.Namespace",
 ) -> dict[str, Any] | InterfaceResponse:
     """
-    Handle start machines operations.
+    Start machines by ID, or all machines with --all.
 
     Args:
         args: Argument namespace with machine_ids and all flags

--- a/src/orb/interface/request_command_handlers.py
+++ b/src/orb/interface/request_command_handlers.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 async def handle_get_request_status(
     args: "argparse.Namespace",
 ) -> Union[dict[str, Any], "InterfaceResponse"]:
-    """Handle get request status operations with --all support."""
+    """Get the status of one or more provisioning requests by ID, or all requests."""
     from orb.application.services.orchestration.dtos import GetRequestStatusInput
     from orb.interface.catalog import OPERATION_CATALOG, Interface
 
@@ -87,7 +87,7 @@ async def handle_get_request_status(
 async def handle_request_machines(
     args: "argparse.Namespace",
 ) -> Union[dict[str, Any], "InterfaceResponse"]:
-    """Handle request machines operations."""
+    """Provision machines from a template, specifying the requested machine count."""
     from orb.application.services.orchestration.dtos import AcquireMachinesInput
     from orb.interface.catalog import OPERATION_CATALOG, Interface
 
@@ -145,7 +145,7 @@ async def handle_request_machines(
 async def handle_get_return_requests(
     args: "argparse.Namespace",
 ) -> Union[dict[str, Any], "InterfaceResponse"]:
-    """Handle get return requests operations."""
+    """List machine return requests, optionally filtered by status, provider, or filter expressions."""
     from orb.application.services.orchestration.dtos import ListReturnRequestsInput
     from orb.interface.catalog import OPERATION_CATALOG, Interface
 
@@ -171,7 +171,7 @@ async def handle_get_return_requests(
 async def handle_request_return_machines(
     args: "argparse.Namespace",
 ) -> Union[dict[str, Any], "InterfaceResponse"]:
-    """Handle request return machines operations."""
+    """Return machines to the provider by machine IDs, request ID, or all (with --force)."""
     from orb.application.services.orchestration.dtos import ReturnMachinesInput
     from orb.interface.catalog import OPERATION_CATALOG, Interface
 
@@ -249,7 +249,7 @@ async def handle_request_return_machines(
 async def handle_list_requests(
     args: "argparse.Namespace",
 ) -> Union[dict[str, Any], "InterfaceResponse"]:
-    """List all active provisioning requests."""
+    """List provisioning requests, optionally filtered by status with pagination."""
     from orb.application.services.orchestration.dtos import ListRequestsInput
     from orb.interface.catalog import OPERATION_CATALOG, Interface
 
@@ -278,7 +278,7 @@ async def handle_list_requests(
 async def handle_cancel_request(
     args: "argparse.Namespace",
 ) -> Union[dict[str, Any], "InterfaceResponse"]:
-    """Handle cancel request operations."""
+    """Cancel a provisioning request by ID, with an optional cancellation reason."""
     from orb.application.services.orchestration.dtos import CancelRequestInput
     from orb.interface.catalog import OPERATION_CATALOG, Interface
 

--- a/src/orb/interface/system_command_handlers.py
+++ b/src/orb/interface/system_command_handlers.py
@@ -19,7 +19,7 @@ async def handle_system_health(args) -> InterfaceResponse:
 
 @handle_interface_exceptions(context="provider_health", interface_type="cli")
 async def handle_provider_health(args) -> dict[str, Any]:
-    """Handle provider health operations."""
+    """Check health status of cloud providers, optionally filtered by name or type."""
     from orb.application.services.orchestration.dtos import GetProviderHealthInput
     from orb.application.services.orchestration.get_provider_health import (
         GetProviderHealthOrchestrator,
@@ -38,7 +38,7 @@ async def handle_provider_health(args) -> dict[str, Any]:
 
 @handle_interface_exceptions(context="list_providers", interface_type="cli")
 async def handle_list_providers(args) -> dict[str, Any]:
-    """Handle list available providers with real capabilities from configuration."""
+    """List configured cloud providers with their capabilities and selection policy."""
     from orb.application.services.orchestration.dtos import ListProvidersInput
     from orb.application.services.orchestration.list_providers import ListProvidersOrchestrator
 
@@ -61,7 +61,7 @@ async def handle_list_providers(args) -> dict[str, Any]:
 
 @handle_interface_exceptions(context="provider_config", interface_type="cli")
 async def handle_provider_config(args) -> dict[str, Any]:
-    """Handle get provider config operations."""
+    """Retrieve the current provider configuration."""
     from orb.application.services.orchestration.dtos import GetProviderConfigInput
     from orb.application.services.orchestration.get_provider_config import (
         GetProviderConfigOrchestrator,
@@ -103,7 +103,7 @@ async def handle_execute_provider_operation(args) -> dict[str, Any]:
 
 @handle_interface_exceptions(context="provider_metrics", interface_type="cli")
 async def handle_provider_metrics(args) -> dict[str, Any]:
-    """Handle get provider metrics operations."""
+    """Retrieve provider usage metrics for a given timeframe, optionally filtered by provider."""
     from orb.application.services.orchestration.dtos import GetProviderMetricsInput
     from orb.application.services.orchestration.get_provider_metrics import (
         GetProviderMetricsOrchestrator,

--- a/src/orb/interface/template_command_handlers.py
+++ b/src/orb/interface/template_command_handlers.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 async def handle_list_templates(
     args: argparse.Namespace,
 ) -> dict[str, Any] | InterfaceResponse:
-    """Handle list templates operations using the ListTemplatesOrchestrator."""
+    """List compute templates, optionally filtered by provider and active status, with pagination."""
     from orb.application.services.orchestration.dtos import ListTemplatesInput
     from orb.domain.base.ports.console_port import ConsolePort
     from orb.interface.catalog import OPERATION_CATALOG, Interface
@@ -78,7 +78,7 @@ async def handle_list_templates(
 async def handle_get_template(
     args: argparse.Namespace,
 ) -> dict[str, Any] | InterfaceResponse:
-    """Handle get template operations using the GetTemplateOrchestrator."""
+    """Retrieve a single compute template by its template ID."""
     from orb.application.services.orchestration.dtos import GetTemplateInput
     from orb.interface.catalog import OPERATION_CATALOG, Interface
 
@@ -377,7 +377,7 @@ async def handle_delete_template(
 async def handle_validate_template(
     args: argparse.Namespace,
 ) -> dict[str, Any] | InterfaceResponse:
-    """Handle validate template operations using the ValidateTemplateOrchestrator."""
+    """Validate a compute template by ID, from a file, or all templates with --all."""
     from orb.application.services.orchestration.dtos import ValidateTemplateInput
     from orb.interface.catalog import OPERATION_CATALOG, Interface
 

--- a/src/orb/providers/aws/domain/services/ami_resolver.py
+++ b/src/orb/providers/aws/domain/services/ami_resolver.py
@@ -164,11 +164,12 @@ class AWSAMIResolver(ImageResolver):
         """
         try:
             import boto3
-            from botocore.config import Config
+
+            from orb.providers.aws.utilities.boto_config import get_boto3_config
 
             ssm_client = boto3.client(
                 "ssm",
-                config=Config(connect_timeout=10, read_timeout=30, retries={"max_attempts": 3}),
+                config=get_boto3_config(),
             )
             response = ssm_client.get_parameter(Name=ssm_path)
             ami_id = str(response["Parameter"]["Value"])

--- a/src/orb/providers/aws/infrastructure/aws_client.py
+++ b/src/orb/providers/aws/infrastructure/aws_client.py
@@ -56,17 +56,18 @@ def _mask_config_dict(config: dict) -> dict:
     return masked
 
 
-from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from orb.domain.base.ports import ConfigurationPort, LoggingPort
 from orb.infrastructure.di.injectable import injectable
+from orb.infrastructure.utilities.network_utils import TimeoutConfig
 from orb.providers.aws.exceptions.aws_exceptions import (
     AuthorizationError,
     AWSConfigurationError,
     NetworkError,
 )
 from orb.providers.aws.infrastructure.instrumentation.botocore_metrics import BotocoreMetricsHandler
+from orb.providers.aws.utilities.boto_config import get_boto3_config
 
 if TYPE_CHECKING:
     from orb.providers.aws.configuration.config import AWSProviderConfig
@@ -119,14 +120,10 @@ class AWSClient:
         read_timeout = int(aws_provider_config.aws_read_timeout) if aws_provider_config else 10
 
         # Configure retry settings
-        self.boto_config = Config(
+        self.boto_config = get_boto3_config(
+            timeout=TimeoutConfig(connect=connect_timeout, read=read_timeout),
+            max_retries=max_attempts,
             region_name=self.region_name,
-            retries={
-                "max_attempts": max_attempts,
-                "mode": "adaptive",
-            },
-            connect_timeout=connect_timeout,
-            read_timeout=read_timeout,
         )
 
         # Load performance configuration

--- a/src/orb/providers/aws/services/infrastructure_discovery_service.py
+++ b/src/orb/providers/aws/services/infrastructure_discovery_service.py
@@ -69,11 +69,10 @@ class AWSInfrastructureDiscoveryService:
         self._console = console or NullConsoleAdapter()
 
         # Create AWS session and clients
-        from botocore.config import Config
-
         from orb.providers.aws.session_factory import AWSSessionFactory
+        from orb.providers.aws.utilities.boto_config import get_boto3_config
 
-        _config = Config(connect_timeout=10, read_timeout=30, retries={"max_attempts": 3})
+        _config = get_boto3_config()
         session = AWSSessionFactory.create_session(profile=profile, region=region)
         self.ec2_client = session.client("ec2", config=_config)
         self.iam_client = session.client("iam", config=_config)

--- a/src/orb/providers/aws/storage/components/dynamodb_client_manager.py
+++ b/src/orb/providers/aws/storage/components/dynamodb_client_manager.py
@@ -2,18 +2,14 @@
 
 from typing import Any, Optional
 
-from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from orb.infrastructure.storage.components.resource_manager import (
     StorageResourceManager as ResourceManager,
 )
+from orb.providers.aws.utilities.boto_config import get_boto3_config
 
-_DEFAULT_CONFIG = Config(
-    connect_timeout=10,
-    read_timeout=30,
-    retries={"max_attempts": 3},
-)
+_DEFAULT_CONFIG = get_boto3_config()
 
 
 class DynamoDBClientManager(ResourceManager):

--- a/src/orb/providers/registration.py
+++ b/src/orb/providers/registration.py
@@ -190,16 +190,15 @@ def register_all_providers(container: DIContainer | None = None) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Deprecated aliases – kept for backward compatibility with existing callers.
+# Bootstrap aliases – kept for backward compatibility with existing callers.
 # ---------------------------------------------------------------------------
 
 
 def register_all_provider_types() -> None:
     """Register all available provider types.
 
-    Deprecated: use ``register_all_providers()`` instead.  Kept as a
-    backward-compatible alias so existing callers continue to work without
-    modification.
+    Backward-compatible alias that delegates to ``register_all_providers()``
+    so existing callers continue to work without modification.
     """
     register_all_providers(container=None)
 
@@ -209,10 +208,8 @@ def register_all_provider_cli_specs() -> None:
 
     Lightweight bootstrap that only registers CLI specs so that
     ``build_parser`` can call it before any application context exists.
-
-    Deprecated: ``register_all_providers()`` now handles CLI spec registration
-    as part of ``initialize_<name>_provider``.  This alias is retained so that
-    ``cli/args.py`` and other early-bootstrap callers continue to work.
+    Retained so that ``cli/args.py`` and other early-bootstrap callers
+    continue to work.
     """
     # Ensure entry-point providers are registered before iterating the list;
     # this function may be called before full bootstrap (e.g. from cli/args.py).
@@ -258,12 +255,9 @@ def register_all_defaults_loaders() -> None:
 
     Lightweight bootstrap that only registers ``ProviderDefaultsLoaderPort``
     implementations so that ``ConfigurationLoader._load_strategy_defaults`` can
-    call it before a full application context has been set up.
-
-    Deprecated: ``register_all_providers()`` now handles defaults-loader
-    registration as part of ``initialize_<name>_provider``.  This alias is
-    retained so that ``config/loader.py`` and other early-bootstrap callers
-    continue to work.
+    call it before a full application context has been set up.  Retained so
+    that ``config/loader.py`` and other early-bootstrap callers continue to
+    work.
     """
     # Ensure entry-point providers are registered before iterating the list;
     # this function may be called before full bootstrap (e.g. from config/loader.py).

--- a/src/orb/sdk/discovery.py
+++ b/src/orb/sdk/discovery.py
@@ -378,6 +378,9 @@ class SDKMethodDiscovery:
         """Create SDK method for query handler using direct CQRS bus."""
 
         async def sdk_method(**kwargs):
+            # Default so the error path can reference it even if mapping itself
+            # raises before the assignment below.
+            mapped_kwargs = kwargs
             try:
                 # Extract serialization options before CQRS mapping
                 raw_response = kwargs.pop("raw_response", False)
@@ -419,7 +422,7 @@ class SDKMethodDiscovery:
                     details={
                         "query_type": query_type.__name__,
                         "original_kwargs": kwargs,
-                        "mapped_kwargs": ParameterMapper.map_parameters(query_type, kwargs),
+                        "mapped_kwargs": mapped_kwargs,
                     },
                 ) from e
 
@@ -506,6 +509,9 @@ class SDKMethodDiscovery:
         """Create SDK method for command handler using direct CQRS bus."""
 
         async def sdk_method(**kwargs):
+            # Default so the error path can reference it even if mapping itself
+            # raises before the assignment below.
+            mapped_kwargs = kwargs
             try:
                 # Extract serialization options before CQRS mapping
                 raw_response = kwargs.pop("raw_response", False)
@@ -550,7 +556,7 @@ class SDKMethodDiscovery:
                     details={
                         "command_type": command_type.__name__,
                         "original_kwargs": kwargs,
-                        "mapped_kwargs": ParameterMapper.map_parameters(command_type, kwargs),
+                        "mapped_kwargs": mapped_kwargs,
                     },
                 )
 

--- a/tests/e2e/test_critical_path_e2e.py
+++ b/tests/e2e/test_critical_path_e2e.py
@@ -152,12 +152,8 @@ class TestRequestLifecycle:
 
     def test_get_request_status_returns_status(self, app, client: TestClient):
         """GET /api/v1/requests/{id}/status returns request status."""
-        mock_req = Mock()
-        mock_req.to_dict = Mock(
-            return_value={"request_id": "req-acquire-abc123", "status": "running"}
-        )
         mock_result = Mock()
-        mock_result.requests = [mock_req]
+        mock_result.requests = [{"request_id": "req-acquire-abc123", "status": "running"}]
         mock_orchestrator = AsyncMock()
         mock_orchestrator.execute = AsyncMock(return_value=mock_result)
 
@@ -259,9 +255,7 @@ class TestRequestLifecycle:
         assert create_resp.status_code == 202
 
         def _make_status_req(rid, status):
-            m = Mock()
-            m.to_dict = Mock(return_value={"request_id": rid, "status": status})
-            return m
+            return {"request_id": rid, "status": status}
 
         mock_status_orchestrator = AsyncMock()
 
@@ -322,11 +316,7 @@ class TestRequestLifecycle:
         machine_ids = ["i-lifecycle-001", "i-lifecycle-002"]
 
         def _make_status_req(rid, status, machines=None):
-            m = Mock()
-            m.to_dict = Mock(
-                return_value={"request_id": rid, "status": status, "machines": machines or []}
-            )
-            return m
+            return {"request_id": rid, "status": status, "machines": machines or []}
 
         # Step 1: create request
         mock_create_result = Mock()

--- a/tests/integration/test_full_workflow.py
+++ b/tests/integration/test_full_workflow.py
@@ -352,7 +352,8 @@ class TestEndToEndScenarios:
         """Test concurrent operations scenario."""
         app, _, _ = await _init_app()
 
-        command_bus = app.get_command_bus()
+        # Confirm the application exposes a command bus with an execute API.
+        assert hasattr(app.get_command_bus(), "execute")
         results = []
         errors = []
 
@@ -360,20 +361,21 @@ class TestEndToEndScenarios:
             import asyncio
 
             try:
-                with patch.object(
-                    command_bus,
-                    "execute",
-                    new=AsyncMock(
-                        return_value={
-                            "request_id": f"req-worker-{worker_id}",
-                            "status": "pending",
-                        }
-                    ),
-                ):
-                    loop = asyncio.new_event_loop()
-                    result = loop.run_until_complete(command_bus.execute(Mock()))
-                    loop.close()
-                    results.append(result)
+                # Each thread uses its own independent bus mock. Patching a
+                # shared object with patch.object is not thread-safe: one
+                # thread's teardown removes the attribute while another is
+                # mid-call, causing spurious AttributeErrors.
+                local_bus = Mock(spec=CommandBus)
+                local_bus.execute = AsyncMock(
+                    return_value={
+                        "request_id": f"req-worker-{worker_id}",
+                        "status": "pending",
+                    }
+                )
+                loop = asyncio.new_event_loop()
+                result = loop.run_until_complete(local_bus.execute(Mock()))
+                loop.close()
+                results.append(result)
             except Exception as e:
                 errors.append(e)
 
@@ -457,20 +459,24 @@ class TestPerformanceIntegration:
         """Test performance with concurrent requests."""
         app, _, _ = await _init_app()
 
-        query_bus = app.get_query_bus()
+        # Confirm the application exposes a query bus with an execute_sync API.
+        assert hasattr(app.get_query_bus(), "execute_sync")
         results = []
 
         def worker(worker_id):
-            with patch.object(
-                query_bus,
-                "execute_sync",
+            # Each thread uses its own independent bus mock. Patching a
+            # shared object with patch.object is not thread-safe: one
+            # thread's teardown removes the attribute while another is
+            # mid-call, causing spurious AttributeErrors.
+            local_bus = Mock(spec=QueryBus)
+            local_bus.execute_sync = Mock(
                 return_value={
                     "request_id": f"req-{worker_id}",
                     "status": "completed",
-                },
-            ):
-                result = query_bus.execute_sync(Mock())
-                results.append(result)
+                }
+            )
+            result = local_bus.execute_sync(Mock())
+            results.append(result)
 
         overall_start = time.time()
         threads = [threading.Thread(target=worker, args=(i,)) for i in range(50)]

--- a/tests/providers/aws/mocked/test_sdk_onmoto.py
+++ b/tests/providers/aws/mocked/test_sdk_onmoto.py
@@ -323,7 +323,7 @@ class TestSDKRequestLifecycle:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("scenario", get_smoke_scenarios(), ids=lambda s: s.scenario_id)
     async def test_full_request_and_return_cycle(
-        self, orb_config_dir, moto_aws, moto_vpc_resources, scenario: TestScenario
+        self, orb_config_dir, moto_aws, moto_vpc_resources, ec2_client, scenario: TestScenario
     ):
         """Full cycle: create_request -> get_request -> create_return_request.
 
@@ -436,6 +436,23 @@ class TestSDKRequestLifecycle:
                         if done:
                             break
                         await asyncio.sleep(0.5)
+
+                # 5b. Verify the underlying moto instances are actually being
+                # terminated. RunInstances creates real moto instances, so after
+                # the return request completes every acquired instance must be in
+                # a terminating/terminated state.
+                describe_result = ec2_client.describe_instances(InstanceIds=machine_ids)
+                instance_states = [
+                    inst["State"]["Name"]
+                    for reservation in describe_result["Reservations"]
+                    for inst in reservation["Instances"]
+                ]
+                assert instance_states, (
+                    f"describe_instances returned no instances for {machine_ids}"
+                )
+                assert all(state in ("shutting-down", "terminated") for state in instance_states), (
+                    f"Instances not terminated after return: {instance_states}"
+                )
 
                 # 6. After return, status should not be 'running' (machines were released)
                 if "get_request_status" in methods:

--- a/tests/providers/aws/unit/infrastructure/test_machine_adapter.py
+++ b/tests/providers/aws/unit/infrastructure/test_machine_adapter.py
@@ -416,3 +416,58 @@ class TestHealthChecksSynthesis:
         hc = result["provider_data"]["health_checks"]
         assert hc["status"] == "impaired"
         assert hc["details"]["state_reason"] == "Host failure"
+
+
+# ---------------------------------------------------------------------------
+# _extract_status_reason direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractStatusReason:
+    """Direct tests for the static _extract_status_reason helper.
+
+    It accepts both PascalCase (StateReason.Message, StateTransitionReason) and
+    snake_case (state_reason.message, state_transition_reason) shapes.
+    """
+
+    def test_pascal_state_reason_message(self):
+        """PascalCase StateReason dict → its Message string."""
+        reason = AWSMachineAdapter._extract_status_reason(
+            {"StateReason": {"Code": "Server.InternalError", "Message": "Host failure"}}
+        )
+        assert reason == "Host failure"
+
+    def test_pascal_state_transition_reason_fallback(self):
+        """No StateReason → falls back to StateTransitionReason."""
+        reason = AWSMachineAdapter._extract_status_reason(
+            {"StateTransitionReason": "User initiated (2026-01-01)"}
+        )
+        assert reason == "User initiated (2026-01-01)"
+
+    def test_snake_state_reason_message(self):
+        """snake_case state_reason dict → its message string."""
+        reason = AWSMachineAdapter._extract_status_reason(
+            {"state_reason": {"code": "Server.InternalError", "message": "Disk failure"}}
+        )
+        assert reason == "Disk failure"
+
+    def test_snake_state_transition_reason_fallback(self):
+        """No state_reason message → falls back to state_transition_reason."""
+        reason = AWSMachineAdapter._extract_status_reason(
+            {"state_transition_reason": "User initiated shutdown"}
+        )
+        assert reason == "User initiated shutdown"
+
+    def test_state_reason_takes_priority_over_transition_reason(self):
+        """StateReason.Message wins over StateTransitionReason when both present."""
+        reason = AWSMachineAdapter._extract_status_reason(
+            {
+                "StateReason": {"Message": "Primary reason"},
+                "StateTransitionReason": "Secondary reason",
+            }
+        )
+        assert reason == "Primary reason"
+
+    def test_no_reason_returns_none(self):
+        """Empty instance data → None."""
+        assert AWSMachineAdapter._extract_status_reason({}) is None

--- a/tests/security/test_trusted_hosts_warning.py
+++ b/tests/security/test_trusted_hosts_warning.py
@@ -1,0 +1,58 @@
+"""Startup warning when Host-header protection is effectively disabled."""
+
+import logging
+
+import pytest
+
+from orb.api.server import create_fastapi_app
+from orb.config.schemas.server_schema import ServerConfig
+
+_WARNING_MARKER = "Host-header protection is effectively DISABLED"
+
+
+def _build_config(trusted_hosts: list[str]) -> ServerConfig:
+    return ServerConfig(trusted_hosts=trusted_hosts)  # type: ignore[call-arg]
+
+
+class TestTrustedHostsStartupWarning:
+    """create_fastapi_app must warn when trusted_hosts disables host protection."""
+
+    def test_empty_trusted_hosts_emits_warning(self, caplog):
+        """An empty allowlist leaves the Host header unchecked — warn about it."""
+        with caplog.at_level(logging.WARNING, logger="orb.api.server"):
+            create_fastapi_app(_build_config([]))
+
+        matches = [r for r in caplog.records if _WARNING_MARKER in r.getMessage()]
+        assert matches, "expected a host-protection warning for empty trusted_hosts"
+        assert matches[0].levelno == logging.WARNING
+        assert "empty" in matches[0].getMessage()
+
+    def test_wildcard_trusted_hosts_emits_warning(self, caplog):
+        """A '*' entry accepts any Host header — warn about it."""
+        with caplog.at_level(logging.WARNING, logger="orb.api.server"):
+            create_fastapi_app(_build_config(["*"]))
+
+        matches = [r for r in caplog.records if _WARNING_MARKER in r.getMessage()]
+        assert matches, "expected a host-protection warning for wildcard trusted_hosts"
+        assert matches[0].levelno == logging.WARNING
+        assert "['*']" in matches[0].getMessage()
+
+    def test_wildcard_among_other_hosts_emits_warning(self, caplog):
+        """A '*' anywhere in the list still disables protection."""
+        with caplog.at_level(logging.WARNING, logger="orb.api.server"):
+            create_fastapi_app(_build_config(["example.com", "*"]))
+
+        matches = [r for r in caplog.records if _WARNING_MARKER in r.getMessage()]
+        assert matches, "expected a host-protection warning when '*' is present"
+
+    def test_explicit_hosts_do_not_emit_warning(self, caplog):
+        """A concrete allowlist keeps protection on — no warning."""
+        with caplog.at_level(logging.WARNING, logger="orb.api.server"):
+            create_fastapi_app(_build_config(["localhost", "127.0.0.1", "::1"]))
+
+        matches = [r for r in caplog.records if _WARNING_MARKER in r.getMessage()]
+        assert not matches, "did not expect a host-protection warning for an explicit list"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/unit/api/test_requests_router.py
+++ b/tests/unit/api/test_requests_router.py
@@ -55,9 +55,23 @@ def _make_formatter():
     return formatter
 
 
-def _make_client(app, overrides=None):
+def _make_echo_formatter():
+    """Formatter that echoes the request dicts so the body can be asserted.
+
+    Mirrors the real formatter's single-request contract (``{"requests": [...]}``)
+    without any camelCase transform, letting tests confirm a failed request's
+    error block reaches the response body rather than being 404'd away.
+    """
+    formatter = MagicMock()
+    formatter.format_request_status.side_effect = lambda requests: MagicMock(
+        data={"requests": requests}
+    )
+    return formatter
+
+
+def _make_client(app, overrides=None, formatter=None):
     scheduler = _make_scheduler()
-    formatter = _make_formatter()
+    formatter = formatter if formatter is not None else _make_formatter()
     app.dependency_overrides[get_scheduler_strategy] = lambda: scheduler
     app.dependency_overrides[get_request_formatter] = lambda: formatter
     for dep, factory in (overrides or {}).items():
@@ -70,10 +84,50 @@ def _make_client(app, overrides=None):
 class TestGetRequestDetailsRemoved:
     """GET /{request_id} route now exists and returns request details."""
 
-    def test_get_request_route_exists(self, requests_app):
-        """GET /requests/req-123 (without /status) must return 200 — route re-added."""
+    def test_get_request_unknown_id_returns_404(self, requests_app):
+        """GET /requests/req-123 (without /status) for an unknown ID must return 404.
+
+        Exercises the ACTUAL production path: the orchestrator swallows the
+        underlying RequestNotFoundError into a single dict carrying the explicit
+        ``not_found`` flag, so result.requests is length-1 (never empty). The
+        router must detect that flag and surface a 404.
+        """
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=GetRequestStatusOutput(
+                requests=[
+                    {
+                        "request_id": "req-123",
+                        "not_found": True,
+                        "error": "Request with ID 'req-123' not found",
+                    }
+                ]
+            )
+        )
+        client = _make_client(requests_app, {get_request_status_orchestrator: lambda: orchestrator})
+
+        resp = client.get("/requests/req-123")
+
+        assert resp.status_code == 404
+
+    def test_get_request_empty_result_returns_404(self, requests_app):
+        """Defensive: a truly empty result (no entries at all) also yields 404."""
         orchestrator = AsyncMock()
         orchestrator.execute = AsyncMock(return_value=GetRequestStatusOutput(requests=[]))
+        client = _make_client(requests_app, {get_request_status_orchestrator: lambda: orchestrator})
+
+        resp = client.get("/requests/req-123")
+
+        assert resp.status_code == 404
+
+    def test_get_request_found_returns_200(self, requests_app):
+        """GET /requests/{id} for a real request (no 'error' key) returns 200."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=GetRequestStatusOutput(
+                requests=[{"request_id": "req-123", "status": "completed"}]
+            )
+        )
         client = _make_client(requests_app, {get_request_status_orchestrator: lambda: orchestrator})
 
         resp = client.get("/requests/req-123")
@@ -102,10 +156,49 @@ class TestGetRequestDetailsRemoved:
         call_input = orchestrator.execute.call_args[0][0]
         assert call_input.verbose is True
 
-    def test_get_request_status_route_exists(self, requests_app):
-        """GET /requests/req-123/status must return 200."""
+    def test_get_request_status_unknown_id_returns_404(self, requests_app):
+        """GET /requests/req-123/status for an unknown ID must return 404.
+
+        Exercises the ACTUAL production path: the orchestrator returns a
+        single dict carrying the explicit ``not_found`` flag rather than an
+        empty list.
+        """
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=GetRequestStatusOutput(
+                requests=[
+                    {
+                        "request_id": "req-123",
+                        "not_found": True,
+                        "error": "Request with ID 'req-123' not found",
+                    }
+                ]
+            )
+        )
+        client = _make_client(requests_app, {get_request_status_orchestrator: lambda: orchestrator})
+
+        resp = client.get("/requests/req-123/status")
+
+        assert resp.status_code == 404
+
+    def test_get_request_status_empty_result_returns_404(self, requests_app):
+        """Defensive: a truly empty result (no entries at all) also yields 404."""
         orchestrator = AsyncMock()
         orchestrator.execute = AsyncMock(return_value=GetRequestStatusOutput(requests=[]))
+        client = _make_client(requests_app, {get_request_status_orchestrator: lambda: orchestrator})
+
+        resp = client.get("/requests/req-123/status")
+
+        assert resp.status_code == 404
+
+    def test_get_request_status_found_returns_200(self, requests_app):
+        """GET /requests/{id}/status for a real request (no 'error' key) returns 200."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=GetRequestStatusOutput(
+                requests=[{"request_id": "req-123", "status": "completed"}]
+            )
+        )
         client = _make_client(requests_app, {get_request_status_orchestrator: lambda: orchestrator})
 
         resp = client.get("/requests/req-123/status")
@@ -144,6 +237,289 @@ class TestGetRequestDetailsRemoved:
 
         call_input = orchestrator.execute.call_args[0][0]
         assert call_input.request_ids == ["req-abc"]
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestGetRequestFailedNotConfusedWithNotFound:
+    """A REAL request that failed provisioning must return 200, never 404.
+
+    RequestDTO carries a legitimate top-level ``error`` block, populated when a
+    request fails provisioning, and ``to_dict()`` emits it alongside a "status"
+    field. The single-ID endpoints must NOT mistake such a request for the
+    orchestrator's synthetic not-found marker (``{"request_id", "error"}`` with
+    no "status"). These are the regression guards.
+    """
+
+    @staticmethod
+    def _failed_request_dict():
+        """A failed request shaped exactly as RequestDTO.to_dict() emits it.
+
+        Includes BOTH a "status" of "failed" and a populated structured "error"
+        block, matching the real production key set (request_id, status,
+        created_at, error, plus the always-present scalar fields).
+        """
+        return {
+            "request_id": "req-1",
+            "status": "failed",
+            "requested_count": 1,
+            "created_at": "2026-01-01T00:00:00Z",
+            "error": {
+                "code": "InsufficientInstanceCapacity",
+                "message": "no capacity",
+            },
+        }
+
+    def test_get_request_failed_request_returns_200(self, requests_app):
+        """GET /requests/{id} for a failed request (status + error) → 200."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=GetRequestStatusOutput(requests=[self._failed_request_dict()])
+        )
+        client = _make_client(
+            requests_app,
+            {get_request_status_orchestrator: lambda: orchestrator},
+            formatter=_make_echo_formatter(),
+        )
+
+        resp = client.get("/requests/req-1")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["requests"][0]["error"]["code"] == "InsufficientInstanceCapacity"
+
+    def test_get_request_status_failed_request_returns_200(self, requests_app):
+        """GET /requests/{id}/status for a failed request (status + error) → 200."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=GetRequestStatusOutput(requests=[self._failed_request_dict()])
+        )
+        client = _make_client(
+            requests_app,
+            {get_request_status_orchestrator: lambda: orchestrator},
+            formatter=_make_echo_formatter(),
+        )
+
+        resp = client.get("/requests/req-1/status")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["requests"][0]["error"]["code"] == "InsufficientInstanceCapacity"
+
+    @staticmethod
+    def _sync_errored_entry():
+        """An EXISTING request whose provider sync raised (non-not-found).
+
+        This is the orchestrator's error marker for a request that exists but
+        failed to sync (e.g. ProviderContractError): a string ``error`` and NO
+        ``not_found`` flag. It must NOT be treated as a 404.
+        """
+        return {
+            "request_id": "req-1",
+            "error": ("Provider aws did not emit ProviderFulfilment for acquire request."),
+        }
+
+    def test_get_request_sync_errored_existing_request_returns_200(self, requests_app):
+        """GET /requests/{id}: existing request, sync errored (no flag) → 200, not 404."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=GetRequestStatusOutput(requests=[self._sync_errored_entry()])
+        )
+        client = _make_client(
+            requests_app,
+            {get_request_status_orchestrator: lambda: orchestrator},
+            formatter=_make_echo_formatter(),
+        )
+
+        resp = client.get("/requests/req-1")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "ProviderFulfilment" in body["requests"][0]["error"]
+
+    def test_get_request_status_sync_errored_existing_request_returns_200(self, requests_app):
+        """GET /requests/{id}/status: existing request, sync errored (no flag) → 200."""
+        orchestrator = AsyncMock()
+        orchestrator.execute = AsyncMock(
+            return_value=GetRequestStatusOutput(requests=[self._sync_errored_entry()])
+        )
+        client = _make_client(
+            requests_app,
+            {get_request_status_orchestrator: lambda: orchestrator},
+            formatter=_make_echo_formatter(),
+        )
+
+        resp = client.get("/requests/req-1/status")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "ProviderFulfilment" in body["requests"][0]["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestGetRequestRealOrchestrator:
+    """End-to-end guard behaviour against the REAL orchestrator (no mock output).
+
+    The orchestrator swallows the underlying RequestNotFoundError into an
+    error-shaped dict so batch callers get partial failures. These tests wire
+    the genuine orchestrator into the router to prove the single-ID endpoints
+    translate that error entry into a 404 rather than a 200 success envelope.
+    """
+
+    @staticmethod
+    def _make_orchestrator(query_bus):
+        from orb.application.services.orchestration.get_request_status import (
+            GetRequestStatusOrchestrator,
+        )
+
+        logger = MagicMock()
+        return GetRequestStatusOrchestrator(
+            command_bus=MagicMock(), query_bus=query_bus, logger=logger
+        )
+
+    def test_get_request_status_unknown_id_real_orchestrator_returns_404(self, requests_app):
+        """Real orchestrator + raising query bus → error-dict → router 404."""
+        from orb.domain.request.exceptions import RequestNotFoundError
+
+        query_bus = MagicMock()
+        query_bus.execute = AsyncMock(side_effect=RequestNotFoundError("does-not-exist"))
+        orchestrator = self._make_orchestrator(query_bus)
+        client = _make_client(requests_app, {get_request_status_orchestrator: lambda: orchestrator})
+
+        resp = client.get("/requests/does-not-exist/status")
+
+        assert resp.status_code == 404
+
+    def test_get_request_unknown_id_real_orchestrator_returns_404(self, requests_app):
+        """Real orchestrator on GET /{id} (no /status suffix) also returns 404."""
+        from orb.domain.request.exceptions import RequestNotFoundError
+
+        query_bus = MagicMock()
+        query_bus.execute = AsyncMock(side_effect=RequestNotFoundError("does-not-exist"))
+        orchestrator = self._make_orchestrator(query_bus)
+        client = _make_client(requests_app, {get_request_status_orchestrator: lambda: orchestrator})
+
+        resp = client.get("/requests/does-not-exist")
+
+        assert resp.status_code == 404
+
+    def test_get_request_status_sync_errored_real_orchestrator_returns_200(self, requests_app):
+        """Real orchestrator + query bus raising ProviderContractError → 200, not 404.
+
+        Drives the orchestrator's non-not-found except-branch: the request
+        exists but its provider sync raised, so the orchestrator emits an error
+        entry WITHOUT the not_found flag and the router must return 200.
+        """
+        from orb.domain.base.exceptions import ProviderContractError
+
+        query_bus = MagicMock()
+        query_bus.execute = AsyncMock(
+            side_effect=ProviderContractError(
+                "Provider aws did not emit ProviderFulfilment for acquire request."
+            )
+        )
+        orchestrator = self._make_orchestrator(query_bus)
+        client = _make_client(
+            requests_app,
+            {get_request_status_orchestrator: lambda: orchestrator},
+            formatter=_make_echo_formatter(),
+        )
+
+        resp = client.get("/requests/req-1/status")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "not_found" not in body["requests"][0]
+        assert "ProviderFulfilment" in body["requests"][0]["error"]
+
+    def test_get_request_sync_errored_real_orchestrator_returns_200(self, requests_app):
+        """Real orchestrator on GET /{id} (no /status): ProviderContractError → 200."""
+        from orb.domain.base.exceptions import ProviderContractError
+
+        query_bus = MagicMock()
+        query_bus.execute = AsyncMock(
+            side_effect=ProviderContractError(
+                "Provider aws did not emit ProviderFulfilment for acquire request."
+            )
+        )
+        orchestrator = self._make_orchestrator(query_bus)
+        client = _make_client(
+            requests_app,
+            {get_request_status_orchestrator: lambda: orchestrator},
+            formatter=_make_echo_formatter(),
+        )
+
+        resp = client.get("/requests/req-1")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "not_found" not in body["requests"][0]
+        assert "ProviderFulfilment" in body["requests"][0]["error"]
+
+    def test_get_request_status_real_failed_dto_returns_200(self, requests_app):
+        """Real orchestrator + query bus returning a real failed RequestDTO → 200.
+
+        Exercises the genuine RequestDTO.to_dict() serialisation path (not a
+        hand-built dict) so the test cannot drift from the production shape. The
+        DTO has status="failed" and a populated error block, which must be
+        surfaced as 200 rather than swallowed into a 404.
+        """
+        from datetime import datetime, timezone
+
+        from orb.application.request.dto import RequestDTO
+
+        failed_dto = RequestDTO(
+            request_id="req-1",
+            status="failed",
+            requested_count=1,
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            error={"code": "InsufficientInstanceCapacity", "message": "no capacity"},
+        )
+        query_bus = MagicMock()
+        query_bus.execute = AsyncMock(return_value=failed_dto)
+        orchestrator = self._make_orchestrator(query_bus)
+        client = _make_client(
+            requests_app,
+            {get_request_status_orchestrator: lambda: orchestrator},
+            formatter=_make_echo_formatter(),
+        )
+
+        resp = client.get("/requests/req-1/status")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["requests"][0]["status"] == "failed"
+        assert body["requests"][0]["error"]["code"] == "InsufficientInstanceCapacity"
+
+    def test_get_request_real_failed_dto_returns_200(self, requests_app):
+        """Real orchestrator on GET /{id} (no /status suffix) for a failed DTO → 200."""
+        from datetime import datetime, timezone
+
+        from orb.application.request.dto import RequestDTO
+
+        failed_dto = RequestDTO(
+            request_id="req-1",
+            status="failed",
+            requested_count=1,
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            error={"code": "InsufficientInstanceCapacity", "message": "no capacity"},
+        )
+        query_bus = MagicMock()
+        query_bus.execute = AsyncMock(return_value=failed_dto)
+        orchestrator = self._make_orchestrator(query_bus)
+        client = _make_client(
+            requests_app,
+            {get_request_status_orchestrator: lambda: orchestrator},
+            formatter=_make_echo_formatter(),
+        )
+
+        resp = client.get("/requests/req-1")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["requests"][0]["status"] == "failed"
+        assert body["requests"][0]["error"]["code"] == "InsufficientInstanceCapacity"
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_router_endpoints.py
+++ b/tests/unit/api/test_router_endpoints.py
@@ -446,7 +446,7 @@ class TestRequestsRouter:
 
     def test_get_request_details(self, requests_app):
         # GET /requests/{id} (without /status) is now re-added; expect 200
-        output = GetRequestStatusOutput(requests=[])
+        output = GetRequestStatusOutput(requests=[{"request_id": "req-456", "status": "running"}])
         self._override_status(requests_app, output)
         self._set_scheduler(requests_app)
         client = TestClient(requests_app, raise_server_exceptions=False)

--- a/tests/unit/application/services/orchestration/test_get_request_status_orchestrator.py
+++ b/tests/unit/application/services/orchestration/test_get_request_status_orchestrator.py
@@ -130,6 +130,58 @@ class TestGetRequestStatusOrchestrator:
         mock_logger.error.assert_called()
 
     @pytest.mark.asyncio
+    async def test_execute_not_found_error_tags_not_found_flag(self, orchestrator, mock_query_bus):
+        """A genuine EntityNotFoundError → entry carries the explicit not_found flag."""
+        from orb.domain.request.exceptions import RequestNotFoundError
+
+        mock_query_bus.execute.side_effect = RequestNotFoundError("req-missing")
+        input = GetRequestStatusInput(request_ids=["req-missing"])
+        result = await orchestrator.execute(input)
+        entry = result.requests[0]
+        assert entry["not_found"] is True
+        assert entry["request_id"] == "req-missing"
+        assert entry["error"]
+
+    @pytest.mark.asyncio
+    async def test_execute_sync_error_has_no_not_found_flag(self, orchestrator, mock_query_bus):
+        """A non-not-found error (ProviderContractError) → error entry, no not_found flag."""
+        from orb.domain.base.exceptions import ProviderContractError
+
+        mock_query_bus.execute.side_effect = ProviderContractError("contract violated")
+        input = GetRequestStatusInput(request_ids=["req-exists"])
+        result = await orchestrator.execute(input)
+        entry = result.requests[0]
+        assert "not_found" not in entry
+        assert entry["error"] == "contract violated"
+
+    @pytest.mark.asyncio
+    async def test_execute_batch_partial_failure_mixes_markers(self, orchestrator, mock_query_bus):
+        """Batch fan-out: one ok, one not-found, one sync-errored — one entry each.
+
+        Guards the per-ID partial-failure contract the batch POST relies on: the
+        orchestrator never blows up mid-batch and each ID yields exactly one
+        entry, with the not_found flag present only on the genuinely missing ID.
+        """
+        from orb.domain.base.exceptions import ProviderContractError
+        from orb.domain.request.exceptions import RequestNotFoundError
+
+        ok = MagicMock(spec=["model_dump"])
+        ok.model_dump.return_value = {"request_id": "req-ok", "status": "completed"}
+        mock_query_bus.execute.side_effect = [
+            ok,
+            RequestNotFoundError("req-missing"),
+            ProviderContractError("contract violated"),
+        ]
+        input = GetRequestStatusInput(request_ids=["req-ok", "req-missing", "req-errored"])
+        result = await orchestrator.execute(input)
+
+        assert len(result.requests) == 3
+        ok_entry, missing_entry, errored_entry = result.requests
+        assert "not_found" not in ok_entry and ok_entry["status"] == "completed"
+        assert missing_entry["not_found"] is True
+        assert "not_found" not in errored_entry and errored_entry["error"] == "contract violated"
+
+    @pytest.mark.asyncio
     async def test_execute_all_requests_none_result_returns_empty(
         self, orchestrator, mock_query_bus
     ):

--- a/tests/unit/domain/test_deprecation_alias_guard.py
+++ b/tests/unit/domain/test_deprecation_alias_guard.py
@@ -1,0 +1,84 @@
+"""Guard test: operator-facing deprecated aliases must have a warning hook.
+
+House standard (``docs/root/developer_guide/deprecation.md``): any
+operator-facing Pydantic model that uses ``AliasChoices`` to accept a
+DEPRECATED legacy field name must ALSO register a
+``model_validator(mode="before")`` that emits a ``logger.warning``.
+``AliasChoices`` alone accepts the old key *silently* — the before-validator is
+what makes the deprecation visible in the operator-facing server logs.
+
+This is a canary, deliberately scoped to the ``Template`` aggregate (the
+canonical example of the pattern) rather than sweeping every Pydantic model in
+the codebase. A blanket sweep would false-positive on camelCase/snake_case
+synonym aliases (e.g. ``machineCount``) that are naming conveniences, not
+deprecations. Every multi-choice alias on ``Template`` is a genuine legacy
+rename (``instance_type`` -> ``machine_type`` and friends).
+
+Intent: if someone adds a new deprecated alias to ``Template`` without wiring up
+the before-validator warning hook, the fields-vs-validator assertion below must
+fail.
+"""
+
+from pydantic import AliasChoices
+
+from orb.domain.template.template_aggregate import Template
+
+
+def _deprecated_alias_fields(model: type) -> list[str]:
+    """Return field names whose validation_alias accepts more than one name.
+
+    A ``AliasChoices`` with more than one choice means the field accepts a
+    legacy alias in addition to its canonical name — i.e. a deprecated field
+    name that still deserialises.
+    """
+    fields: list[str] = []
+    for name, info in model.model_fields.items():
+        alias = info.validation_alias
+        if isinstance(alias, AliasChoices) and len(alias.choices) > 1:
+            fields.append(name)
+    return fields
+
+
+def _has_before_model_validator(model: type) -> bool:
+    """True if the model registers at least one ``model_validator(mode="before")``."""
+    validators = model.__pydantic_decorators__.model_validators
+    return any(decorator.info.mode == "before" for decorator in validators.values())
+
+
+def test_template_exposes_deprecated_aliases() -> None:
+    """Sanity anchor: Template really does carry deprecated legacy aliases.
+
+    If this ever returns empty the canary below would pass vacuously, so guard
+    against the fields being removed/renamed out from under the test.
+    """
+    assert _deprecated_alias_fields(Template), (
+        "Expected Template to expose deprecated legacy aliases via AliasChoices; "
+        "none found. Update this guard if the deprecation pattern changed."
+    )
+
+
+def test_template_deprecated_aliases_have_before_validator() -> None:
+    """Deprecated aliases on Template must be paired with a warning hook.
+
+    The presence of any deprecated alias obliges the model to register a
+    ``model_validator(mode="before")`` (Template's ``_warn_deprecated_field_names``)
+    so the deprecated key is not accepted silently.
+    """
+    deprecated = _deprecated_alias_fields(Template)
+    assert deprecated  # anchored by test above; keeps the implication non-vacuous
+
+    validators = Template.__pydantic_decorators__.model_validators
+    assert validators, (
+        "Template exposes deprecated aliases "
+        f"({', '.join(sorted(deprecated))}) but registers no model_validator. "
+        "AliasChoices accepts the legacy key silently — add a "
+        'model_validator(mode="before") emitting logger.warning per '
+        "docs/root/developer_guide/deprecation.md."
+    )
+    assert _has_before_model_validator(Template), (
+        "Template exposes deprecated aliases "
+        f"({', '.join(sorted(deprecated))}) but has no "
+        'model_validator(mode="before"). The before-validator is the '
+        "load-bearing hook that emits the operator-facing logger.warning on "
+        "every deserialization path; AliasChoices alone is silent."
+    )

--- a/tests/unit/domain/test_request_metadata.py
+++ b/tests/unit/domain/test_request_metadata.py
@@ -8,7 +8,6 @@ from orb.domain.request.request_metadata import (
     LaunchTemplateInfo,
     MachineCount,
     RequestConfiguration,
-    RequestHistoryEvent,
     RequestTag,
     RequestTimeout,
 )
@@ -220,62 +219,3 @@ class TestLaunchTemplateInfo:
         assert "lt-123" in str(lt)
         assert "my-tmpl" in str(lt)
         assert "3" in str(lt)
-
-
-class TestRequestHistoryEvent:
-    def test_valid_event(self):
-        evt = RequestHistoryEvent(
-            event_type="status_change",
-            timestamp="2026-01-01T00:00:00",
-            message="Status changed",
-        )
-        assert evt.event_type == "status_change"
-        assert evt.message == "Status changed"
-
-    def test_event_type_normalized(self):
-        evt = RequestHistoryEvent(
-            event_type="Status-Change",
-            timestamp="2026-01-01T00:00:00",
-            message="msg",
-        )
-        assert evt.event_type == "status_change"
-
-    def test_invalid_timestamp_raises(self):
-        with pytest.raises(Exception):
-            RequestHistoryEvent(
-                event_type="error",
-                timestamp="not-a-date",
-                message="msg",
-            )
-
-    def test_empty_message_raises(self):
-        with pytest.raises(Exception):
-            RequestHistoryEvent(
-                event_type="error",
-                timestamp="2026-01-01T00:00:00",
-                message="",
-            )
-
-    def test_create_factory(self):
-        evt = RequestHistoryEvent.create("error", "Something went wrong", source="provider")
-        assert evt.event_type == "error"
-        assert evt.message == "Something went wrong"
-        assert evt.source == "provider"
-
-    def test_is_error_event(self):
-        evt = RequestHistoryEvent.create("error", "msg")
-        assert evt.is_error_event() is True
-
-    def test_is_not_error_event(self):
-        evt = RequestHistoryEvent.create("status_change", "msg")
-        assert evt.is_error_event() is False
-
-    def test_is_status_change_event(self):
-        evt = RequestHistoryEvent.create("status_change", "msg")
-        assert evt.is_status_change_event() is True
-
-    def test_str_representation(self):
-        evt = RequestHistoryEvent.create("error", "Something failed")
-        s = str(evt)
-        assert "error" in s
-        assert "Something failed" in s

--- a/tests/unit/infrastructure/storage/test_sql_file_locking.py
+++ b/tests/unit/infrastructure/storage/test_sql_file_locking.py
@@ -1,0 +1,151 @@
+"""Tests for SQLite storage concurrent-write serialization.
+
+Parallels ``test_json_file_locking.py`` for the SQL/SQLite backend. Verifies
+that:
+(a) Two sequential saves of DIFFERENT records to the same database both survive.
+(b) Two threads concurrently saving different records both persist (no clobber /
+    lost-update).
+
+Unlike the JSON backend — which reimplements cross-process serialization with an
+fcntl.flock on a sibling lock file — SQLite serializes writers natively via its
+built-in database-level file locking. These tests exercise that path against a
+FILE-backed SQLite database in ``tmp_path`` (a ``:memory:`` database is
+per-connection and cannot be shared across threads, so it would not exercise the
+shared-database locking behaviour under test).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from orb.infrastructure.storage.sql.strategy import SQLStorageStrategy
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COLUMNS = {
+    "id": "TEXT PRIMARY KEY",
+    "name": "TEXT",
+    "value": "INTEGER",
+}
+
+
+def _make_strategy(tmp_path: Path, table_name: str = "entities") -> SQLStorageStrategy:
+    """Return a strategy backed by a file-based SQLite DB in tmp_path.
+
+    A file (not ``:memory:``) is required so every thread's connection opens the
+    same physical database and SQLite's file locking serializes their writes.
+    """
+    db_path = str(tmp_path / "test_data.db")
+    return SQLStorageStrategy(
+        config={"type": "sqlite", "name": db_path},
+        table_name=table_name,
+        columns=_COLUMNS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) No-clobber: two sequential saves of different records both persist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNoClobberSequential:
+    """Two saves of different records must both persist — sequential baseline."""
+
+    def test_two_sequential_saves_both_survive(self, tmp_path: Path) -> None:
+        """Save record A, then save record B: both must be readable afterwards."""
+        strategy = _make_strategy(tmp_path)
+
+        strategy.save("record-A", {"id": "record-A", "name": "alpha", "value": 1})
+        strategy.save("record-B", {"id": "record-B", "name": "beta", "value": 2})
+
+        result = strategy.find_all()
+        assert "record-A" in result, "record-A was clobbered"
+        assert "record-B" in result, "record-B was clobbered"
+        assert result["record-A"]["name"] == "alpha"
+        assert result["record-B"]["name"] == "beta"
+
+    def test_update_record_does_not_drop_other_records(self, tmp_path: Path) -> None:
+        """Updating one record must not remove pre-existing records."""
+        strategy = _make_strategy(tmp_path)
+
+        strategy.save("rec-1", {"id": "rec-1", "name": "first", "value": 1})
+        strategy.save("rec-2", {"id": "rec-2", "name": "second", "value": 2})
+        # Now update rec-1 — rec-2 must survive
+        strategy.save("rec-1", {"id": "rec-1", "name": "updated", "value": 1})
+
+        result = strategy.find_all()
+        assert "rec-1" in result, "rec-1 missing after update"
+        assert "rec-2" in result, "rec-2 was clobbered by update of rec-1"
+        assert result["rec-1"]["name"] == "updated"
+        assert result["rec-2"]["name"] == "second"
+
+
+# ---------------------------------------------------------------------------
+# (b) Threaded concurrency: two threads saving different records both survive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestThreadedConcurrency:
+    """SQLite file locking + the in-process lock must prevent write clobber."""
+
+    def test_two_threads_save_different_records_both_survive(self, tmp_path: Path) -> None:
+        """Two threads concurrently saving different records must both persist."""
+        strategy = _make_strategy(tmp_path)
+        errors: list[Exception] = []
+
+        def save_record(entity_id: str, value: int) -> None:
+            try:
+                for _ in range(5):
+                    strategy.save(
+                        entity_id,
+                        {"id": entity_id, "name": entity_id, "value": value},
+                    )
+                    time.sleep(0)  # yield to the other thread
+            except Exception as exc:  # collected for assertion after join
+                errors.append(exc)
+
+        t1 = threading.Thread(target=save_record, args=("thread-A", 100))
+        t2 = threading.Thread(target=save_record, args=("thread-B", 200))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert not errors, f"Thread errors: {errors}"
+        result = strategy.find_all()
+        assert "thread-A" in result, "thread-A record missing after concurrent saves"
+        assert "thread-B" in result, "thread-B record missing after concurrent saves"
+        assert result["thread-A"]["value"] == 100
+        assert result["thread-B"]["value"] == 200
+
+    def test_many_threads_distinct_records_all_survive(self, tmp_path: Path) -> None:
+        """N threads each writing a distinct record: every record must persist."""
+        strategy = _make_strategy(tmp_path)
+        errors: list[Exception] = []
+        thread_count = 8
+
+        def save_record(index: int) -> None:
+            entity_id = f"rec-{index}"
+            try:
+                strategy.save(entity_id, {"id": entity_id, "name": entity_id, "value": index})
+            except Exception as exc:  # collected for assertion after join
+                errors.append(exc)
+
+        threads = [threading.Thread(target=save_record, args=(i,)) for i in range(thread_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread errors: {errors}"
+        result = strategy.find_all()
+        for i in range(thread_count):
+            assert f"rec-{i}" in result, f"rec-{i} missing after concurrent saves"


### PR DESCRIPTION
## Description
A batch of correctness, security, and quality cleanups across the API, AWS provider, SDK, storage, MCP, and CI surfaces.

### Bug fixes
- **404 for missing requests** — `GET /requests/{id}` and `/requests/{id}/status` returned HTTP 200 with an empty-but-valid body for a non-existent request ID. The shared status orchestrator collapsed every per-ID exception into one `{request_id, error}` shape, so the endpoint could not tell "not found" from "exists but provider-sync errored". The orchestrator now tags a genuine `EntityNotFoundError` with an explicit `not_found` flag (other per-ID errors keep a plain error entry so the batch endpoint still reports partial failures), and the single-ID endpoints raise `EntityNotFoundError` → 404 only on that flag. A request that exists but failed provisioning (status set, populated error block) still returns 200 with its detail.

### Security
- **Host-header protection** — the server now logs a startup WARNING when `trusted_hosts` is empty or contains `*` (either of which disables `TrustedHostMiddleware`), so an operator is told when DNS-rebinding/Host-spoofing protection is off.

### Correctness / provider-agnostic
- **Provider-type resolution** — removed the last two hardcoded `"aws"` fallbacks. The app schema now raises `ConfigurationError` (pointing at `orb init`) when no active provider is configured rather than defaulting to a provider or reaching into the provider registry (which would breach the config-layer boundary); the explicit configured provider still wins.
- **AWS boto config DRY** — four remaining inline botocore `Config` constructions now route through the shared `get_boto3_config()` helper. Per-site values are preserved (including `aws_client`s config-driven timeouts + region); retry mode aligns with the rest of the codebase (adaptive).
- **SDK parameter mapping** — the CQRS query/command factories computed the parameter mapping twice (try body + except block); it is now computed once and reused.

### Tests
- Thread-safe rewrite of two concurrency tests that patched a shared bus mock across worker threads (a `patch.object` race that intermittently raised `AttributeError`).
- New deprecation-alias guard test: a `Template` field exposing a deprecated legacy alias must have a `model_validator(mode="before")` warning hook, so a new silent operator-facing deprecation cannot be introduced.
- Direct unit coverage for `AWSMachineAdapter._extract_status_reason` (PascalCase + snake_case shapes).
- Moto SDK lifecycle test now asserts instance state is terminating/terminated after a return cycle.
- New SQLite concurrent-write test mirroring the JSON one; storage lock scope documented as in-process, with SQLites cross-process file locking documented at the connection layer.
- Orchestrator-level tests covering the not-found flag, the no-flag-on-sync-error path, and batch partial-failure.

### Cleanup / docs / CI
- Removed the unused `RequestHistoryEvent` value object (an unwired value object with no production callers).
- MCP tool descriptions now accurately reflect handler behaviour (fixed ~14 generic first-line docstrings that surface in `tools/list`).
- Cleared ruff lint debt in the bootstrap package (dead `noqa` directives, an unnecessary quoted annotation, a redundant lambda).
- Dropped inaccurate "Deprecated" docstrings from three internal bootstrap aliases (they have live callers and emit no warning).
- Removed the manual per-PR CHANGELOG checkbox and the workflow step that nudged manual edits, now that the changelog is generated automatically from conventional commits at release time (format-validation and preview retained).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup or refactor

## How Has This Been Tested?
- [x] Unit tests added/updated
- pyright: 0 errors across all changed files. import-linter: 3 contracts kept, 0 broken. ruff: no new findings on changed files (net removal of lint debt). Combined coverage gate passes at ~83%. Affected suites pass (api, sdk, aws provider, storage, mcp, integration workflow, security, e2e); the two previously-intermittent concurrency tests were run repeatedly to confirm stability.

## Security Considerations
- [x] Adds a startup warning when Host-header protection is disabled. The 404 change makes a genuinely-missing request return 404 instead of a 200 success envelope; existing requests (including failed ones) are unaffected.

## Reviewers
@finos/open-resource-broker-maintainers