### PR TITLE
feat: CLI/SDK wait mode, config-set persistence, UI live updates, and test coverage

### DIFF
--- a/sdk/spec/openapi.json
+++ b/sdk/spec/openapi.json
@@ -551,15 +551,43 @@
         "summary": "Request Machines",
         "description": "Request new machines from a template",
         "operationId": "requestMachines",
+        "parameters": [
+          {
+            "name": "wait",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Block until the request reaches a terminal state",
+              "default": false,
+              "title": "Wait"
+            },
+            "description": "Block until the request reaches a terminal state"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 600,
+              "minimum": 1,
+              "description": "Max wait duration in seconds",
+              "default": 300,
+              "title": "Timeout"
+            },
+            "description": "Max wait duration in seconds"
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/RequestMachinesRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "202": {
@@ -593,15 +621,43 @@
         "summary": "Return Machines",
         "description": "Return machines to the provider",
         "operationId": "returnMachines",
+        "parameters": [
+          {
+            "name": "wait",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Block until the request reaches a terminal state",
+              "default": false,
+              "title": "Wait"
+            },
+            "description": "Block until the request reaches a terminal state"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 600,
+              "minimum": 1,
+              "description": "Max wait duration in seconds",
+              "default": 300,
+              "title": "Timeout"
+            },
+            "description": "Max wait duration in seconds"
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/ReturnMachinesRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -1526,6 +1582,32 @@
               "title": "Verbose"
             },
             "description": "Include detailed info and refresh provider state"
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Block until the request reaches a terminal state",
+              "default": false,
+              "title": "Wait"
+            },
+            "description": "Block until the request reaches a terminal state"
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 600,
+              "minimum": 1,
+              "description": "Max wait duration in seconds",
+              "default": 300,
+              "title": "Timeout"
+            },
+            "description": "Max wait duration in seconds"
           }
         ],
         "responses": {
@@ -2394,8 +2476,8 @@
         "tags": [
           "Configuration"
         ],
-        "summary": "Set a configuration value (in-memory only)",
-        "description": "Sets a configuration value in memory. The change is **not** persisted to disk. Reloading from file will revert this change. Blocked when the server is in read-only mode.",
+        "summary": "Set a configuration value",
+        "description": "Sets a configuration value in memory. By default the change is **not** persisted to disk and reloading from file will revert it. Pass ``?persist=true`` to also write the updated configuration to the loaded config file so the change survives a restart. Blocked when the server is in read-only mode.",
         "operationId": "setConfigValue",
         "parameters": [
           {
@@ -2406,6 +2488,18 @@
               "type": "string",
               "title": "Key"
             }
+          },
+          {
+            "name": "persist",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Also write the updated config to the loaded config file.",
+              "default": false,
+              "title": "Persist"
+            },
+            "description": "Also write the updated config to the loaded config file."
           }
         ],
         "requestBody": {
@@ -2420,7 +2514,7 @@
         },
         "responses": {
           "200": {
-            "description": "Value set successfully (in-memory).",
+            "description": "Value set successfully.",
             "content": {
               "application/json": {
                 "schema": {}
@@ -2428,7 +2522,7 @@
             }
           },
           "400": {
-            "description": "Missing or malformed request body."
+            "description": "Missing body or no config file to persist to."
           },
           "422": {
             "description": "Validation Error",

--- a/src/orb/api/routers/config.py
+++ b/src/orb/api/routers/config.py
@@ -43,6 +43,7 @@ class SetValueResponse(BaseModel):
     key: str
     value: Any
     persisted: bool = False
+    path: str | None = None
     note: str = (
         "Set in memory only. Call POST /config/save to persist to the loaded "
         "config file, or POST /admin/reload-config to revert to disk."
@@ -259,26 +260,61 @@ async def get_config_value(
 @router.put(
     "/{key:path}",
     operation_id="setConfigValue",
-    summary="Set a configuration value (in-memory only)",
+    summary="Set a configuration value",
     description=(
-        "Sets a configuration value in memory. The change is **not** persisted to disk. "
-        "Reloading from file will revert this change. "
+        "Sets a configuration value in memory. By default the change is **not** "
+        "persisted to disk and reloading from file will revert it. Pass "
+        "``?persist=true`` to also write the updated configuration to the loaded "
+        "config file so the change survives a restart. "
         "Blocked when the server is in read-only mode."
     ),
     responses={
-        200: {"description": "Value set successfully (in-memory)."},
-        400: {"description": "Missing or malformed request body."},
+        200: {"description": "Value set successfully."},
+        400: {"description": "Missing body or no config file to persist to."},
     },
 )
 async def set_config_value(
     key: str,
     body: SetValueRequest,
+    request: Request,
+    persist: bool = Query(
+        default=False,
+        description="Also write the updated config to the loaded config file.",
+    ),
     _user=Depends(require_role("admin")),
     config_manager=CONFIG_MANAGER,
 ) -> JSONResponse:
-    """Set a configuration value in memory and return the new value with a persistence warning."""
+    """Set a configuration value; optionally persist it to disk with ?persist=true."""
     config_manager.set_configuration_value(key, body.value)
     # Read back the value to confirm it was applied
     new_value = config_manager.get_configuration_value(key, body.value)
-    response = SetValueResponse(key=key, value=new_value)
+
+    if not persist:
+        response = SetValueResponse(key=key, value=new_value)
+        return JSONResponse(content=response.model_dump(), status_code=200)
+
+    # Persisting mutates disk — apply the same destructive-admin guard the
+    # dedicated /config/save endpoint uses.
+    _check_destructive_admin_allowed(request)
+    try:
+        written_to = config_manager.save_config(None)
+    except ValueError as exc:
+        logger.warning("Config persist rejected — no config path resolved: %s", exc)
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "NO_CONFIG_PATH",
+                "message": (
+                    "No config file could be resolved to persist to. "
+                    "The value was set in memory only."
+                ),
+            },
+        ) from exc
+    response = SetValueResponse(
+        key=key,
+        value=new_value,
+        persisted=True,
+        path=written_to,
+        note=f"Set in memory and persisted to {written_to}.",
+    )
     return JSONResponse(content=response.model_dump(), status_code=200)

--- a/src/orb/api/routers/machines.py
+++ b/src/orb/api/routers/machines.py
@@ -53,6 +53,14 @@ STATUS_QUERY = Query(None, description="Filter by machine status")
 REQUEST_ID_QUERY = Query(None, description="Filter by request ID")
 OFFSET_QUERY = Query(0, ge=0, description="Number of results to skip")
 
+# Server-side ceiling for blocking ``?wait=true`` requests, so a client cannot
+# hold a worker connection open indefinitely.
+_MAX_WAIT_TIMEOUT_SECONDS = 600
+WAIT_QUERY = Query(False, description="Block until the request reaches a terminal state")
+WAIT_TIMEOUT_QUERY = Query(
+    300, ge=1, le=_MAX_WAIT_TIMEOUT_SECONDS, description="Max wait duration in seconds"
+)
+
 
 class RequestMachinesRequest(APIRequest):
     """Request for machine provisioning.
@@ -105,6 +113,8 @@ class ReturnMachinesRequest(APIRequest):
 @handle_rest_exceptions(endpoint="/api/v1/machines/request", method="POST")
 async def request_machines(
     request_data: RequestMachinesRequest,
+    wait: bool = WAIT_QUERY,
+    timeout: int = WAIT_TIMEOUT_QUERY,
     _user=Depends(require_role("operator")),
     orchestrator=ACQUIRE_ORCHESTRATOR,
     formatter=FORMATTER,
@@ -115,12 +125,16 @@ async def request_machines(
     - **template_id**: Template to use for machine creation
     - **count**: Number of machines to request (also accepted as machine_count or machineCount)
     - **additional_data**: Optional additional configuration data
+    - **wait**: Block server-side until the request is terminal or ``timeout`` elapses
+    - **timeout**: Maximum seconds to block when ``wait=true`` (server caps at 600)
     """
     result = await orchestrator.execute(
         AcquireMachinesInput(
             template_id=request_data.template_id,
             requested_count=request_data.count,
             additional_data=request_data.additional_data or {},
+            wait=wait,
+            timeout_seconds=min(timeout, _MAX_WAIT_TIMEOUT_SECONDS),
         )
     )
     entry = OPERATION_CATALOG["request_machines"]
@@ -138,6 +152,8 @@ async def request_machines(
 @handle_rest_exceptions(endpoint="/api/v1/machines/return", method="POST")
 async def return_machines(
     request_data: ReturnMachinesRequest,
+    wait: bool = WAIT_QUERY,
+    timeout: int = WAIT_TIMEOUT_QUERY,
     _user=Depends(require_role("operator")),
     orchestrator=RETURN_ORCHESTRATOR,
     formatter=FORMATTER,
@@ -146,6 +162,8 @@ async def return_machines(
     Return machines to the provider.
 
     - **machine_ids**: List of machine IDs to return
+    - **wait**: Block server-side until the return is terminal or ``timeout`` elapses
+    - **timeout**: Maximum seconds to block when ``wait=true`` (server caps at 600)
     """
     result = await orchestrator.execute(
         ReturnMachinesInput(
@@ -153,6 +171,8 @@ async def return_machines(
             request_id=request_data.request_id,
             all_machines=request_data.all_machines,
             force=request_data.force,
+            wait=wait,
+            timeout_seconds=min(timeout, _MAX_WAIT_TIMEOUT_SECONDS),
             provider_name=request_data.provider_name,
             provider_type=request_data.provider_type,
         )

--- a/src/orb/api/routers/requests.py
+++ b/src/orb/api/routers/requests.py
@@ -70,6 +70,11 @@ STATUS_QUERY = Query(None, description="Filter by request status")
 LIMIT_QUERY = Query(50, description="Limit number of results")
 OFFSET_QUERY = Query(0, ge=0, description="Number of results to skip")
 
+# Server-side ceiling for blocking ``?wait=true`` requests. Callers may pass a
+# smaller ``timeout`` but never a larger one, so a client cannot hold a worker
+# connection open indefinitely.
+_MAX_WAIT_TIMEOUT_SECONDS = 600
+
 
 def _is_terminal_status(status: str) -> bool:
     """Return True when *status* is a terminal RequestStatus value.
@@ -226,6 +231,10 @@ async def get_request(
 async def get_request_status(
     request_id: str,
     verbose: bool = Query(True, description="Include detailed info and refresh provider state"),
+    wait: bool = Query(False, description="Block until the request reaches a terminal state"),
+    timeout: int = Query(
+        300, ge=1, le=_MAX_WAIT_TIMEOUT_SECONDS, description="Max wait duration in seconds"
+    ),
     _user=Depends(require_role("viewer")),
     orchestrator=STATUS_ORCHESTRATOR,
     formatter=FORMATTER,
@@ -235,9 +244,16 @@ async def get_request_status(
 
     - **request_id**: Request identifier
     - **verbose**: Include detailed information about the request
+    - **wait**: Poll server-side until the request is terminal or ``timeout`` elapses
+    - **timeout**: Maximum seconds to block when ``wait=true`` (server caps at 600)
     """
     result = await orchestrator.execute(
-        GetRequestStatusInput(request_ids=[request_id], verbose=verbose)
+        GetRequestStatusInput(
+            request_ids=[request_id],
+            verbose=verbose,
+            wait=wait,
+            timeout_seconds=min(timeout, _MAX_WAIT_TIMEOUT_SECONDS),
+        )
     )
     # The orchestrator tags a genuinely non-existent request with an explicit
     # "not_found" flag (EntityNotFoundError swallowed for batch partial-failure

--- a/src/orb/application/commands/machine_handlers.py
+++ b/src/orb/application/commands/machine_handlers.py
@@ -41,12 +41,18 @@ class UpdateMachineStatusHandler(BaseCommandHandler[UpdateMachineStatusCommand, 
         machine = self._machine_repository.find_by_id(command.machine_id)
         if not machine:
             raise MachineNotFoundError(command.machine_id)
-        machine.update_status(
+        new_status = (
             MachineStatus.from_str(command.status)
             if isinstance(command.status, str)
             else command.status
-        )  # type: ignore[arg-type]
-        self._machine_repository.save(machine)
+        )
+        # Machine is an immutable aggregate: update_status returns a NEW machine
+        # (with the status change and its MachineStatusChangedEvent) rather than
+        # mutating in place. Persist the returned instance, not the original.
+        updated = machine.update_status(new_status)  # type: ignore[arg-type]
+        events = self._machine_repository.save(updated)
+        for event in events or []:
+            self.event_publisher.publish(event)  # type: ignore[union-attr]
 
 
 @command_handler(CleanupMachineResourcesCommand)  # type: ignore[arg-type]

--- a/src/orb/application/commands/system.py
+++ b/src/orb/application/commands/system.py
@@ -47,6 +47,10 @@ class SetConfigurationCommand(BaseCommand):
 
     key: str
     value: str
+    # Persist the change to the loaded config file. Defaults to True because a
+    # CLI process exits immediately after running, so an in-memory-only set
+    # would be lost the moment the command returns.
+    persist: bool = True
 
     # Mutable result fields for CQRS compliance
     result: Optional[dict[str, Any]] = None

--- a/src/orb/application/commands/system_handlers.py
+++ b/src/orb/application/commands/system_handlers.py
@@ -191,12 +191,21 @@ class SetConfigurationHandler(BaseCommandHandler[SetConfigurationCommand, None])
             config_manager = self.container.get(ConfigurationPort)
             config_manager.set_configuration_value(command.key, command.value)
 
+            # Persist to disk so the change survives process exit. The CLI
+            # process terminates immediately after this command, so without a
+            # disk write the value would only ever live in memory.
+            persisted_path: str | None = None
+            if command.persist:
+                persisted_path = config_manager.save_config(None)
+
             # Store result in command (CQRS compliance)
             command.result = {
                 "status": "success",
                 "message": f"Configuration '{command.key}' set successfully",
                 "key": command.key,
                 "value": command.value,
+                "persisted": command.persist,
+                "persisted_path": persisted_path,
                 "command_id": command.command_id,
             }
 

--- a/src/orb/application/queries/bulk_handlers.py
+++ b/src/orb/application/queries/bulk_handlers.py
@@ -12,6 +12,7 @@ from orb.application.dto.bulk_responses import (
     BulkRequestResponse,
     BulkTemplateResponse,
 )
+from orb.application.ports.query_bus_port import QueryBusPort
 from orb.domain.base import UnitOfWorkFactory
 from orb.domain.base.exceptions import EntityNotFoundError
 from orb.domain.base.ports import ContainerPort, ErrorHandlingPort, LoggingPort
@@ -75,35 +76,36 @@ class GetMultipleTemplatesHandler(
         logger: LoggingPort,
         error_handler: ErrorHandlingPort,
         container: ContainerPort,
+        query_bus: QueryBusPort,
     ) -> None:
         super().__init__(logger, error_handler)
         self.uow_factory = uow_factory
         self._container = container
-
-        from orb.application.factories.template_dto_factory import (  # type: ignore
-            TemplateDTOFactory,  # type: ignore[import]
-        )
-        from orb.application.services.template_query_service import (  # type: ignore
-            TemplateQueryService,  # type: ignore[import]
-        )
-
-        self._query_service = TemplateQueryService(uow_factory, logger)
-        self._dto_factory = TemplateDTOFactory()
+        # Reuse the single-template read path (GetTemplateQuery) so bulk
+        # retrieval stays consistent with defaults resolution and DTO shaping
+        # rather than duplicating that logic here.
+        self._query_bus = query_bus
 
     async def execute_query(self, query: GetMultipleTemplatesQuery) -> BulkTemplateResponse:
         """Execute bulk template retrieval."""
+        from orb.application.dto.queries import GetTemplateQuery
+
         templates = []
         not_found_ids = []
 
         for template_id in query.template_ids:
             try:
-                template = await self._query_service.get_template(template_id)
-                if query.active_only and not template.active:
+                template = await self._query_bus.execute(
+                    GetTemplateQuery(
+                        template_id=template_id,
+                        provider_name=query.provider_name,
+                    )
+                )
+                if query.active_only and not getattr(template, "is_active", True):
                     not_found_ids.append(template_id)
                     continue
 
-                template_dto = self._dto_factory.create_from_domain(template)
-                templates.append(template_dto)
+                templates.append(template)
             except EntityNotFoundError:
                 not_found_ids.append(template_id)
 
@@ -125,37 +127,30 @@ class GetMultipleMachinesHandler(BaseQueryHandler[GetMultipleMachinesQuery, Bulk
         logger: LoggingPort,
         error_handler: ErrorHandlingPort,
         container: ContainerPort,
+        query_bus: QueryBusPort,
     ) -> None:
         super().__init__(logger, error_handler)
         self.uow_factory = uow_factory
         self._container = container
-
-        from orb.application.factories.machine_dto_factory import (  # type: ignore
-            MachineDTOFactory,  # type: ignore[import]
-        )
-        from orb.application.services.machine_query_service import (  # type: ignore
-            MachineQueryService,  # type: ignore[import]
-        )
-
-        self._query_service = MachineQueryService(uow_factory, logger)
-        self._dto_factory = MachineDTOFactory()
+        # Reuse the single-machine read path (GetMachineQuery) so bulk
+        # retrieval returns the same MachineDTO shape as the single-fetch path.
+        self._query_bus = query_bus
 
     async def execute_query(self, query: GetMultipleMachinesQuery) -> BulkMachineResponse:
         """Execute bulk machine retrieval."""
+        from orb.application.dto.queries import GetMachineQuery
+
         machines = []
         not_found_ids = []
 
         for machine_id in query.machine_ids:
             try:
-                machine = await self._query_service.get_machine(machine_id)
-                request = None
-                if query.include_requests and machine.request_id:
-                    from orb.application.services.request_query_service import RequestQueryService
-
-                    request_service = RequestQueryService(self.uow_factory, self.logger)
-                    request = await request_service.get_request(machine.request_id)
-
-                machine_dto = self._dto_factory.create_from_domain(machine, request)
+                machine_dto = await self._query_bus.execute(
+                    GetMachineQuery(
+                        machine_id=machine_id,
+                        provider_name=query.provider_name,
+                    )
+                )
                 machines.append(machine_dto)
             except EntityNotFoundError:
                 not_found_ids.append(machine_id)

--- a/src/orb/application/services/orchestration/dtos.py
+++ b/src/orb/application/services/orchestration/dtos.py
@@ -86,6 +86,8 @@ class GetRequestStatusInput:
     request_ids: list[str] = dataclasses.field(default_factory=list)
     all_requests: bool = False
     verbose: bool = False
+    wait: bool = False
+    timeout_seconds: int = 300
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/orb/application/services/orchestration/get_request_status.py
+++ b/src/orb/application/services/orchestration/get_request_status.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from orb.application.dto.queries import SyncAndGetRequestQuery, SyncAndListActiveRequestsQuery
 from orb.application.ports.command_bus_port import CommandBusPort
 from orb.application.ports.query_bus_port import QueryBusPort
-from orb.application.services.orchestration.base import OrchestratorBase
+from orb.application.services.orchestration.base import (
+    TERMINAL_STATUSES as _TERMINAL_STATUSES,
+    OrchestratorBase,
+)
 from orb.application.services.orchestration.dtos import (
     GetRequestStatusInput,
     GetRequestStatusOutput,
@@ -13,6 +18,10 @@ from orb.application.services.orchestration.dtos import (
 )
 from orb.domain.base.exceptions import EntityNotFoundError
 from orb.domain.base.ports.logging_port import LoggingPort
+
+# Interval between status polls when ``wait=True``. Wall-clock time is tracked
+# against ``timeout_seconds`` so the total wait never exceeds the caller's cap.
+_POLL_INTERVAL_SECONDS = 2
 
 
 class GetRequestStatusOrchestrator(OrchestratorBase[GetRequestStatusInput, GetRequestStatusOutput]):
@@ -34,6 +43,14 @@ class GetRequestStatusOrchestrator(OrchestratorBase[GetRequestStatusInput, GetRe
             items = results.items if isinstance(results, Paginated) else (results or [])
             return GetRequestStatusOutput(requests=[self._to_dict(r) for r in items])
 
+        if input.wait and input.request_ids:
+            request_dicts = await self._poll_until_terminal(input)
+            return GetRequestStatusOutput(requests=request_dicts)
+
+        return GetRequestStatusOutput(requests=await self._fetch_once(input))
+
+    async def _fetch_once(self, input: GetRequestStatusInput) -> list[dict]:
+        """Fetch a single status snapshot for every requested ID."""
         request_dicts = []
         for request_id in input.request_ids:
             try:
@@ -71,7 +88,34 @@ class GetRequestStatusOrchestrator(OrchestratorBase[GetRequestStatusInput, GetRe
                 self._logger.error("Failed to get status for %s: %s", request_id, exc)
                 request_dicts.append({"request_id": request_id, "error": str(exc)})
 
-        return GetRequestStatusOutput(requests=request_dicts)
+        return request_dicts
+
+    async def _poll_until_terminal(self, input: GetRequestStatusInput) -> list[dict]:
+        """Poll every requested ID until all reach a terminal state or timeout.
+
+        Wall-clock time is tracked from the first poll against
+        ``input.timeout_seconds``; the last snapshot is returned when the cap is
+        reached even if some requests are still non-terminal, so callers always
+        get the freshest known state.
+        """
+        elapsed = 0
+        request_dicts = await self._fetch_once(input)
+        while not self._all_terminal(request_dicts) and elapsed < input.timeout_seconds:
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+            elapsed += _POLL_INTERVAL_SECONDS
+            request_dicts = await self._fetch_once(input)
+        return request_dicts
+
+    @staticmethod
+    def _all_terminal(request_dicts: list[dict]) -> bool:
+        """Return True once every entry is terminal, errored, or not found."""
+        for entry in request_dicts:
+            if entry.get("not_found") or entry.get("error"):
+                continue
+            status = str(entry.get("status", "")).lower()
+            if status not in _TERMINAL_STATUSES:
+                return False
+        return True
 
     @staticmethod
     def _to_dict(obj: object) -> dict:

--- a/src/orb/cli/args.py
+++ b/src/orb/cli/args.py
@@ -188,6 +188,7 @@ def add_machine_actions(subparsers, pp: "ParentParsers | None" = None):
     machines_show = subparsers.add_parser(
         "show",
         help="Show machine details",
+        description="Show detailed information about one or more machines.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     machines_show.add_argument("machine_id", nargs="?", help="Machine ID to show")
@@ -198,6 +199,7 @@ def add_machine_actions(subparsers, pp: "ParentParsers | None" = None):
     machines_request = subparsers.add_parser(
         "request",
         help="Request machines",
+        description="Request machines from a template and provision them via the active provider.",
         parents=[pp.common, pp.list, pp.provider_scope, pp.hf_compat],
     )
     machines_request.add_argument("template_id", nargs="?", help="Template ID to use")
@@ -220,6 +222,7 @@ def add_machine_actions(subparsers, pp: "ParentParsers | None" = None):
     machines_return = subparsers.add_parser(
         "return",
         help="Return machines",
+        description="Return machines to the provider, releasing the underlying compute resources.",
         parents=[pp.common, pp.list, pp.write, pp.provider_scope, pp.hf_compat],
     )
     machines_return.add_argument(
@@ -246,6 +249,7 @@ def add_machine_actions(subparsers, pp: "ParentParsers | None" = None):
     machines_terminate = subparsers.add_parser(
         "terminate",
         help="Terminate (return) machines",
+        description="Terminate machines and return them to the provider (alias for return).",
         parents=[pp.common, pp.list, pp.write, pp.provider_scope],
     )
     machines_terminate.add_argument(
@@ -269,6 +273,7 @@ def add_machine_actions(subparsers, pp: "ParentParsers | None" = None):
     machines_status = subparsers.add_parser(
         "status",
         help="Check machine status",
+        description="Check the current status of one or more machines.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     machines_status.add_argument(
@@ -282,6 +287,7 @@ def add_machine_actions(subparsers, pp: "ParentParsers | None" = None):
     machines_stop = subparsers.add_parser(
         "stop",
         help="Stop running machines",
+        description="Stop running machines without releasing them from the provider.",
         parents=[pp.common, pp.list, pp.write, pp.provider_scope],
     )
     machines_stop.add_argument(
@@ -295,6 +301,7 @@ def add_machine_actions(subparsers, pp: "ParentParsers | None" = None):
     machines_start = subparsers.add_parser(
         "start",
         help="Start stopped machines",
+        description="Start previously stopped machines for the active provider.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     machines_start.add_argument(
@@ -331,6 +338,7 @@ def add_request_actions(subparsers, pp: "ParentParsers | None" = None):
     requests_show = subparsers.add_parser(
         "show",
         help="Show request details",
+        description="Show detailed information about one or more provisioning requests.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     requests_show.add_argument(
@@ -344,6 +352,7 @@ def add_request_actions(subparsers, pp: "ParentParsers | None" = None):
     requests_cancel = subparsers.add_parser(
         "cancel",
         help="Cancel request",
+        description="Cancel an in-flight provisioning request.",
         parents=[pp.common, pp.list, pp.write, pp.provider_scope],
     )
     requests_cancel.add_argument("request_id", nargs="?", help="Request ID to cancel")
@@ -354,6 +363,7 @@ def add_request_actions(subparsers, pp: "ParentParsers | None" = None):
     requests_status = subparsers.add_parser(
         "status",
         help="Check request status",
+        description="Check the current status of one or more provisioning requests.",
         parents=[pp.common, pp.list, pp.provider_scope, pp.hf_compat],
     )
     requests_status.add_argument(
@@ -366,13 +376,12 @@ def add_request_actions(subparsers, pp: "ParentParsers | None" = None):
     requests_status.add_argument(
         "--wait", action="store_true", help="Poll until the request reaches a terminal state"
     )
-    requests_status.add_argument(
-        "--timeout", type=int, default=300, help="Wait timeout in seconds"
-    )
+    requests_status.add_argument("--timeout", type=int, default=300, help="Wait timeout in seconds")
 
     requests_watch = subparsers.add_parser(
         "watch",
         help="Watch request status in real time",
+        description="Watch a provisioning request and stream status updates until it settles.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     requests_watch.add_argument(
@@ -385,6 +394,7 @@ def add_request_actions(subparsers, pp: "ParentParsers | None" = None):
     requests_list_returns = subparsers.add_parser(
         "list-returns",
         help="List return requests",
+        description="List return requests with filtering support.",
         parents=[pp.common, pp.list, pp.provider_scope, pp.hf_compat],
     )
     requests_list_returns.add_argument("--status", help="Filter by return request status")
@@ -440,6 +450,7 @@ def add_provider_actions(subparsers, pp: "ParentParsers | None" = None):
     providers_show = subparsers.add_parser(
         "show",
         help="Show provider details",
+        description="Show detailed configuration for a provider instance.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     providers_show.add_argument("provider_name", nargs="?", help="Provider name to show")
@@ -447,11 +458,15 @@ def add_provider_actions(subparsers, pp: "ParentParsers | None" = None):
     subparsers.add_parser(
         "health",
         help="Check provider health",
+        description="Check the health of the active or selected provider.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     providers_add = subparsers.add_parser(
-        "add", help="Add new provider", parents=[pp.common, pp.list, pp.provider_scope]
+        "add",
+        help="Add new provider",
+        description="Add a new provider instance to the configuration.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     for _spec in CLISpecRegistry.all().values():
         _spec.add_arguments(providers_add)
@@ -459,13 +474,17 @@ def add_provider_actions(subparsers, pp: "ParentParsers | None" = None):
     providers_add.add_argument("--discover", action="store_true", help="Discover infrastructure")
 
     providers_remove = subparsers.add_parser(
-        "remove", help="Remove provider", parents=[pp.common, pp.list, pp.provider_scope]
+        "remove",
+        help="Remove provider",
+        description="Remove a provider instance from the configuration.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     providers_remove.add_argument("provider_name", help="Provider instance name to remove")
 
     providers_update = subparsers.add_parser(
         "update",
         help="Update provider configuration",
+        description="Update the configuration of an existing provider instance.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     providers_update.add_argument("provider_name", help="Provider instance name")
@@ -475,26 +494,39 @@ def add_provider_actions(subparsers, pp: "ParentParsers | None" = None):
     providers_set_default = subparsers.add_parser(
         "set-default",
         help="Set default provider",
+        description="Set the default provider instance used when none is specified.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     providers_set_default.add_argument("provider_name", help="Provider name to set as default")
 
     providers_get = subparsers.add_parser(
-        "get", help="Get provider details by name", parents=[pp.common, pp.list, pp.provider_scope]
+        "get",
+        help="Get provider details by name",
+        description="Get details for a provider instance by name.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     providers_get.add_argument("name", help="Provider name")
 
     subparsers.add_parser(
-        "get-default", help="Show default provider", parents=[pp.common, pp.list, pp.provider_scope]
+        "get-default",
+        help="Show default provider",
+        description="Show the current default provider instance.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     providers_select = subparsers.add_parser(
-        "select", help="Select provider instance", parents=[pp.common, pp.list, pp.provider_scope]
+        "select",
+        help="Select provider instance",
+        description="Select the active provider instance for the current session.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     providers_select.add_argument("provider_name", help="Provider name to select")
 
     providers_exec = subparsers.add_parser(
-        "exec", help="Execute provider command", parents=[pp.common, pp.list, pp.provider_scope]
+        "exec",
+        help="Execute provider command",
+        description="Execute a raw operation against a provider instance.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     providers_exec.add_argument("operation", help="Operation to execute")
     providers_exec.add_argument(
@@ -502,7 +534,10 @@ def add_provider_actions(subparsers, pp: "ParentParsers | None" = None):
     )
 
     providers_metrics = subparsers.add_parser(
-        "metrics", help="Show provider metrics", parents=[pp.common, pp.list, pp.provider_scope]
+        "metrics",
+        help="Show provider metrics",
+        description="Show operational metrics for a provider instance.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     providers_metrics.add_argument(
         "--timeframe", default="1h", help="Metrics timeframe (e.g., 1h, 24h, 7d)"
@@ -524,6 +559,7 @@ def add_template_actions(subparsers, pp: "ParentParsers | None" = None):
     templates_show = subparsers.add_parser(
         "show",
         help="Show template details",
+        description="Show detailed information about a compute template.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     templates_show.add_argument("template_id", nargs="?", help="Template ID to show")
@@ -534,6 +570,7 @@ def add_template_actions(subparsers, pp: "ParentParsers | None" = None):
     templates_create = subparsers.add_parser(
         "create",
         help="Create template",
+        description="Create a new compute template from a configuration file.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     templates_create.add_argument("--file", required=True, help="Template configuration file")
@@ -544,6 +581,7 @@ def add_template_actions(subparsers, pp: "ParentParsers | None" = None):
     templates_update = subparsers.add_parser(
         "update",
         help="Update template",
+        description="Update an existing compute template from a configuration file.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     templates_update.add_argument("template_id", nargs="?", help="Template ID to update")
@@ -557,6 +595,7 @@ def add_template_actions(subparsers, pp: "ParentParsers | None" = None):
     templates_delete = subparsers.add_parser(
         "delete",
         help="Delete template",
+        description="Delete a compute template by ID.",
         parents=[pp.common, pp.list, pp.write, pp.provider_scope],
     )
     templates_delete.add_argument("template_id", nargs="?", help="Template ID to delete")
@@ -567,6 +606,7 @@ def add_template_actions(subparsers, pp: "ParentParsers | None" = None):
     templates_validate = subparsers.add_parser(
         "validate",
         help="Validate template",
+        description="Validate one or more compute templates for correctness.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     templates_validate.add_argument("--all", action="store_true", help="Validate all templates")
@@ -579,12 +619,14 @@ def add_template_actions(subparsers, pp: "ParentParsers | None" = None):
     subparsers.add_parser(
         "refresh",
         help="Refresh template cache",
+        description="Refresh the cached template list from the provider.",
         parents=[pp.common, pp.list, pp.write, pp.provider_scope],
     )
 
     templates_generate = subparsers.add_parser(
         "generate",
         help="Generate example templates",
+        description="Generate example compute templates for the configured providers.",
         parents=[pp.common, pp.list, pp.write, pp.provider_scope],
     )
     add_multi_provider_arguments(templates_generate)
@@ -666,11 +708,19 @@ For more information, visit: {DOCS_URL}
     resource_parsers = {}
 
     # Templates
-    templates_parser = subparsers.add_parser("templates", help="Compute templates")
+    templates_parser = subparsers.add_parser(
+        "templates",
+        help="Manage compute templates",
+        description="Manage compute templates — list, show, create, update, and validate them.",
+    )
     resource_parsers["templates"] = templates_parser
     templates_subparsers = templates_parser.add_subparsers(dest="action", help="Template actions")
 
-    template_parser = subparsers.add_parser("template")
+    template_parser = subparsers.add_parser(
+        "template",
+        help="Manage compute templates (alias for templates)",
+        description="Manage compute templates (singular alias for templates).",
+    )
     resource_parsers["template"] = template_parser
     template_subparsers = template_parser.add_subparsers(dest="action", help="Template actions")
 
@@ -678,11 +728,19 @@ For more information, visit: {DOCS_URL}
     add_template_actions(template_subparsers, pp)
 
     # Machines
-    machines_parser = subparsers.add_parser("machines", help="Compute instances")
+    machines_parser = subparsers.add_parser(
+        "machines",
+        help="Manage compute instances",
+        description="Manage compute instances — request, list, show, return, and control machines.",
+    )
     resource_parsers["machines"] = machines_parser
     machines_subparsers = machines_parser.add_subparsers(dest="action", help="Machine actions")
 
-    machine_parser = subparsers.add_parser("machine")
+    machine_parser = subparsers.add_parser(
+        "machine",
+        help="Manage compute instances (alias for machines)",
+        description="Manage compute instances (singular alias for machines).",
+    )
     resource_parsers["machine"] = machine_parser
     machine_subparsers = machine_parser.add_subparsers(dest="action", help="Machine actions")
 
@@ -690,11 +748,19 @@ For more information, visit: {DOCS_URL}
     add_machine_actions(machine_subparsers, pp)
 
     # Requests
-    requests_parser = subparsers.add_parser("requests", help="Provisioning requests")
+    requests_parser = subparsers.add_parser(
+        "requests",
+        help="Manage provisioning requests",
+        description="Manage provisioning requests — list, show, cancel, and watch them.",
+    )
     resource_parsers["requests"] = requests_parser
     requests_subparsers = requests_parser.add_subparsers(dest="action", help="Request actions")
 
-    request_parser = subparsers.add_parser("request")
+    request_parser = subparsers.add_parser(
+        "request",
+        help="Manage provisioning requests (alias for requests)",
+        description="Manage provisioning requests (singular alias for requests).",
+    )
     resource_parsers["request"] = request_parser
     request_subparsers = request_parser.add_subparsers(dest="action", help="Request actions")
 
@@ -702,33 +768,48 @@ For more information, visit: {DOCS_URL}
     add_request_actions(request_subparsers, pp)
 
     # System
-    system_parser = subparsers.add_parser("system", help="System operations")
+    system_parser = subparsers.add_parser(
+        "system",
+        help="Inspect system operations",
+        description="Inspect system operations — status, health, metrics, and configuration reload.",
+    )
     resource_parsers["system"] = system_parser
     system_subparsers = system_parser.add_subparsers(
         dest="action", help="System actions", required=True
     )
 
     system_subparsers.add_parser(
-        "status", help="Show system status", parents=[pp.common, pp.list, pp.provider_scope]
+        "status",
+        help="Show system status",
+        description="Show the overall status of the ORB system.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     system_subparsers.add_parser(
-        "health", help="Check system health", parents=[pp.common, pp.list, pp.provider_scope]
+        "health",
+        help="Check system health",
+        description="Check the health of the ORB system and its dependencies.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     system_subparsers.add_parser(
-        "metrics", help="Show system metrics", parents=[pp.common, pp.list, pp.provider_scope]
+        "metrics",
+        help="Show system metrics",
+        description="Show operational metrics for the ORB system.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     system_subparsers.add_parser(
         "reload",
         help="Reload provider configuration",
+        description="Reload provider configuration without restarting the system.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     # Server (process lifecycle — local daemon control)
     server_parser = subparsers.add_parser(
         "server",
-        help="ORB server process lifecycle (start/stop/status/restart/logs/reload)",
+        help="Control the ORB server process lifecycle",
+        description="Control the ORB server process lifecycle — start, stop, status, restart, logs, and reload.",
     )
     resource_parsers["server"] = server_parser
     server_subparsers = server_parser.add_subparsers(
@@ -764,12 +845,16 @@ For more information, visit: {DOCS_URL}
     server_start = server_subparsers.add_parser(
         "start",
         help="Start the ORB server (daemonised by default)",
+        description="Start the ORB server, daemonising it by default.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     _add_server_start_args(server_start)
 
     server_stop = server_subparsers.add_parser(
-        "stop", help="Stop the running ORB server", parents=[pp.common, pp.list, pp.provider_scope]
+        "stop",
+        help="Stop the running ORB server",
+        description="Stop the running ORB server gracefully.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     server_stop.add_argument(
         "--timeout",
@@ -781,11 +866,15 @@ For more information, visit: {DOCS_URL}
     server_subparsers.add_parser(
         "status",
         help="Show ORB server status + health",
+        description="Show the ORB server process status and health.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     server_restart = server_subparsers.add_parser(
-        "restart", help="Restart the ORB server", parents=[pp.common, pp.list, pp.provider_scope]
+        "restart",
+        help="Restart the ORB server",
+        description="Restart the ORB server (stop then start).",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     _add_server_start_args(server_restart)
     server_restart.add_argument(
@@ -797,19 +886,24 @@ For more information, visit: {DOCS_URL}
     )
 
     server_logs = server_subparsers.add_parser(
-        "logs", help="Tail the ORB server log file", parents=[pp.common, pp.list, pp.provider_scope]
+        "logs",
+        help="Tail the ORB server log file",
+        description="Tail the ORB server log file.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     server_logs.add_argument("-n", "--lines", type=int, default=50, help="Lines to tail")
 
     server_subparsers.add_parser(
         "reload",
         help="Send SIGHUP to the running ORB server",
+        description="Send SIGHUP to the running ORB server to reload its configuration.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     server_ui_export = server_subparsers.add_parser(
         "ui-export",
         help="Copy the compiled SPA bundle to a local directory for CDN / static-host serving",
+        description="Copy the compiled SPA bundle to a local directory for CDN or static-host serving.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     server_ui_export.add_argument(
@@ -824,13 +918,21 @@ For more information, visit: {DOCS_URL}
     )
 
     # Infrastructure
-    infrastructure_parser = subparsers.add_parser("infrastructure", help="Infrastructure discovery")
+    infrastructure_parser = subparsers.add_parser(
+        "infrastructure",
+        help="Discover and inspect infrastructure",
+        description="Discover and inspect cloud infrastructure — VPCs, subnets, and security groups.",
+    )
     resource_parsers["infrastructure"] = infrastructure_parser
     infrastructure_subparsers = infrastructure_parser.add_subparsers(
         dest="action", help="Infrastructure actions"
     )
 
-    infra_parser = subparsers.add_parser("infra")
+    infra_parser = subparsers.add_parser(
+        "infra",
+        help="Discover and inspect infrastructure (alias for infrastructure)",
+        description="Discover and inspect cloud infrastructure (alias for infrastructure).",
+    )
     resource_parsers["infra"] = infra_parser
     infra_subparsers = infra_parser.add_subparsers(dest="action", help="Infrastructure actions")
 
@@ -838,18 +940,28 @@ For more information, visit: {DOCS_URL}
     add_infrastructure_actions(infra_subparsers, pp)
 
     # Config
-    config_parser = subparsers.add_parser("config", help="Configuration")
+    config_parser = subparsers.add_parser(
+        "config",
+        help="Manage ORB configuration",
+        description="Manage ORB configuration — show, get, set, validate, and reload settings.",
+    )
     resource_parsers["config"] = config_parser
     config_subparsers = config_parser.add_subparsers(
         dest="action", help="Config actions", required=True
     )
 
     config_subparsers.add_parser(
-        "show", help="Show configuration", parents=[pp.common, pp.list, pp.provider_scope]
+        "show",
+        help="Show configuration",
+        description="Show the current ORB configuration.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     config_set = config_subparsers.add_parser(
-        "set", help="Set configuration", parents=[pp.common, pp.list, pp.provider_scope]
+        "set",
+        help="Set configuration",
+        description="Set a configuration value by key.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     config_set.add_argument("key", help="Configuration key")
     config_set.add_argument("value", help="Configuration value")
@@ -862,27 +974,42 @@ For more information, visit: {DOCS_URL}
     )
 
     config_get = config_subparsers.add_parser(
-        "get", help="Get configuration", parents=[pp.common, pp.list, pp.provider_scope]
+        "get",
+        help="Get configuration",
+        description="Get a configuration value by key.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     config_get.add_argument("key", help="Configuration key")
 
     config_validate = config_subparsers.add_parser(
-        "validate", help="Validate configuration", parents=[pp.common, pp.list, pp.provider_scope]
+        "validate",
+        help="Validate configuration",
+        description="Validate the ORB configuration file for correctness.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     config_validate.add_argument("--file", help="Configuration file to validate")
 
     config_subparsers.add_parser(
         "reload",
         help="Reload provider configuration",
+        description="Reload provider configuration from disk.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     # Providers
-    providers_parser = subparsers.add_parser("providers", help="Cloud providers")
+    providers_parser = subparsers.add_parser(
+        "providers",
+        help="Manage cloud providers",
+        description="Manage cloud providers — list, add, update, remove, and inspect provider instances.",
+    )
     resource_parsers["providers"] = providers_parser
     providers_subparsers = providers_parser.add_subparsers(dest="action", help="Provider actions")
 
-    provider_parser = subparsers.add_parser("provider")
+    provider_parser = subparsers.add_parser(
+        "provider",
+        help="Manage cloud providers (alias for providers)",
+        description="Manage cloud providers (singular alias for providers).",
+    )
     resource_parsers["provider"] = provider_parser
     provider_subparsers = provider_parser.add_subparsers(dest="action", help="Provider actions")
 
@@ -890,43 +1017,66 @@ For more information, visit: {DOCS_URL}
     add_provider_actions(provider_subparsers, pp)
 
     # Storage
-    storage_parser = subparsers.add_parser("storage", help="Storage")
+    storage_parser = subparsers.add_parser(
+        "storage",
+        help="Manage storage backends",
+        description="Manage storage backends — list, inspect, validate, test, and migrate strategies.",
+    )
     resource_parsers["storage"] = storage_parser
     storage_subparsers = storage_parser.add_subparsers(
         dest="action", help="Storage actions", required=True
     )
 
     storage_subparsers.add_parser(
-        "list", help="List storage strategies", parents=[pp.common, pp.list, pp.provider_scope]
+        "list",
+        help="List storage strategies",
+        description="List the available storage strategies.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     storage_show = storage_subparsers.add_parser(
-        "show", help="Show storage configuration", parents=[pp.common, pp.list, pp.provider_scope]
+        "show",
+        help="Show storage configuration",
+        description="Show the configuration of the active or selected storage strategy.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     storage_show.add_argument("--strategy", help="Show specific storage strategy details")
 
     storage_validate = storage_subparsers.add_parser(
-        "validate", help="Validate storage", parents=[pp.common, pp.list, pp.provider_scope]
+        "validate",
+        help="Validate storage",
+        description="Validate the configuration of a storage strategy.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     storage_validate.add_argument("--strategy", help="Validate specific storage strategy")
 
     storage_test = storage_subparsers.add_parser(
-        "test", help="Test storage connectivity", parents=[pp.common, pp.list, pp.provider_scope]
+        "test",
+        help="Test storage connectivity",
+        description="Test connectivity to a storage strategy backend.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     storage_test.add_argument("--strategy", help="Test specific storage strategy")
     storage_test.add_argument("--timeout", type=int, default=30, help="Test timeout in seconds")
 
     storage_subparsers.add_parser(
-        "health", help="Check storage health", parents=[pp.common, pp.list, pp.provider_scope]
+        "health",
+        help="Check storage health",
+        description="Check the health of the active storage backend.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     storage_metrics = storage_subparsers.add_parser(
-        "metrics", help="Show storage metrics", parents=[pp.common, pp.list, pp.provider_scope]
+        "metrics",
+        help="Show storage metrics",
+        description="Show operational metrics for a storage strategy.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     storage_metrics.add_argument("--strategy", help="Show metrics for specific storage strategy")
 
     storage_migrate = storage_subparsers.add_parser(
         "migrate",
         help="Run SQL storage migrations (Alembic). No-op for JSON backend.",
+        description="Run SQL storage migrations via Alembic (no-op for the JSON backend).",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
     storage_migrate.add_argument(
@@ -936,39 +1086,61 @@ For more information, visit: {DOCS_URL}
     )
 
     # Scheduler
-    scheduler_parser = subparsers.add_parser("scheduler", help="Scheduler")
+    scheduler_parser = subparsers.add_parser(
+        "scheduler",
+        help="Manage scheduler strategies",
+        description="Manage scheduler strategies — list, inspect, and validate them.",
+    )
     resource_parsers["scheduler"] = scheduler_parser
     scheduler_subparsers = scheduler_parser.add_subparsers(
         dest="action", help="Scheduler actions", required=True
     )
 
     scheduler_subparsers.add_parser(
-        "list", help="List scheduler strategies", parents=[pp.common, pp.list, pp.provider_scope]
+        "list",
+        help="List scheduler strategies",
+        description="List the available scheduler strategies.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     scheduler_show = scheduler_subparsers.add_parser(
-        "show", help="Show scheduler details", parents=[pp.common, pp.list, pp.provider_scope]
+        "show",
+        help="Show scheduler details",
+        description="Show the configuration of a scheduler strategy.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     scheduler_show.add_argument("--strategy", help="Show specific scheduler strategy details")
 
     scheduler_validate = scheduler_subparsers.add_parser(
-        "validate", help="Validate scheduler", parents=[pp.common, pp.list, pp.provider_scope]
+        "validate",
+        help="Validate scheduler",
+        description="Validate the configuration of a scheduler strategy.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     scheduler_validate.add_argument("--strategy", help="Validate specific scheduler strategy")
 
     # MCP
-    mcp_parser = subparsers.add_parser("mcp", help="MCP (Model Context Protocol) operations")
+    mcp_parser = subparsers.add_parser(
+        "mcp",
+        help="Operate the MCP (Model Context Protocol) interface",
+        description="Operate the MCP (Model Context Protocol) interface — manage tools, validate, and serve.",
+    )
     resource_parsers["mcp"] = mcp_parser
     mcp_subparsers = mcp_parser.add_subparsers(dest="action", help="MCP actions", required=True)
 
     mcp_subparsers.add_parser(
         "validate",
         help="Validate the MCP tool set offline (no server)",
+        description="Validate the MCP tool set offline — build every catalog-derived "
+        "tool and confirm each has a resolvable input schema, without starting a server.",
         parents=[pp.common, pp.list, pp.provider_scope],
     )
 
     mcp_serve = mcp_subparsers.add_parser(
-        "serve", help="Start MCP server", parents=[pp.common, pp.list, pp.provider_scope]
+        "serve",
+        help="Start MCP server",
+        description="Start the MCP server to expose ORB tools to MCP clients.",
+        parents=[pp.common, pp.list, pp.provider_scope],
     )
     mcp_serve.add_argument(
         "--transport",
@@ -992,7 +1164,11 @@ For more information, visit: {DOCS_URL}
     add_k8s_legacy_subparser(subparsers)
 
     # Init
-    init_parser = subparsers.add_parser("init", help="Initialize ORB configuration")
+    init_parser = subparsers.add_parser(
+        "init",
+        help="Initialize ORB configuration",
+        description="Initialize ORB configuration, optionally discovering infrastructure interactively.",
+    )
     add_force_argument(init_parser)
     init_parser.add_argument("--non-interactive", action="store_true", help="Non-interactive mode")
     init_parser.add_argument(

--- a/src/orb/cli/args.py
+++ b/src/orb/cli/args.py
@@ -853,6 +853,13 @@ For more information, visit: {DOCS_URL}
     )
     config_set.add_argument("key", help="Configuration key")
     config_set.add_argument("value", help="Configuration value")
+    config_set.add_argument(
+        "--no-persist",
+        dest="persist",
+        action="store_false",
+        default=True,
+        help="Set the value in memory only; do not write it to the config file",
+    )
 
     config_get = config_subparsers.add_parser(
         "get", help="Get configuration", parents=[pp.common, pp.list, pp.provider_scope]

--- a/src/orb/cli/args.py
+++ b/src/orb/cli/args.py
@@ -363,6 +363,12 @@ def add_request_actions(subparsers, pp: "ParentParsers | None" = None):
     requests_status.add_argument(
         "--request-id", "-r", action="append", dest="flag_request_ids", help="Request ID to check"
     )
+    requests_status.add_argument(
+        "--wait", action="store_true", help="Poll until the request reaches a terminal state"
+    )
+    requests_status.add_argument(
+        "--timeout", type=int, default=300, help="Wait timeout in seconds"
+    )
 
     requests_watch = subparsers.add_parser(
         "watch",

--- a/src/orb/cli/factories/system_command_factory.py
+++ b/src/orb/cli/factories/system_command_factory.py
@@ -94,10 +94,11 @@ class SystemCommandFactory:
         self,
         key: str,
         value: str,
+        persist: bool = True,
         **kwargs: Any,
     ) -> SetConfigurationCommand:
         """Create command to set configuration value."""
-        return SetConfigurationCommand(key=key, value=value)
+        return SetConfigurationCommand(key=key, value=value, persist=persist)
 
     def create_get_system_config_query(
         self,

--- a/src/orb/cli/help_utils.py
+++ b/src/orb/cli/help_utils.py
@@ -6,7 +6,7 @@ def print_getting_started_help():
     from orb.cli.console import print_command, print_info
 
     print_info("To get started:")
-    print_command("  orb init --interactive       # Set up infrastructure discovery")
+    print_command("  orb init                     # Set up infrastructure discovery")
     print_command("  orb templates generate       # Generate example templates")
     print_info("")
 
@@ -16,7 +16,7 @@ def print_getting_started_help():
     print_info("")
 
     print_info("Example workflow:")
-    print_command("  $ orb init --interactive")
+    print_command("  $ orb init")
     print_command("  $ orb templates generate")
     print_command("  $ orb templates list")
     print_command("  $ orb machines request my-template 3")

--- a/src/orb/config/managers/configuration_manager.py
+++ b/src/orb/config/managers/configuration_manager.py
@@ -433,6 +433,10 @@ class ConfigurationManager:
                 try:
                     os.unlink(tmp_name)
                 except OSError:
+                    # Best-effort cleanup: the temp file may already be gone
+                    # (e.g. the failure was os.replace succeeding partially, or
+                    # the file was never created). Swallow the unlink error so
+                    # the original write failure below is the one propagated.
                     pass
                 raise
             logger.info("Configuration saved to %s", config_path)

--- a/src/orb/config/managers/configuration_manager.py
+++ b/src/orb/config/managers/configuration_manager.py
@@ -67,6 +67,10 @@ class ConfigurationManager:
         # Initialize component managers
         self._cache_manager = ConfigCacheManager()
         self._raw_config: Optional[Dict[str, Any]] = None
+        # Overlay of edits the caller made via ``set``/``update``. Persisted on
+        # top of the user's ORIGINAL config on ``save`` so that the merged,
+        # env-expanded runtime config never reaches disk. See ``save``.
+        self._pending_edits: Dict[str, Any] = {}
         self._type_converter: Optional[ConfigTypeConverter] = None
         self._path_resolver: Optional[ConfigPathResolver] = None
         self._provider_manager: Optional[ProviderConfigManager] = None
@@ -182,6 +186,7 @@ class ConfigurationManager:
             # Clear all caches
             self._cache_manager.clear_cache()
             self._raw_config = None
+            self._pending_edits = {}
             self._app_config = None
             self._type_converter = None
             self._path_resolver = None
@@ -232,14 +237,40 @@ class ConfigurationManager:
     def set(self, key: str, value: Any) -> None:
         """Set configuration value."""
         self._ensure_type_converter().set(key, value)
+        # Record the edit so ``save`` can apply it to the user's ORIGINAL
+        # config rather than persisting the merged/expanded runtime dict.
+        self._record_edit(key, value)
         # Clear relevant caches
         self._cache_manager.clear_cache()
 
     def update(self, updates: dict[str, Any]) -> None:
         """Update configuration with new values."""
         self._ensure_type_converter().update(updates)
+        # Record the edits (see ``set``).
+        self._merge_edits(self._pending_edits, updates)
         # Clear relevant caches
         self._cache_manager.clear_cache()
+
+    def _record_edit(self, key: str, value: Any) -> None:
+        """Record a single dot-notation edit into the pending-edits overlay."""
+        keys = key.split(".")
+        target = self._pending_edits
+        for k in keys[:-1]:
+            existing = target.get(k)
+            if not isinstance(existing, dict):
+                existing = {}
+                target[k] = existing
+            target = existing
+        target[keys[-1]] = value
+
+    @classmethod
+    def _merge_edits(cls, base: dict[str, Any], update: dict[str, Any]) -> None:
+        """Deep-merge *update* into *base* (dicts merge, other values replace)."""
+        for key, value in update.items():
+            if key in base and isinstance(base[key], dict) and isinstance(value, dict):
+                cls._merge_edits(base[key], value)
+            else:
+                base[key] = value
 
     # Delegate path resolution methods
     def resolve_path(
@@ -339,12 +370,71 @@ class ConfigurationManager:
         """Get configuration for a specific provider instance."""
         return self._ensure_provider_manager().get_provider_instance_config(provider_name)
 
+    def _load_original_user_config(self) -> dict[str, Any]:
+        """Return the user's OWN config content, before loader merge/expansion.
+
+        This is the raw on-disk file (or the in-memory ``config_dict`` the
+        manager was constructed from) — it contains only what the user
+        authored, with ``${VAR}`` placeholders intact and none of the package
+        or strategy defaults the loader merges in at runtime. It is the correct
+        base to write back on ``save`` so persisting a single edit never bakes
+        the merged/expanded runtime config onto the user's file.
+        """
+        import copy
+
+        if self._config_dict is not None:
+            return copy.deepcopy(self._config_dict)
+        if self._config_file:
+            from pathlib import Path
+
+            path = Path(self._config_file)
+            if path.exists():
+                with path.open() as f:
+                    loaded = json.load(f)
+                    return loaded if isinstance(loaded, dict) else {}
+        return {}
+
     def save(self, config_path: str) -> None:
-        """Save configuration to file."""
+        """Save configuration to file atomically.
+
+        Persists the user's ORIGINAL config (their on-disk file or the
+        in-memory ``config_dict`` the manager was built from) with only the
+        edits recorded via ``set``/``update`` applied on top. The merged,
+        env-expanded runtime config is never written, so ``${VAR}`` placeholders
+        survive verbatim and package/strategy defaults never leak into the
+        user's file.
+
+        Writes to a temporary file in the destination directory and then
+        renames it over the target. ``os.replace`` is atomic on the same
+        filesystem, so a reader never observes a half-written config and a
+        crash mid-write leaves the original file intact.
+        """
+        import os
+        import tempfile
+        from pathlib import Path
+
         try:
-            raw_config = self._ensure_raw_config()
-            with open(config_path, "w") as f:
-                json.dump(raw_config, f, indent=2)
+            raw_config = self._load_original_user_config()
+            self._merge_edits(raw_config, self._pending_edits)
+            target = Path(config_path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp_name = tempfile.mkstemp(
+                dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp"
+            )
+            try:
+                with os.fdopen(fd, "w") as f:
+                    json.dump(raw_config, f, indent=2)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(tmp_name, str(target))
+            except Exception:
+                # Clean up the temp file on any failure so we don't litter
+                # the config directory with orphaned .tmp files.
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+                raise
             logger.info("Configuration saved to %s", config_path)
         except Exception as e:
             logger.error("Failed to save configuration: %s", e, exc_info=True)

--- a/src/orb/interface/config_command_handlers.py
+++ b/src/orb/interface/config_command_handlers.py
@@ -58,7 +58,8 @@ async def handle_set_configuration(args: Any) -> dict[str, Any] | InterfaceRespo
     value: Any = getattr(args, "value", None)
     if not key or value is None:
         return formatter.format_error("Key and value are required")
-    cmd = factory.create_set_configuration_command(key=key, value=value)
+    persist: bool = getattr(args, "persist", True)
+    cmd = factory.create_set_configuration_command(key=key, value=value, persist=persist)
     result = await container.get(CommandBus).execute(cmd)
     raw: dict[str, Any] = (
         result if isinstance(result, dict) else {"key": key, "value": value, "success": True}

--- a/src/orb/interface/infrastructure_command_handler.py
+++ b/src/orb/interface/infrastructure_command_handler.py
@@ -141,7 +141,7 @@ def _show_provider_infrastructure(provider: Dict[str, Any], container) -> None:
     else:
         console.info("\nNo infrastructure defaults configured")
         console.info("To configure infrastructure defaults:")
-        console.info("  1. Run: orb init --interactive")
+        console.info("  1. Run: orb init")
         console.info("  2. Or run: orb infra discover (to see available infrastructure)")
         console.info("  3. Then manually add template_defaults to your provider config")
 

--- a/src/orb/interface/request_command_handlers.py
+++ b/src/orb/interface/request_command_handlers.py
@@ -78,6 +78,8 @@ async def handle_get_request_status(
         GetRequestStatusInput(
             request_ids=[str(rid) for rid in request_ids],
             verbose=getattr(args, "verbose", False),
+            wait=bool(getattr(args, "wait", False)),
+            timeout_seconds=int(getattr(args, "timeout", 300)),
         )
     )
     return render(formatter, result)

--- a/src/orb/sdk/client.py
+++ b/src/orb/sdk/client.py
@@ -68,6 +68,7 @@ class ORBClient:
         provider_type: Optional[str] = None,
         provider_name: Optional[str] = None,
         provider_config: Optional[dict[str, Any]] = None,
+        dry_run: Optional[bool] = None,
         region: Optional[str] = None,  # DEPRECATED — use provider_config
         profile: Optional[str] = None,  # DEPRECATED — use provider_config
         **kwargs,
@@ -89,6 +90,8 @@ class ORBClient:
                            instance (e.g. ``"my-k8s-cluster"``). Passed through to
                            Input DTOs on each operation.
             provider_config: Provider-specific key/value pairs (e.g. ``{"region": "us-east-1"}``).
+            dry_run: Run in dry-run mode — provider operations are mocked so nothing is
+                     provisioned. Mirrors the CLI ``--dry-run`` flag.
             region: **Deprecated.** Use ``provider_config={"region": ...}`` instead.
             profile: **Deprecated.** Use ``provider_config={"profile": ...}`` instead.
             **kwargs: Additional configuration options
@@ -135,6 +138,8 @@ class ORBClient:
             self._config.provider_name = provider_name
         if provider_config is not None:
             self._config.provider_config = {**self._config.provider_config, **provider_config}
+        if dry_run is not None:
+            self._config.dry_run = dry_run
 
         # Add any additional kwargs to custom config
         if kwargs:
@@ -208,7 +213,7 @@ class ORBClient:
                 container=self._container,
             )
 
-            if not await self._app.initialize():
+            if not await self._app.initialize(dry_run=self._config.dry_run):
                 raise ProviderError(
                     f"Failed to initialize {self._config.provider} provider",
                     provider=self._config.provider,

--- a/src/orb/sdk/client.py
+++ b/src/orb/sdk/client.py
@@ -577,6 +577,8 @@ class ORBClient:
                 request_ids=ids,
                 all_requests=kwargs.get("all_requests", False),
                 verbose=kwargs.get("verbose", False),
+                wait=kwargs.get("wait", False),
+                timeout_seconds=kwargs.get("timeout_seconds", 300),
             ),
         )
 
@@ -615,6 +617,8 @@ class ORBClient:
                 machine_ids=list(machine_ids),
                 all_machines=kwargs.get("all_machines", False),
                 force=kwargs.get("force", False),
+                wait=kwargs.get("wait", False),
+                timeout_seconds=kwargs.get("timeout_seconds", 300),
                 provider_name=kwargs.get("provider_name") or self._config.provider_name,
                 provider_type=kwargs.get("provider_type") or self._config.provider_type,
             ),

--- a/src/orb/sdk/config.py
+++ b/src/orb/sdk/config.py
@@ -50,6 +50,10 @@ class SDKConfig:
     timeout: int = 300
     retry_attempts: int = 3
 
+    # Dry-run mode: mocks provider operations so nothing is provisioned. Mirrors
+    # the CLI's --dry-run flag and is applied to Application.initialize().
+    dry_run: bool = False
+
     # Logging configuration
     log_level: str = "INFO"
 
@@ -160,6 +164,7 @@ class SDKConfig:
             timeout=int(os.getenv("ORB_TIMEOUT", "300")),
             retry_attempts=int(os.getenv("ORB_RETRY_ATTEMPTS", "3")),
             log_level=os.getenv("ORB_LOG_LEVEL", "INFO"),
+            dry_run=os.getenv("ORB_DRY_RUN", "").lower() in ("1", "true", "yes", "on"),
             config_path=os.getenv("ORB_CONFIG_FILE"),
         )
 
@@ -267,6 +272,7 @@ class SDKConfig:
             "timeout": self.timeout,
             "retry_attempts": self.retry_attempts,
             "log_level": self.log_level,
+            "dry_run": self.dry_run,
         }
 
         if self.provider_config:

--- a/src/orb/ui/pages/requests.py
+++ b/src/orb/ui/pages/requests.py
@@ -68,6 +68,16 @@ MAX_VISIBLE_COLUMNS = 5
 _TERMINAL_STATUSES: set[str] = {"complete", "failed", "cancelled", "timeout", "partial"}
 _FAILURE_LIKE_STATUSES: set[str] = {"failed", "partial", "timeout"}
 
+# Backend SSE event types (domain-event class names emitted by the event-bus
+# bridge in bootstrap.core_services) that carry a request status transition.
+# The request list subscribes to just these so it patches the affected row in
+# place instead of full-reloading on every unrelated machine/template event.
+_REQUEST_STATUS_EVENT_TYPES: set[str] = {
+    "RequestStatusChangedEvent",
+    "RequestCompletedEvent",
+    "RequestFailedEvent",
+}
+
 
 def _empty_request_skeleton() -> dict[str, Any]:
     """UI mirror of REST snake_case response shape.
@@ -1221,6 +1231,95 @@ class RequestsState(AppState):
         yield RequestsState.load
 
     _poll_started: bool = False
+
+    # Single-flight guard for the SSE live-update subscriber. Set True while
+    # ``stream_status_events`` holds an open connection so re-mounting the
+    # page never spawns a second concurrent subscriber writing to the list.
+    _sse_started: bool = False
+
+    @staticmethod
+    def _status_from_event(event_type: str, data: dict[str, Any]) -> tuple[str, str]:
+        """Extract ``(request_id, new_status)`` from an SSE request event payload.
+
+        Handles the three request-event shapes the backend event-bus bridge
+        emits (see ``bootstrap.core_services``):
+
+        - ``RequestStatusChangedEvent`` → ``new_status``
+        - ``RequestCompletedEvent``     → ``completion_status``
+        - ``RequestFailedEvent``        → ``"failed"``
+
+        The wire status is lower-cased to match the list's snake_case wire
+        contract. Returns ``("", "")`` when the payload carries no request id
+        or no derivable status so the caller can skip it.
+        """
+        rid = str(data.get("request_id") or data.get("aggregate_id") or "")
+        if not rid:
+            return "", ""
+        if event_type == "RequestFailedEvent":
+            status = "failed"
+        elif event_type == "RequestCompletedEvent":
+            status = str(data.get("completion_status") or "complete")
+        else:
+            status = str(data.get("new_status") or data.get("status") or "")
+        return rid, status.lower()
+
+    def _apply_request_status_event(self, event_type: str, data: dict[str, Any]) -> bool:
+        """Patch the matching request row's status from an SSE event.
+
+        Matches on ``request_id`` and rewrites only the ``status`` field of
+        that row (the status badge and progress-bar colour derive from it).
+        Rows for requests not currently loaded — e.g. filtered out by the
+        active tab — are ignored; they surface on the next full load.
+
+        Returns True when a row was actually changed so callers/tests can
+        assert the list was patched. Reassigns ``self.requests`` to a new
+        list so Reflex detects the mutation and recomputes ``request_rows``.
+        """
+        rid, status = self._status_from_event(event_type, data)
+        if not rid or not status:
+            return False
+        updated = False
+        new_rows: list[dict[str, Any]] = []
+        for r in self.requests:
+            if r.get("request_id") == rid and (r.get("status") or "").lower() != status:
+                patched = dict(r)
+                patched["status"] = status
+                new_rows.append(patched)
+                updated = True
+            else:
+                new_rows.append(r)
+        if updated:
+            self.requests = new_rows
+        return updated
+
+    @rx.event(background=True)
+    async def stream_status_events(self) -> None:
+        """Subscribe to the backend SSE stream and patch request rows live.
+
+        Consumes ``RequestStatusChanged`` / ``RequestCompleted`` /
+        ``RequestFailed`` events pushed over the global SSE endpoint and
+        patches the affected row in place — no full page reload, so the
+        operator's scroll position, checkbox selection and any open drawer
+        are preserved.
+
+        ``api.subscribe_events`` (via ``sse_client.stream_sse``) already
+        reconnects with exponential backoff (max 30 s) on disconnect, so this
+        loop only needs to drain events. Single-flight guarded by
+        ``_sse_started`` so a page re-mount does not open a second stream.
+        """
+        async with self:
+            if self._sse_started:
+                return
+            self._sse_started = True
+        try:
+            async for event_type, data in api.subscribe_events(
+                event_types=_REQUEST_STATUS_EVENT_TYPES
+            ):
+                async with self:
+                    self._apply_request_status_event(event_type, data)
+        finally:
+            async with self:
+                self._sse_started = False
 
     @rx.event(background=True)
     async def auto_refresh(self) -> None:
@@ -2435,5 +2534,6 @@ def requests_page() -> rx.Component:
             RequestsState.load,
             RequestsState.open_from_query,
             RequestsState.auto_refresh,
+            RequestsState.stream_status_events,
         ],
     )

--- a/tests/fixtures/mock_provider.py
+++ b/tests/fixtures/mock_provider.py
@@ -6,14 +6,14 @@ from orb.domain.machine.machine_identifiers import MachineId
 from orb.infrastructure.interfaces.provider import ProviderConfig
 
 
-class MockProviderConfig(ProviderConfig):
+class FakeProviderConfig(ProviderConfig):
     """Mock provider configuration."""
 
     provider_type: str = "mock"
     region: Optional[str] = "mock-region"
 
 
-class MockProvider:
+class FakeProvider:
     """Mock provider for testing generic functionality."""
 
     def __init__(self):
@@ -165,6 +165,6 @@ class MockProvider:
         self._instance_counter = 0
 
 
-def create_mock_provider() -> MockProvider:
+def create_mock_provider() -> FakeProvider:
     """Factory function to create a mock provider."""
-    return MockProvider()
+    return FakeProvider()

--- a/tests/infrastructure/di/test_injectable_decorator.py
+++ b/tests/infrastructure/di/test_injectable_decorator.py
@@ -13,15 +13,15 @@ from orb.infrastructure.di.decorators import get_injectable_info, injectable, is
 
 
 # Test interfaces
-class MockPort:
+class FakePort:
     """Mock port interface."""
 
 
-class MockService:
+class FakeService:
     """Mock service interface."""
 
 
-class MockAdapter(MockPort):
+class FakeAdapter(FakePort):
     """Mock adapter implementation."""
 
     def __init__(self, name: str = "test"):
@@ -29,7 +29,7 @@ class MockAdapter(MockPort):
         self.name = name
 
 
-class MockServiceImpl(MockService):
+class FakeServiceImpl(FakeService):
     """Mock service implementation."""
 
     def __init__(self, value: int = 42):
@@ -42,15 +42,15 @@ class TestInjectableDecorator:
     def setup_method(self):
         """Set up test environment."""
         self.container = DIContainer()
-        self.container.register_singleton(MockPort, lambda c: MockAdapter("injected"))
-        self.container.register_singleton(MockService, lambda c: MockServiceImpl(100))
+        self.container.register_singleton(FakePort, lambda c: FakeAdapter("injected"))
+        self.container.register_singleton(FakeService, lambda c: FakeServiceImpl(100))
 
     def test_injectable_decorator_basic(self):
         """Test basic injectable decorator functionality."""
 
         @injectable
         class BasicService:
-            def __init__(self, port: MockPort):
+            def __init__(self, port: FakePort):
                 self.port = port
 
         # Verify decorator applied
@@ -59,9 +59,9 @@ class TestInjectableDecorator:
         assert hasattr(BasicService, "_original_init")
 
         # Test manual instantiation still works
-        manual_port = MockAdapter("manual")
+        manual_port = FakeAdapter("manual")
         service = BasicService(port=manual_port)
-        assert isinstance(service.port, MockAdapter)
+        assert isinstance(service.port, FakeAdapter)
         assert service.port.name == "manual"
 
     def test_injectable_with_container_resolution(self):
@@ -69,7 +69,7 @@ class TestInjectableDecorator:
 
         @injectable
         class ServiceWithDependency:
-            def __init__(self, port: MockPort, service: MockService):
+            def __init__(self, port: FakePort, service: FakeService):
                 self.port = port
                 self.service = service
 
@@ -77,9 +77,9 @@ class TestInjectableDecorator:
             # Create instance - dependencies should be auto-resolved
             instance = ServiceWithDependency()  # type: ignore[call-arg]
 
-            assert isinstance(instance.port, MockAdapter)
+            assert isinstance(instance.port, FakeAdapter)
             assert instance.port.name == "injected"
-            assert isinstance(instance.service, MockServiceImpl)
+            assert isinstance(instance.service, FakeServiceImpl)
             assert instance.service.value == 100
 
     def test_injectable_with_optional_dependencies(self):
@@ -87,7 +87,7 @@ class TestInjectableDecorator:
 
         @injectable
         class ServiceWithOptional:
-            def __init__(self, port: MockPort, optional_service: Optional[MockService] = None):
+            def __init__(self, port: FakePort, optional_service: Optional[FakeService] = None):
                 self.port = port
                 self.optional_service = optional_service
 
@@ -95,9 +95,9 @@ class TestInjectableDecorator:
             instance = ServiceWithOptional()  # type: ignore[call-arg]
 
             # Required dependency resolved
-            assert isinstance(instance.port, MockAdapter)
+            assert isinstance(instance.port, FakeAdapter)
             # Optional dependency also resolved since it's available
-            assert isinstance(instance.optional_service, MockServiceImpl)
+            assert isinstance(instance.optional_service, FakeServiceImpl)
 
     def test_injectable_with_optional_unavailable(self):
         """Test Optional dependencies when service not available."""
@@ -108,7 +108,7 @@ class TestInjectableDecorator:
 
         @injectable
         class ServiceWithUnavailableOptional:
-            def __init__(self, port: MockPort, unavailable: Optional[UnavailableService] = None):
+            def __init__(self, port: FakePort, unavailable: Optional[UnavailableService] = None):
                 self.port = port
                 self.unavailable = unavailable
 
@@ -116,7 +116,7 @@ class TestInjectableDecorator:
             instance = ServiceWithUnavailableOptional()  # type: ignore[call-arg]
 
             # Required dependency resolved
-            assert isinstance(instance.port, MockAdapter)
+            assert isinstance(instance.port, FakeAdapter)
             # Optional dependency falls back to None when instantiation fails
             assert instance.unavailable is None
 
@@ -125,7 +125,7 @@ class TestInjectableDecorator:
 
         @injectable
         class MixedService:
-            def __init__(self, port: MockPort, manual_param: str, service: MockService):
+            def __init__(self, port: FakePort, manual_param: str, service: FakeService):
                 self.port = port
                 self.manual_param = manual_param
                 self.service = service
@@ -134,8 +134,8 @@ class TestInjectableDecorator:
             instance = MixedService(manual_param="test_value")  # type: ignore[call-arg]
 
             # Auto-resolved dependencies
-            assert isinstance(instance.port, MockAdapter)
-            assert isinstance(instance.service, MockServiceImpl)
+            assert isinstance(instance.port, FakeAdapter)
+            assert isinstance(instance.service, FakeServiceImpl)
             # Manual parameter
             assert instance.manual_param == "test_value"
 
@@ -146,9 +146,9 @@ class TestInjectableDecorator:
         class ServiceWithDefaults:
             def __init__(
                 self,
-                port: MockPort,
+                port: FakePort,
                 default_param: str = "default",
-                service: Optional[MockService] = None,
+                service: Optional[FakeService] = None,
             ):
                 self.port = port
                 self.default_param = default_param
@@ -157,16 +157,16 @@ class TestInjectableDecorator:
         with patch("orb.infrastructure.di.container.get_container", return_value=self.container):
             instance = ServiceWithDefaults()  # type: ignore[call-arg]
 
-            assert isinstance(instance.port, MockAdapter)
+            assert isinstance(instance.port, FakeAdapter)
             assert instance.default_param == "default"
-            assert isinstance(instance.service, MockServiceImpl)
+            assert isinstance(instance.service, FakeServiceImpl)
 
     def test_injectable_error_handling(self):
         """Test error handling in dependency resolution."""
 
         @injectable
         class ServiceWithError:
-            def __init__(self, port: MockPort):
+            def __init__(self, port: FakePort):
                 self.port = port
 
         # Mock container that raises exception
@@ -185,25 +185,25 @@ class TestInjectableDecorator:
         """Test extracting information about injectable classes."""
 
         @injectable
-        class InfoMockService:
+        class InfoFakeService:
             def __init__(
                 self,
-                port: MockPort,
-                optional: Optional[MockService] = None,
+                port: FakePort,
+                optional: Optional[FakeService] = None,
                 manual: str = "default",
             ):
                 self.port = port
                 self.optional = optional
                 self.manual = manual
 
-        info = get_injectable_info(InfoMockService)
+        info = get_injectable_info(InfoFakeService)
 
-        assert info["class_name"] == "InfoMockService"
+        assert info["class_name"] == "InfoFakeService"
         assert info["total_dependencies"] == 3
 
         deps = info["dependencies"]
         assert "port" in deps
-        assert deps["port"]["type"] == MockPort
+        assert deps["port"]["type"] == FakePort
         assert not deps["port"]["optional"]
 
         assert "optional" in deps
@@ -270,7 +270,7 @@ class TestInjectableIntegration:
         """Test the specific CommandBus pattern that was causing issues."""
 
         # Mock the EventPublisherPort
-        class MockEventPublisher:
+        class FakeEventPublisher:
             pass
 
         @injectable
@@ -278,14 +278,14 @@ class TestInjectableIntegration:
             def __init__(
                 self,
                 logger: Optional[LoggingPort] = None,
-                event_publisher: Optional[MockEventPublisher] = None,
+                event_publisher: Optional[FakeEventPublisher] = None,
             ):
                 self.logger = logger
                 self.event_publisher = event_publisher
 
         container = DIContainer()
         container.register_singleton(LoggingPort, lambda c: Mock(spec=LoggingPort))
-        container.register_singleton(MockEventPublisher, lambda c: MockEventPublisher())
+        container.register_singleton(FakeEventPublisher, lambda c: FakeEventPublisher())
 
         with patch("orb.infrastructure.di.container.get_container", return_value=container):
             # This should work without the Optional[LoggingPort] error

--- a/tests/infrastructure/registry/test_base_registry.py
+++ b/tests/infrastructure/registry/test_base_registry.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from orb.infrastructure.registry.base_registry import BaseRegistry, RegistryMode
 
 
-class MockStrategy:
+class FakeStrategy:
     """Mock strategy for testing."""
 
     def __init__(self, config=None):
@@ -35,7 +35,7 @@ class TestBaseRegistryConsolidatedMethods:
 
     def test_is_registered_consolidated(self):
         """Test consolidated is_registered method."""
-        strategy_factory = Mock(return_value=MockStrategy())
+        strategy_factory = Mock(return_value=FakeStrategy())
         config_factory = Mock()
 
         # Not registered initially
@@ -47,7 +47,7 @@ class TestBaseRegistryConsolidatedMethods:
 
     def test_get_registered_types_consolidated(self):
         """Test consolidated get_registered_types method."""
-        strategy_factory = Mock(return_value=MockStrategy())
+        strategy_factory = Mock(return_value=FakeStrategy())
         config_factory = Mock()
 
         # Empty initially
@@ -64,7 +64,7 @@ class TestBaseRegistryConsolidatedMethods:
 
     def test_format_not_registered_error_consolidated(self):
         """Test consolidated error formatting method."""
-        strategy_factory = Mock(return_value=MockStrategy())
+        strategy_factory = Mock(return_value=FakeStrategy())
         config_factory = Mock()
 
         # Test with no registrations
@@ -79,7 +79,7 @@ class TestBaseRegistryConsolidatedMethods:
 
     def test_format_registry_error_backward_compatibility(self):
         """Test backward compatibility alias for error formatting."""
-        strategy_factory = Mock(return_value=MockStrategy())
+        strategy_factory = Mock(return_value=FakeStrategy())
         config_factory = Mock()
 
         self.registry.register_type("aws", strategy_factory, config_factory)
@@ -96,7 +96,7 @@ class TestBaseRegistryConsolidatedMethods:
         ConcreteRegistry._instances.clear()
         registry = ConcreteRegistry(mode=RegistryMode.MULTI_CHOICE)
 
-        strategy_factory = Mock(return_value=MockStrategy())
+        strategy_factory = Mock(return_value=FakeStrategy())
         config_factory = Mock()
 
         # Test instance registration and checking
@@ -114,7 +114,7 @@ class TestBaseRegistryConsolidatedMethods:
         ConcreteRegistry._instances.clear()
         registry = ConcreteRegistry(mode=RegistryMode.MULTI_CHOICE)
 
-        strategy_factory = Mock(return_value=MockStrategy())
+        strategy_factory = Mock(return_value=FakeStrategy())
         config_factory = Mock()
 
         # Register both type and instance

--- a/tests/infrastructure/registry/test_base_registry_factory.py
+++ b/tests/infrastructure/registry/test_base_registry_factory.py
@@ -6,7 +6,7 @@ from orb.infrastructure.registry.base_registry import BaseRegistry, RegistryMode
 from orb.infrastructure.registry.registry_factory import RegistryFactory
 
 
-class MockStrategy:
+class FakeStrategy:
     """Mock strategy for testing."""
 
     def __init__(self, config=None):
@@ -54,18 +54,18 @@ class TestBaseRegistryWithFactory:
 
     def test_register_type_uses_factory(self):
         """Test that register_type uses factory for registration."""
-        strategy_factory = Mock(return_value=MockStrategy())
+        strategy_factory = Mock(return_value=FakeStrategy())
         config_factory = Mock()
 
         self.registry.register_type("test", strategy_factory, config_factory)
 
         # Should be able to create instance through factory
         instance = self.factory.create_instance("test")
-        assert isinstance(instance, MockStrategy)
+        assert isinstance(instance, FakeStrategy)
 
     def test_create_strategy_by_type_uses_factory(self):
         """Test that create_strategy_by_type uses factory."""
-        mock_strategy = MockStrategy(config="test")
+        mock_strategy = FakeStrategy(config="test")
         strategy_factory = Mock(return_value=mock_strategy)
         config_factory = Mock()
 

--- a/tests/infrastructure/registry/test_registry_factory.py
+++ b/tests/infrastructure/registry/test_registry_factory.py
@@ -5,7 +5,7 @@ import pytest
 from orb.infrastructure.registry.registry_factory import RegistryFactory
 
 
-class MockService:
+class FakeService:
     """Mock service for testing."""
 
     def __init__(self, config=None):
@@ -21,20 +21,20 @@ class TestRegistryFactory:
 
     def test_register_and_create_instance(self):
         """Test registering constructor and creating instance."""
-        self.factory.register_constructor("mock", MockService, {"config": "test"})
+        self.factory.register_constructor("mock", FakeService, {"config": "test"})
 
         instance = self.factory.create_instance("mock")
 
-        assert isinstance(instance, MockService)
+        assert isinstance(instance, FakeService)
         assert instance.config == "test"
 
     def test_create_instance_with_override_kwargs(self):
         """Test creating instance with override kwargs."""
-        self.factory.register_constructor("mock", MockService, {"config": "default"})
+        self.factory.register_constructor("mock", FakeService, {"config": "default"})
 
         instance = self.factory.create_instance("mock", config="override")
 
-        assert isinstance(instance, MockService)
+        assert isinstance(instance, FakeService)
         assert instance.config == "override"
 
     def test_create_instance_unregistered_raises_error(self):
@@ -44,9 +44,9 @@ class TestRegistryFactory:
 
     def test_register_constructor_without_dependencies(self):
         """Test registering constructor without dependencies."""
-        self.factory.register_constructor("mock", MockService)
+        self.factory.register_constructor("mock", FakeService)
 
         instance = self.factory.create_instance("mock")
 
-        assert isinstance(instance, MockService)
+        assert isinstance(instance, FakeService)
         assert instance.config is None

--- a/tests/infrastructure/storage/interfaces/test_interfaces.py
+++ b/tests/infrastructure/storage/interfaces/test_interfaces.py
@@ -15,7 +15,7 @@ from orb.infrastructure.storage.interfaces import (
 )
 
 
-class MockStorageStrategy(BaseStorageStrategy):
+class FakeStorageStrategy(BaseStorageStrategy):
     """Mock storage strategy for testing."""
 
     def __init__(self):
@@ -151,7 +151,7 @@ class TestStorageStrategyAdapter:
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.mock_strategy = MockStorageStrategy()
+        self.mock_strategy = FakeStorageStrategy()
         self.adapter = StorageStrategyAdapter(self.mock_strategy)
 
     def test_adapter_implements_all_interfaces(self):

--- a/tests/infrastructure/test_getrequestatus_functionality.py
+++ b/tests/infrastructure/test_getrequestatus_functionality.py
@@ -11,7 +11,7 @@ from orb.infrastructure.scheduler.hostfactory.hostfactory_strategy import (
 from orb.providers.results import ProviderSelectionResult
 
 
-class MockRequestDTO:
+class FakeRequestDTO:
     """Mock RequestDTO for testing."""
 
     def __init__(self, request_id="test-123", status="completed", machines=None):
@@ -72,7 +72,7 @@ class TestGetRequestStatusFunctionality:
     def test_hostfactory_format_basic(self, scheduler_strategy):
         """Test basic HostFactory formatting for getRequestStatus."""
         # Create test data
-        mock_dto = MockRequestDTO(
+        mock_dto = FakeRequestDTO(
             request_id="test-request-123",
             status="completed",
             machines=[
@@ -112,7 +112,7 @@ class TestGetRequestStatusFunctionality:
 
     def test_hostfactory_format_multiple_machines(self, scheduler_strategy):
         """Test HostFactory formatting with multiple machines."""
-        mock_dto = MockRequestDTO(
+        mock_dto = FakeRequestDTO(
             request_id="multi-test-456",
             status="completed",
             machines=[
@@ -159,7 +159,7 @@ class TestGetRequestStatusFunctionality:
         ]
 
         for domain_status, expected_hf_status in test_cases:
-            mock_dto = MockRequestDTO(status=domain_status)
+            mock_dto = FakeRequestDTO(status=domain_status)
             result = scheduler_strategy.convert_domain_to_hostfactory_output(
                 "getRequestStatus", mock_dto
             )
@@ -178,7 +178,7 @@ class TestGetRequestStatusFunctionality:
         ]
 
         for machine_status, expected_result in test_cases:
-            mock_dto = MockRequestDTO(
+            mock_dto = FakeRequestDTO(
                 machines=[
                     {
                         "instance_id": "i-test",
@@ -197,7 +197,7 @@ class TestGetRequestStatusFunctionality:
 
     def test_empty_machines_list(self, scheduler_strategy):
         """Test handling of empty machines list."""
-        mock_dto = MockRequestDTO(machines=[])
+        mock_dto = FakeRequestDTO(machines=[])
         result = scheduler_strategy.convert_domain_to_hostfactory_output(
             "getRequestStatus", mock_dto
         )

--- a/tests/integration/api/test_authentication_flows.py
+++ b/tests/integration/api/test_authentication_flows.py
@@ -166,7 +166,7 @@ class TestAuthenticationFlows:
         from orb.api.middleware.auth_middleware import AuthMiddleware
 
         # Create mock request
-        class MockRequest:
+        class FakeRequest:
             def __init__(self):
                 self.method = "GET"
                 self.url = URL("http://testserver/api/v1/templates")
@@ -181,7 +181,7 @@ class TestAuthenticationFlows:
         middleware = AuthMiddleware(app=Mock(), auth_port=auth_strategy, require_auth=False)
 
         # Test context creation
-        request = MockRequest()
+        request = FakeRequest()
         context = middleware._create_auth_context(request)  # type: ignore[arg-type]
 
         assert context.method == "GET"

--- a/tests/integration/test_dependency_injection.py
+++ b/tests/integration/test_dependency_injection.py
@@ -91,14 +91,14 @@ def test_aws_launch_template_manager_registration():
         # Test that the manager can be instantiated (with mocked dependencies)
         try:
             # Create a mock DI container to test registration
-            class MockContainer:
+            class FakeContainer:
                 def __init__(self):
                     self._services = {}
                     self._registered = set()
 
                 def get(self, service_type):
                     if service_type.__name__ == "LoggingPort":
-                        return MockLogger()
+                        return FakeLogger()
                     return None
 
                 def register_singleton(self, service_type, factory=None):
@@ -107,7 +107,7 @@ def test_aws_launch_template_manager_registration():
                 def is_registered(self, service_type):
                     return service_type.__name__ in self._registered
 
-            class MockLogger:
+            class FakeLogger:
                 def debug(self, msg):
                     pass
 
@@ -121,7 +121,7 @@ def test_aws_launch_template_manager_registration():
                     pass
 
             # Test registration
-            mock_container = MockContainer()
+            mock_container = FakeContainer()
             register_aws_services_with_di(mock_container)
 
             # Check if AWSLaunchTemplateManager was registered

--- a/tests/integration/test_hostfactory_lifecycle.py
+++ b/tests/integration/test_hostfactory_lifecycle.py
@@ -11,8 +11,8 @@ from tests.fixtures.provider_scenarios import (
 )
 
 
-class MockAppService:
-    """Thin adapter wrapping MockProvider with Host Factory-style API."""
+class FakeAppService:
+    """Thin adapter wrapping FakeProvider with Host Factory-style API."""
 
     def __init__(self, provider):
         self._provider = provider
@@ -244,7 +244,7 @@ class TestHostFactoryLifecycle:
         assert status_response["requests"][0]["requestId"] == req_id
 
         # Create another app service instance sharing the same provider (simulating restart)
-        app_service2 = MockAppService(provider)
+        app_service2 = FakeAppService(provider)
         # Copy state to simulate persistence
         app_service2._requests = app_service._requests
 
@@ -300,7 +300,7 @@ class TestHostFactoryLifecycle:
 
     def _create_app_service_with_provider(self, provider_type: str, provider):
         """Create application service with mock provider."""
-        return MockAppService(provider)
+        return FakeAppService(provider)
 
 
 @pytest.mark.integration

--- a/tests/providers/aws/contract/test_aws_ec2_fleet_contract.py
+++ b/tests/providers/aws/contract/test_aws_ec2_fleet_contract.py
@@ -1,0 +1,133 @@
+"""EC2Fleet contract coverage (moto-backed).
+
+The shared contract fixtures in conftest.py provision via ASG (provisioning)
+and RunInstances (monitoring). This module extends contract-tier coverage to
+EC2Fleet, which previously had none, and asserts the two behaviours the shared
+suite skips as simulator limitations:
+
+  * exact-count fulfilment — a request for N instances yields N running
+    instances with a fulfilled verdict (not merely ">= 1");
+  * real release_hosts termination — release is called with the actual launched
+    instance IDs and the instances are observed terminated afterwards.
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent / "src"))
+
+from orb.domain.base.provider_fulfilment import CheckHostsStatusResult
+from orb.providers.aws.domain.template.aws_template_aggregate import AWSTemplate
+from orb.providers.aws.infrastructure.handlers.ec2_fleet.handler import EC2FleetHandler
+from orb.providers.aws.utilities.aws_operations import AWSOperations
+from tests.providers.aws.contract.conftest import (
+    REGION,
+    _make_aws_client,
+    _make_config_port,
+    _make_logger,
+    _make_lt_manager,
+    _make_request,
+)
+
+
+def _build_ec2_fleet_handler(aws_client, logger, config_port) -> EC2FleetHandler:
+    aws_ops = AWSOperations(aws_client, logger, config_port)
+    lt_manager = _make_lt_manager(aws_client, logger)
+    return EC2FleetHandler(
+        aws_client=aws_client,
+        logger=logger,
+        aws_ops=aws_ops,
+        launch_template_manager=lt_manager,
+        config_port=config_port,
+    )
+
+
+def _ec2_fleet_template(subnet_id: str, sg_id: str, fleet_type: str = "maintain") -> AWSTemplate:
+    return AWSTemplate(
+        template_id="tpl-contract-fleet",
+        name="contract-fleet",
+        provider_api="EC2Fleet",
+        machine_types={"t3.micro": 1},
+        image_id="ami-12345678",
+        max_instances=5,
+        price_type="ondemand",
+        fleet_type=fleet_type,
+        subnet_ids=[subnet_id],
+        security_group_ids=[sg_id],
+        tags={"Environment": "contract-test"},
+    )
+
+
+@pytest.fixture
+def ec2_fleet_handler(moto_vpc_resources) -> EC2FleetHandler:
+    return _build_ec2_fleet_handler(_make_aws_client(), _make_logger(), _make_config_port())
+
+
+@pytest.mark.provider_contract
+class TestAWSEC2FleetContract:
+    """EC2Fleet satisfies the provisioning + monitoring contract at exact count."""
+
+    def test_acquire_returns_success_and_fleet_id(
+        self, ec2_fleet_handler, moto_vpc_resources
+    ) -> None:
+        subnet_id = moto_vpc_resources["subnet_ids"][0]
+        sg_id = moto_vpc_resources["sg_id"]
+        request = _make_request(request_id="contract-fleet-001", requested_count=2)
+
+        result = ec2_fleet_handler.acquire_hosts(request, _ec2_fleet_template(subnet_id, sg_id))
+
+        assert isinstance(result, dict)
+        assert result["success"] is True
+        assert result["resource_ids"] and result["resource_ids"][0].startswith("fleet-")
+
+    def test_exact_count_fulfilment(self, ec2_fleet_handler, moto_vpc_resources) -> None:
+        """A request for N instances yields exactly N running instances, fulfilled."""
+        subnet_id = moto_vpc_resources["subnet_ids"][0]
+        sg_id = moto_vpc_resources["sg_id"]
+        request = _make_request(request_id="contract-fleet-002", requested_count=3)
+
+        fleet_id = ec2_fleet_handler.acquire_hosts(request, _ec2_fleet_template(subnet_id, sg_id))[
+            "resource_ids"
+        ][0]
+
+        status_request = _make_request(
+            request_id="contract-fleet-002", requested_count=3, resource_ids=[fleet_id]
+        )
+        result = ec2_fleet_handler.check_hosts_status(status_request)
+
+        assert isinstance(result, CheckHostsStatusResult)
+        assert len(result.instances) == 3
+        assert result.fulfilment.running_count == 3
+        assert result.fulfilment.target_units == 3
+        assert result.fulfilment.state == "fulfilled"
+
+    def test_release_terminates_launched_instances(
+        self, ec2_fleet_handler, moto_vpc_resources
+    ) -> None:
+        """release_hosts called with real instance IDs terminates them."""
+        subnet_id = moto_vpc_resources["subnet_ids"][0]
+        sg_id = moto_vpc_resources["sg_id"]
+        ec2 = boto3.client("ec2", region_name=REGION)
+        request = _make_request(request_id="contract-fleet-003", requested_count=2)
+
+        fleet_id = ec2_fleet_handler.acquire_hosts(request, _ec2_fleet_template(subnet_id, sg_id))[
+            "resource_ids"
+        ][0]
+
+        status_request = _make_request(
+            request_id="contract-fleet-003", requested_count=2, resource_ids=[fleet_id]
+        )
+        instance_ids = [
+            entry["instance_id"]
+            for entry in ec2_fleet_handler.check_hosts_status(status_request).instances
+        ]
+        assert len(instance_ids) == 2
+
+        ec2_fleet_handler.release_hosts(instance_ids)
+
+        resp = ec2.describe_instances(InstanceIds=instance_ids)
+        states = [i["State"]["Name"] for r in resp["Reservations"] for i in r["Instances"]]
+        assert all(s in ("shutting-down", "terminated") for s in states)

--- a/tests/providers/aws/contract/test_aws_spot_fleet_contract.py
+++ b/tests/providers/aws/contract/test_aws_spot_fleet_contract.py
@@ -1,0 +1,148 @@
+"""SpotFleet contract coverage (moto-backed).
+
+The shared contract fixtures in conftest.py provision via ASG and RunInstances.
+This module extends contract-tier coverage to SpotFleet, which previously had
+none, and asserts exact-count fulfilment and real release_hosts termination
+(non-empty instance ID list) the shared suite skips as simulator limitations.
+
+The config builder is wrapped to strip the ``instance`` TagSpecification entry
+that moto's request_spot_fleet rejects — the same shim the mocked-tier lifecycle
+tests use.
+"""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import boto3
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent / "src"))
+
+from orb.domain.base.provider_fulfilment import CheckHostsStatusResult
+from orb.providers.aws.domain.template.aws_template_aggregate import AWSTemplate
+from orb.providers.aws.infrastructure.handlers.spot_fleet.handler import SpotFleetHandler
+from orb.providers.aws.utilities.aws_operations import AWSOperations
+from tests.providers.aws.contract.conftest import (
+    REGION,
+    SPOT_FLEET_ROLE,
+    _make_aws_client,
+    _make_config_port,
+    _make_logger,
+    _make_lt_manager,
+    _make_request,
+)
+
+
+def _build_spot_fleet_handler(aws_client, logger, config_port) -> SpotFleetHandler:
+    aws_ops = AWSOperations(aws_client, logger, config_port)
+    lt_manager = _make_lt_manager(aws_client, logger)
+    handler = SpotFleetHandler(
+        aws_client=aws_client,
+        logger=logger,
+        aws_ops=aws_ops,
+        launch_template_manager=lt_manager,
+        config_port=config_port,
+    )
+    # moto rejects the 'instance' TagSpecification on request_spot_fleet.
+    original_build = handler._config_builder.build
+
+    def _patched_build(**kwargs: Any) -> dict:
+        config = original_build(**kwargs)
+        config["TagSpecifications"] = [
+            ts for ts in config.get("TagSpecifications", []) if ts.get("ResourceType") != "instance"
+        ]
+        return config
+
+    handler._config_builder.build = _patched_build  # type: ignore[method-assign]
+    return handler
+
+
+def _spot_fleet_template(subnet_id: str, sg_id: str, fleet_type: str = "request") -> AWSTemplate:
+    return AWSTemplate(
+        template_id="tpl-contract-spot",
+        name="contract-spot",
+        provider_api="SpotFleet",
+        machine_types={"t3.micro": 1},
+        image_id="ami-12345678",
+        max_instances=5,
+        price_type="spot",
+        fleet_type=fleet_type,
+        fleet_role=SPOT_FLEET_ROLE,
+        allocation_strategy="lowest_price",
+        subnet_ids=[subnet_id],
+        security_group_ids=[sg_id],
+        tags={"Environment": "contract-test"},
+    )
+
+
+@pytest.fixture
+def spot_fleet_handler(moto_vpc_resources) -> SpotFleetHandler:
+    return _build_spot_fleet_handler(_make_aws_client(), _make_logger(), _make_config_port())
+
+
+@pytest.mark.provider_contract
+class TestAWSSpotFleetContract:
+    """SpotFleet satisfies the provisioning + monitoring contract at exact count."""
+
+    def test_acquire_returns_success_and_fleet_id(
+        self, spot_fleet_handler, moto_vpc_resources
+    ) -> None:
+        subnet_id = moto_vpc_resources["subnet_ids"][0]
+        sg_id = moto_vpc_resources["sg_id"]
+        request = _make_request(request_id="contract-spot-001", requested_count=2)
+
+        result = spot_fleet_handler.acquire_hosts(request, _spot_fleet_template(subnet_id, sg_id))
+
+        assert isinstance(result, dict)
+        assert result["success"] is True
+        assert result["resource_ids"] and result["resource_ids"][0].startswith("sfr-")
+
+    def test_exact_count_fulfilment(self, spot_fleet_handler, moto_vpc_resources) -> None:
+        """A request for N instances yields exactly N running instances, fulfilled."""
+        subnet_id = moto_vpc_resources["subnet_ids"][0]
+        sg_id = moto_vpc_resources["sg_id"]
+        request = _make_request(request_id="contract-spot-002", requested_count=3)
+
+        fleet_id = spot_fleet_handler.acquire_hosts(
+            request, _spot_fleet_template(subnet_id, sg_id)
+        )["resource_ids"][0]
+
+        status_request = _make_request(
+            request_id="contract-spot-002", requested_count=3, resource_ids=[fleet_id]
+        )
+        result = spot_fleet_handler.check_hosts_status(status_request)
+
+        assert isinstance(result, CheckHostsStatusResult)
+        assert len(result.instances) == 3
+        assert result.fulfilment.running_count == 3
+        assert result.fulfilment.target_units == 3
+        assert result.fulfilment.state == "fulfilled"
+
+    def test_release_terminates_launched_instances(
+        self, spot_fleet_handler, moto_vpc_resources
+    ) -> None:
+        """release_hosts called with real instance IDs terminates them."""
+        subnet_id = moto_vpc_resources["subnet_ids"][0]
+        sg_id = moto_vpc_resources["sg_id"]
+        ec2 = boto3.client("ec2", region_name=REGION)
+        request = _make_request(request_id="contract-spot-003", requested_count=2)
+
+        fleet_id = spot_fleet_handler.acquire_hosts(
+            request, _spot_fleet_template(subnet_id, sg_id)
+        )["resource_ids"][0]
+
+        status_request = _make_request(
+            request_id="contract-spot-003", requested_count=2, resource_ids=[fleet_id]
+        )
+        instance_ids = [
+            entry["instance_id"]
+            for entry in spot_fleet_handler.check_hosts_status(status_request).instances
+        ]
+        assert len(instance_ids) == 2
+
+        spot_fleet_handler.release_hosts(instance_ids)
+
+        resp = ec2.describe_instances(InstanceIds=instance_ids)
+        states = [i["State"]["Name"] for r in resp["Reservations"] for i in r["Instances"]]
+        assert all(s in ("shutting-down", "terminated") for s in states)

--- a/tests/providers/aws/mocked/test_fleet_fulfilment_mapping.py
+++ b/tests/providers/aws/mocked/test_fleet_fulfilment_mapping.py
@@ -1,0 +1,231 @@
+"""Fleet fulfilment status-mapping tests at the mocked tier.
+
+check_hosts_status for ASG, EC2Fleet, and SpotFleet is exercised end-to-end
+against real moto-provisioned instances — not just for return type. Each test
+provisions a fleet, then verifies that the describe -> format -> count status
+mapping populates per-instance data and computes the correct fulfilment verdict
+(running_count, target_units, state) for the running instances the API reports.
+
+A dedicated shortfall test terminates instances behind an EC2Fleet in
+``maintain`` mode so the fulfilled capacity drops below the target, exercising
+the ``running_count < target_units`` partial/in-progress path that the
+fulfilment state machine resolves.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from orb.domain.base.provider_fulfilment import CheckHostsStatusResult
+from tests.providers.aws.mocked.test_provision_lifecycle import (
+    _asg_template,
+    _ec2_fleet_template,
+    _make_aws_client,
+    _make_config_port,
+    _make_factory,
+    _make_logger,
+    _make_request,
+    _run_instances_template,
+    _spot_fleet_template,
+)
+
+REGION = "eu-west-2"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test_provision_lifecycle — moto-backed handler factory)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def aws_client(moto_aws):
+    return _make_aws_client()
+
+
+@pytest.fixture
+def factory(aws_client):
+    return _make_factory(aws_client, _make_logger(), _make_config_port())
+
+
+@pytest.fixture
+def subnet_id(moto_vpc_resources):
+    return moto_vpc_resources["subnet_ids"][0]
+
+
+@pytest.fixture
+def sg_id(moto_vpc_resources):
+    return moto_vpc_resources["sg_id"]
+
+
+def _instance_status_keys_present(result: CheckHostsStatusResult) -> None:
+    """Every populated status entry carries instance_id + status."""
+    for entry in result.instances:
+        assert "instance_id" in entry, f"status entry missing instance_id: {entry}"
+        assert "status" in entry, f"status entry missing status: {entry}"
+
+
+# ---------------------------------------------------------------------------
+# ASG — real instance-data status mapping
+# ---------------------------------------------------------------------------
+
+
+class TestASGStatusMapping:
+    def test_check_status_populates_running_instances(self, factory, subnet_id, sg_id):
+        """ASG check_hosts_status returns one populated entry per InService instance."""
+        handler = factory.create_handler("ASG")
+        template = _asg_template(subnet_id, sg_id)
+        request = _make_request(request_id="map-asg-001", requested_count=2)
+
+        acquire_result = handler.acquire_hosts(request, template)
+        asg_name = acquire_result["resource_ids"][0]
+
+        status_request = _make_request(
+            request_id="map-asg-001", requested_count=2, resource_ids=[asg_name]
+        )
+        result = handler.check_hosts_status(status_request)
+
+        assert isinstance(result, CheckHostsStatusResult)
+        assert len(result.instances) == 2
+        _instance_status_keys_present(result)
+        assert all(entry["status"] in ("running", "pending") for entry in result.instances)
+        # Every entry is stamped with the owning ASG.
+        assert all(entry["resource_id"] == asg_name for entry in result.instances)
+
+    def test_check_status_fulfilment_counts(self, factory, subnet_id, sg_id):
+        """ASG fulfilment reports running_count == target == requested and state fulfilled."""
+        handler = factory.create_handler("ASG")
+        template = _asg_template(subnet_id, sg_id)
+        request = _make_request(request_id="map-asg-002", requested_count=2)
+
+        asg_name = handler.acquire_hosts(request, template)["resource_ids"][0]
+        status_request = _make_request(
+            request_id="map-asg-002", requested_count=2, resource_ids=[asg_name]
+        )
+        result = handler.check_hosts_status(status_request)
+
+        assert result.fulfilment.running_count == 2
+        assert result.fulfilment.target_units == 2
+        assert result.fulfilment.state == "fulfilled"
+
+
+# ---------------------------------------------------------------------------
+# EC2Fleet — real instance-data status mapping
+# ---------------------------------------------------------------------------
+
+
+class TestEC2FleetStatusMapping:
+    @pytest.mark.parametrize("fleet_type", ["instant", "maintain"])
+    def test_check_status_populates_running_instances(self, factory, subnet_id, sg_id, fleet_type):
+        """EC2Fleet check_hosts_status returns one populated entry per active instance."""
+        handler = factory.create_handler("EC2Fleet")
+        template = _ec2_fleet_template(subnet_id, sg_id, fleet_type=fleet_type)
+        request = _make_request(request_id=f"map-fleet-{fleet_type}", requested_count=2)
+
+        acquire_result = handler.acquire_hosts(request, template)
+        fleet_id = acquire_result["resource_ids"][0]
+
+        status_request = _make_request(
+            request_id=f"map-fleet-{fleet_type}", requested_count=2, resource_ids=[fleet_id]
+        )
+        status_request.metadata = acquire_result.get("provider_data", {})
+        result = handler.check_hosts_status(status_request)
+
+        assert isinstance(result, CheckHostsStatusResult)
+        assert len(result.instances) == 2
+        _instance_status_keys_present(result)
+        assert all(entry["resource_id"] == fleet_id for entry in result.instances)
+        assert result.fulfilment.running_count == 2
+        assert result.fulfilment.target_units == 2
+        assert result.fulfilment.state == "fulfilled"
+
+    def test_maintain_fleet_shortfall_is_not_fulfilled(self, factory, subnet_id, sg_id, ec2_client):
+        """Terminating an active instance drops a maintain fleet below target.
+
+        The remaining running instances are still reported with populated data,
+        but the fulfilment verdict must reflect the shortfall
+        (running_count < target_units, state not fulfilled).
+        """
+        handler = factory.create_handler("EC2Fleet")
+        template = _ec2_fleet_template(subnet_id, sg_id, fleet_type="maintain")
+        request = _make_request(request_id="map-fleet-shortfall", requested_count=3)
+
+        fleet_id = handler.acquire_hosts(request, template)["resource_ids"][0]
+
+        active = ec2_client.describe_fleet_instances(FleetId=fleet_id)["ActiveInstances"]
+        active_ids = [i["InstanceId"] for i in active]
+        assert len(active_ids) == 3
+        ec2_client.terminate_instances(InstanceIds=active_ids[:1])
+
+        status_request = _make_request(
+            request_id="map-fleet-shortfall", requested_count=3, resource_ids=[fleet_id]
+        )
+        result = handler.check_hosts_status(status_request)
+
+        assert result.fulfilment.target_units == 3
+        assert result.fulfilment.running_count == 2
+        assert result.fulfilment.running_count < result.fulfilment.target_units
+        assert result.fulfilment.state != "fulfilled"
+
+
+# ---------------------------------------------------------------------------
+# SpotFleet — real instance-data status mapping
+# ---------------------------------------------------------------------------
+
+
+class TestSpotFleetStatusMapping:
+    @pytest.mark.parametrize("fleet_type", ["request", "maintain"])
+    def test_check_status_populates_running_instances(self, factory, subnet_id, sg_id, fleet_type):
+        """SpotFleet check_hosts_status returns one populated entry per active instance."""
+        handler = factory.create_handler("SpotFleet")
+        template = _spot_fleet_template(subnet_id, sg_id, fleet_type=fleet_type)
+        request = _make_request(request_id=f"map-spot-{fleet_type}", requested_count=2)
+
+        acquire_result = handler.acquire_hosts(request, template)
+        fleet_id = acquire_result["resource_ids"][0]
+
+        status_request = _make_request(
+            request_id=f"map-spot-{fleet_type}", requested_count=2, resource_ids=[fleet_id]
+        )
+        result = handler.check_hosts_status(status_request)
+
+        assert isinstance(result, CheckHostsStatusResult)
+        assert len(result.instances) == 2
+        _instance_status_keys_present(result)
+        assert all(entry["resource_id"] == fleet_id for entry in result.instances)
+        assert result.fulfilment.running_count == 2
+        assert result.fulfilment.target_units == 2
+        assert result.fulfilment.state == "fulfilled"
+
+
+# ---------------------------------------------------------------------------
+# RunInstances — shortfall reference (the only API where moto historically
+# fulfilled). Kept alongside the fleet cases to document the shared contract.
+# ---------------------------------------------------------------------------
+
+
+class TestRunInstancesShortfall:
+    def test_terminated_instance_produces_shortfall(self, factory, subnet_id, sg_id, ec2_client):
+        """Terminating a launched instance leaves the request below its target."""
+        handler = factory.create_handler("RunInstances")
+        template = _run_instances_template(subnet_id, sg_id)
+        request = _make_request(request_id="map-run-shortfall", requested_count=3)
+
+        acquire_result = handler.acquire_hosts(request, template)
+        instance_ids = acquire_result["provider_data"]["instance_ids"]
+        reservation_id = acquire_result["resource_ids"][0]
+        ec2_client.terminate_instances(InstanceIds=instance_ids[:1])
+
+        status_request = _make_request(
+            request_id="map-run-shortfall",
+            requested_count=3,
+            resource_ids=[reservation_id],
+            provider_data={"instance_ids": instance_ids, "reservation_id": reservation_id},
+        )
+        result = handler.check_hosts_status(status_request)
+
+        assert result.fulfilment.target_units == 3
+        assert result.fulfilment.running_count < 3
+        assert result.fulfilment.state != "fulfilled"

--- a/tests/providers/aws/unit/handlers/test_base_handler_circuit_breaker_config.py
+++ b/tests/providers/aws/unit/handlers/test_base_handler_circuit_breaker_config.py
@@ -1,6 +1,14 @@
-"""Tests for circuit breaker config wiring in AWSHandler._get_circuit_breaker_config."""
+"""Tests for circuit breaker config wiring in AWSHandler._get_circuit_breaker_config.
 
-from unittest.mock import MagicMock
+Also exercises the *runtime* retry / circuit-breaker behaviour of
+``_retry_with_backoff`` (transient-error retry, non-retryable pass-through,
+and circuit opening after the failure threshold) — not just the config wiring.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
 
 from orb.providers.aws.infrastructure.handlers.base_handler import AWSHandler
 
@@ -179,3 +187,85 @@ class TestRetryStrategyConfigNonCritical:
 
         assert config["strategy"] == "exponential"
         assert "failure_threshold" not in config
+
+
+# ---------------------------------------------------------------------------
+# Test 6: runtime retry / circuit-breaker behaviour (not just config wiring)
+# ---------------------------------------------------------------------------
+
+
+def _throttle_error() -> ClientError:
+    return ClientError(
+        {"Error": {"Code": "RequestLimitExceeded", "Message": "slow down"}}, "DescribeInstances"
+    )
+
+
+def _service_unavailable() -> ClientError:
+    return ClientError(
+        {"Error": {"Code": "ServiceUnavailable", "Message": "boom"}}, "run_instances"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_circuit_states():
+    """Circuit state is class-level shared — clear it around each runtime test."""
+    from orb.infrastructure.resilience.strategy.circuit_breaker import CircuitBreakerStrategy
+
+    CircuitBreakerStrategy._circuit_states.clear()
+    yield
+    CircuitBreakerStrategy._circuit_states.clear()
+
+
+class TestRetryRuntimeBehaviour:
+    def test_transient_error_is_retried_then_succeeds(self):
+        """A transient throttle is retried and the eventual success is returned."""
+        handler = _make_handler(config_port=None)
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise _throttle_error()
+            return "ok"
+
+        with patch("orb.infrastructure.resilience.retry_decorator.time.sleep") as sleep:
+            result = handler._retry_with_backoff(flaky, operation_type="read_only")
+
+        assert result == "ok"
+        assert calls["n"] == 2  # first attempt failed, retry succeeded
+        assert sleep.call_count == 1  # slept once before the retry
+
+    def test_success_first_call_does_not_sleep(self):
+        """A call that succeeds immediately is not retried and never sleeps."""
+        handler = _make_handler(config_port=None)
+        func = MagicMock(return_value="done")
+
+        with patch("orb.infrastructure.resilience.retry_decorator.time.sleep") as sleep:
+            result = handler._retry_with_backoff(func, operation_type="read_only")
+
+        assert result == "done"
+        assert func.call_count == 1
+        assert sleep.call_count == 0
+
+    def test_circuit_opens_after_failure_threshold(self):
+        """Critical operations trip the circuit breaker OPEN once the threshold is hit."""
+        from orb.infrastructure.resilience.exceptions import CircuitBreakerOpenError
+        from orb.infrastructure.resilience.strategy.circuit_breaker import (
+            CircuitBreakerStrategy,
+            CircuitState,
+        )
+
+        port = _make_config_port(failure_threshold=3, recovery_timeout=60)
+        handler = _make_handler(config_port=port)
+
+        def always_fail():
+            raise _service_unavailable()
+
+        with patch("orb.infrastructure.resilience.retry_decorator.time.sleep"):
+            with pytest.raises(CircuitBreakerOpenError):
+                handler._retry_with_backoff(always_fail, operation_type="critical")
+
+        service = handler._get_service_name()
+        circuit = CircuitBreakerStrategy._circuit_states[service]
+        assert circuit["state"] == CircuitState.OPEN
+        assert circuit["failure_count"] >= 3

--- a/tests/providers/k8s/unit/utilities/test_pod_state.py
+++ b/tests/providers/k8s/unit/utilities/test_pod_state.py
@@ -135,7 +135,7 @@ class TestBaseHandlerSucceededWarning:
                 return []
 
         client = MagicMock()
-        config = K8sProviderConfig(namespace="test")
+        config = K8sProviderConfig(namespace="test")  # type: ignore[call-arg]
         logger = MagicMock()
         return _ConcreteHandler(kubernetes_client=client, config=config, logger=logger), logger
 

--- a/tests/providers/k8s/unit/utilities/test_pod_state.py
+++ b/tests/providers/k8s/unit/utilities/test_pod_state.py
@@ -12,6 +12,7 @@ Also verifies the unchanged mappings for other phases.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -111,7 +112,7 @@ def test_controller_respawns_set_contains_expected_types() -> None:
 class TestBaseHandlerSucceededWarning:
     """Verify the handler emits a warning for controller-respawned Succeeded pods."""
 
-    def _make_handler(self, provider_api: str) -> object:
+    def _make_handler(self, provider_api: str) -> tuple[Any, MagicMock]:
         """Return a minimal K8sHandlerBase subclass with a mock logger."""
 
         from orb.providers.k8s.configuration.config import K8sProviderConfig

--- a/tests/ui/test_state_integration.py
+++ b/tests/ui/test_state_integration.py
@@ -182,6 +182,145 @@ class TestRequestsStateFilterChaining:
         assert s.provider_filter == "aws"
 
 
+class TestRequestsStateSseLiveUpdates:
+    """RequestsState live-updates request rows from the backend SSE stream.
+
+    Covers ``_status_from_event`` payload extraction, ``_apply_request_status_event``
+    row patching, and ``stream_status_events`` draining events from a mocked
+    ``api.subscribe_events`` async generator.
+    """
+
+    def _make_state(self, requests=None):
+        from orb.ui.pages.requests import RequestsState
+
+        TestableState = _make_testable_subclass(RequestsState)
+        s = TestableState.__new__(TestableState)
+        s.requests = requests if requests is not None else []
+        s._sse_started = False
+        return s
+
+    # --- _status_from_event -------------------------------------------------
+
+    def test_status_from_event_status_changed(self):
+        s = self._make_state()
+        rid, status = s._status_from_event(
+            "RequestStatusChangedEvent",
+            {"request_id": "req-1", "new_status": "IN_PROGRESS"},
+        )
+        assert rid == "req-1"
+        assert status == "in_progress"
+
+    def test_status_from_event_completed_uses_completion_status(self):
+        s = self._make_state()
+        rid, status = s._status_from_event(
+            "RequestCompletedEvent",
+            {"request_id": "req-2", "completion_status": "complete"},
+        )
+        assert rid == "req-2"
+        assert status == "complete"
+
+    def test_status_from_event_failed_is_failed(self):
+        s = self._make_state()
+        rid, status = s._status_from_event(
+            "RequestFailedEvent",
+            {"request_id": "req-3", "error_message": "boom"},
+        )
+        assert rid == "req-3"
+        assert status == "failed"
+
+    def test_status_from_event_falls_back_to_aggregate_id(self):
+        s = self._make_state()
+        rid, _status = s._status_from_event(
+            "RequestStatusChangedEvent",
+            {"aggregate_id": "req-4", "new_status": "complete"},
+        )
+        assert rid == "req-4"
+
+    def test_status_from_event_no_id_returns_empty(self):
+        s = self._make_state()
+        assert s._status_from_event("RequestStatusChangedEvent", {"new_status": "x"}) == ("", "")
+
+    # --- _apply_request_status_event ---------------------------------------
+
+    def test_apply_patches_matching_row_only(self):
+        s = self._make_state(
+            [
+                {"request_id": "req-1", "status": "pending"},
+                {"request_id": "req-2", "status": "pending"},
+            ]
+        )
+        changed = s._apply_request_status_event(
+            "RequestStatusChangedEvent",
+            {"request_id": "req-1", "new_status": "in_progress"},
+        )
+        assert changed is True
+        assert s.requests[0]["status"] == "in_progress"
+        assert s.requests[1]["status"] == "pending"
+
+    def test_apply_noop_when_status_unchanged(self):
+        s = self._make_state([{"request_id": "req-1", "status": "in_progress"}])
+        changed = s._apply_request_status_event(
+            "RequestStatusChangedEvent",
+            {"request_id": "req-1", "new_status": "in_progress"},
+        )
+        assert changed is False
+
+    def test_apply_ignores_unknown_request(self):
+        s = self._make_state([{"request_id": "req-1", "status": "pending"}])
+        changed = s._apply_request_status_event(
+            "RequestStatusChangedEvent",
+            {"request_id": "req-999", "new_status": "complete"},
+        )
+        assert changed is False
+        assert s.requests[0]["status"] == "pending"
+
+    # --- stream_status_events (drains the SSE generator) -------------------
+
+    @pytest.mark.asyncio
+    async def test_stream_status_events_applies_three_events_in_order(self):
+        """Emit 3 status events; assert all 3 patch the list in order."""
+        s = self._make_state(
+            [
+                {"request_id": "req-1", "status": "pending"},
+                {"request_id": "req-2", "status": "pending"},
+            ]
+        )
+
+        async def _fake_subscribe(event_types=None):
+            yield "RequestStatusChangedEvent", {"request_id": "req-1", "new_status": "in_progress"}
+            yield "RequestStatusChangedEvent", {"request_id": "req-2", "new_status": "in_progress"}
+            yield "RequestCompletedEvent", {"request_id": "req-1", "completion_status": "complete"}
+
+        with patch("orb.ui.pages.requests.api") as mock_api:
+            mock_api.subscribe_events = _fake_subscribe
+            await s.stream_status_events()
+
+        by_id = {r["request_id"]: r["status"] for r in s.requests}
+        assert by_id["req-1"] == "complete"
+        assert by_id["req-2"] == "in_progress"
+        assert s._sse_started is False
+
+    @pytest.mark.asyncio
+    async def test_stream_status_events_single_flight_guard(self):
+        """A second concurrent subscriber returns immediately (guarded)."""
+        s = self._make_state([{"request_id": "req-1", "status": "pending"}])
+        s._sse_started = True
+
+        called = False
+
+        async def _fake_subscribe(event_types=None):
+            nonlocal called
+            called = True
+            if False:  # pragma: no cover - generator with no yields
+                yield
+
+        with patch("orb.ui.pages.requests.api") as mock_api:
+            mock_api.subscribe_events = _fake_subscribe
+            await s.stream_status_events()
+
+        assert called is False, "guarded subscriber must not open a second stream"
+
+
 class TestTemplatesStateFilterChaining:
     """TemplatesState.set_provider_filter triggers load; set_filter is client-side."""
 

--- a/tests/ui/test_state_integration.py
+++ b/tests/ui/test_state_integration.py
@@ -420,7 +420,7 @@ class TestSubstateProviderSchemasVisibility:
         from orb.ui.pages.machines import MachinesState
 
         s = self._machines_state()
-        cols = MachinesState.dynamic_columns(s)
+        cols = MachinesState.dynamic_columns(s)  # type: ignore[call-arg]
         assert isinstance(cols, list)
         assert len(cols) >= 1, "Expected at least one dynamic column from AWS schema"
 
@@ -443,7 +443,7 @@ class TestSubstateProviderSchemasVisibility:
         s = RequestsState.__new__(RequestsState)
         s.provider_schemas = schemas
         s.provider_filter = "aws"
-        cols = RequestsState.dynamic_columns(s)
+        cols = RequestsState.dynamic_columns(s)  # type: ignore[call-arg]
         assert isinstance(cols, list)
         assert len(cols) >= 1, "Expected at least one dynamic column from AWS schema"
 
@@ -466,7 +466,7 @@ class TestSubstateProviderSchemasVisibility:
         s = TemplatesState.__new__(TemplatesState)
         s.provider_schemas = schemas
         s.provider_filter = "aws"
-        cols = TemplatesState.dynamic_columns(s)
+        cols = TemplatesState.dynamic_columns(s)  # type: ignore[call-arg]
         assert isinstance(cols, list)
         assert len(cols) >= 1, "Expected at least one dynamic column from AWS schema"
 
@@ -502,8 +502,8 @@ class TestAppStateLocalStorage:
 
         s = self._make_state()
         # is_collapsed reads sidebar_collapsed; precompute for the var chain
-        object.__setattr__(s, "is_collapsed", AppState.is_collapsed(s))
-        AppState.toggle_sidebar(s)
+        object.__setattr__(s, "is_collapsed", AppState.is_collapsed(s))  # type: ignore[call-arg]
+        AppState.toggle_sidebar(s)  # type: ignore[call-arg]
         assert s.sidebar_collapsed == "true"
 
     def test_toggle_sidebar_sets_false_when_true(self):
@@ -512,8 +512,8 @@ class TestAppStateLocalStorage:
 
         s = self._make_state()
         s.sidebar_collapsed = "true"
-        object.__setattr__(s, "is_collapsed", AppState.is_collapsed(s))
-        AppState.toggle_sidebar(s)
+        object.__setattr__(s, "is_collapsed", AppState.is_collapsed(s))  # type: ignore[call-arg]
+        AppState.toggle_sidebar(s)  # type: ignore[call-arg]
         assert s.sidebar_collapsed == "false"
 
     def test_is_collapsed_true_when_sidebar_collapsed_true(self):
@@ -522,14 +522,14 @@ class TestAppStateLocalStorage:
 
         s = self._make_state()
         s.sidebar_collapsed = "true"
-        assert AppState.is_collapsed(s) is True
+        assert AppState.is_collapsed(s) is True  # type: ignore[call-arg]
 
     def test_is_collapsed_false_when_sidebar_collapsed_false(self):
         """is_collapsed returns False when sidebar_collapsed == 'false'."""
         from orb.ui.state import AppState
 
         s = self._make_state()
-        assert AppState.is_collapsed(s) is False
+        assert AppState.is_collapsed(s) is False  # type: ignore[call-arg]
 
     def test_double_toggle_sidebar_returns_to_original(self):
         """Two toggles must return to the original collapsed state."""
@@ -537,8 +537,8 @@ class TestAppStateLocalStorage:
 
         s = self._make_state()
         for _ in range(2):
-            object.__setattr__(s, "is_collapsed", AppState.is_collapsed(s))
-            AppState.toggle_sidebar(s)
+            object.__setattr__(s, "is_collapsed", AppState.is_collapsed(s))  # type: ignore[call-arg]
+            AppState.toggle_sidebar(s)  # type: ignore[call-arg]
         assert s.sidebar_collapsed == "false"
 
     def test_dismiss_onboarding_sets_raw_to_true(self):
@@ -546,7 +546,7 @@ class TestAppStateLocalStorage:
         from orb.ui.state import AppState
 
         s = self._make_state()
-        AppState.dismiss_onboarding(s)
+        AppState.dismiss_onboarding(s)  # type: ignore[call-arg]
         assert s._onboarding_dismissed_raw == "true"
 
     def test_onboarding_dismissed_true_after_dismiss(self):
@@ -554,15 +554,15 @@ class TestAppStateLocalStorage:
         from orb.ui.state import AppState
 
         s = self._make_state()
-        AppState.dismiss_onboarding(s)
-        assert AppState.onboarding_dismissed(s) is True
+        AppState.dismiss_onboarding(s)  # type: ignore[call-arg]
+        assert AppState.onboarding_dismissed(s) is True  # type: ignore[call-arg]
 
     def test_onboarding_dismissed_false_initially(self):
         """onboarding_dismissed returns False before dismiss."""
         from orb.ui.state import AppState
 
         s = self._make_state()
-        assert AppState.onboarding_dismissed(s) is False
+        assert AppState.onboarding_dismissed(s) is False  # type: ignore[call-arg]
 
 
 # ---------------------------------------------------------------------------
@@ -681,7 +681,7 @@ class TestDashboardStateFallback:
 
         from orb.ui.pages.dashboard import DashboardState
 
-        assert DashboardState.total_templates(s) == 7
+        assert DashboardState.total_templates(s) == 7  # type: ignore[call-arg]
         mock_api.list_templates.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -703,7 +703,7 @@ class TestDashboardStateFallback:
 
         from orb.ui.pages.dashboard import DashboardState
 
-        assert DashboardState.total_templates(s) == 4
+        assert DashboardState.total_templates(s) == 4  # type: ignore[call-arg]
 
     @pytest.mark.asyncio
     async def test_both_zero_tile_shows_zero(self):
@@ -724,4 +724,4 @@ class TestDashboardStateFallback:
 
         from orb.ui.pages.dashboard import DashboardState
 
-        assert DashboardState.total_templates(s) == 0
+        assert DashboardState.total_templates(s) == 0  # type: ignore[call-arg]

--- a/tests/unit/api/test_config_router.py
+++ b/tests/unit/api/test_config_router.py
@@ -213,6 +213,62 @@ class TestSetConfigValue:
         body = r.json()
         assert "in-memory" in body["note"].lower() or "revert" in body["note"].lower()
 
+    def test_persist_true_writes_to_disk_and_reports_path(self, config_app):
+        """PUT /config/{key}?persist=true also saves to disk and reports the path."""
+        from unittest.mock import patch
+
+        port = _make_config_port()
+        port.get_configuration_value.side_effect = lambda key, default=None: {
+            "allow_destructive_admin": True,
+            "environment": "development",
+        }.get(key, default)
+        port.save_config.return_value = "/etc/orb/orb.yaml"
+
+        config_app.dependency_overrides[get_config_manager] = lambda: port
+        server_config = MagicMock()
+        server_config.auth.enabled = True
+
+        with patch(
+            "orb.api.dependencies.get_di_container",
+            return_value=MagicMock(**{"get.return_value": port}),
+        ):
+            with patch("orb.api.dependencies.get_server_config", return_value=server_config):
+                client = TestClient(config_app, raise_server_exceptions=False)
+                r = client.put("/config/server.port?persist=true", json={"value": 9090})
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["persisted"] is True
+        assert body["path"] == "/etc/orb/orb.yaml"
+        port.set_configuration_value.assert_called_once_with("server.port", 9090)
+        port.save_config.assert_called_once_with(None)
+
+    def test_persist_true_returns_400_when_no_config_file(self, config_app):
+        """PUT /config/{key}?persist=true returns 400 when nothing can be persisted."""
+        from unittest.mock import patch
+
+        port = _make_config_port()
+        port.get_configuration_value.side_effect = lambda key, default=None: {
+            "allow_destructive_admin": True,
+            "environment": "development",
+        }.get(key, default)
+        port.save_config.side_effect = ValueError("no config file loaded")
+
+        config_app.dependency_overrides[get_config_manager] = lambda: port
+        server_config = MagicMock()
+        server_config.auth.enabled = True
+
+        with patch(
+            "orb.api.dependencies.get_di_container",
+            return_value=MagicMock(**{"get.return_value": port}),
+        ):
+            with patch("orb.api.dependencies.get_server_config", return_value=server_config):
+                client = TestClient(config_app, raise_server_exceptions=False)
+                r = client.put("/config/server.port?persist=true", json={"value": 9090})
+
+        assert r.status_code == 400
+        assert r.json()["detail"]["code"] == "NO_CONFIG_PATH"
+
 
 @pytest.mark.unit
 @pytest.mark.api

--- a/tests/unit/api/test_router_endpoints.py
+++ b/tests/unit/api/test_router_endpoints.py
@@ -140,6 +140,36 @@ class TestMachinesRouter:
             {"request_id": "req-abc", "status": "pending", "machine_ids": []}, "pending"
         )
 
+    def test_request_machines_wait_query_forwarded(self, machines_app):
+        output = AcquireMachinesOutput(request_id="req-wait", status="complete")
+        orch = self._override_acquire(machines_app, output)
+        self._set_scheduler(machines_app)
+        client = TestClient(machines_app, raise_server_exceptions=False)
+
+        resp = client.post(
+            "/machines/request?wait=true&timeout=120",
+            json={"template_id": "t1", "count": 1},
+        )
+
+        assert resp.status_code == 202
+        inp: AcquireMachinesInput = orch.execute.call_args.args[0]
+        assert inp.wait is True
+        assert inp.timeout_seconds == 120
+
+    def test_request_machines_wait_timeout_capped(self, machines_app):
+        output = AcquireMachinesOutput(request_id="req-cap", status="complete")
+        self._override_acquire(machines_app, output)
+        self._set_scheduler(machines_app)
+        client = TestClient(machines_app, raise_server_exceptions=False)
+
+        # Above the server ceiling → rejected by query validation.
+        resp = client.post(
+            "/machines/request?wait=true&timeout=99999",
+            json={"template_id": "t1", "count": 1},
+        )
+
+        assert resp.status_code == 422
+
     def test_request_machines_camel_case_body(self, machines_app):
         output = AcquireMachinesOutput(request_id="req-camel", status="pending")
         orch = self._override_acquire(machines_app, output)
@@ -193,6 +223,19 @@ class TestMachinesRouter:
         orch.execute.assert_awaited_once()
         inp: ReturnMachinesInput = orch.execute.call_args.args[0]
         assert inp.machine_ids == ["i-123"]
+
+    def test_return_machines_wait_query_forwarded(self, machines_app):
+        output = ReturnMachinesOutput(request_id="ret-wait", status="complete")
+        orch = self._override_return(machines_app, output)
+        self._set_scheduler(machines_app)
+        client = TestClient(machines_app, raise_server_exceptions=False)
+
+        resp = client.post("/machines/return?wait=true&timeout=90", json={"machine_ids": ["i-1"]})
+
+        assert resp.status_code == 200
+        inp: ReturnMachinesInput = orch.execute.call_args.args[0]
+        assert inp.wait is True
+        assert inp.timeout_seconds == 90
 
     def test_return_machines_empty_ids(self, machines_app):
         output = ReturnMachinesOutput(request_id=None, status="pending")

--- a/tests/unit/application/commands/test_machine_command_handlers.py
+++ b/tests/unit/application/commands/test_machine_command_handlers.py
@@ -1,0 +1,300 @@
+"""Unit tests for application/commands/machine_handlers.py.
+
+Covers UpdateMachineStatusHandler, CleanupMachineResourcesHandler and
+UpdateMachineProviderDataHandler: happy path, not-found/error paths, and
+verification that the correct repository/provider port methods are called.
+
+Domain aggregates (Machine) are used as real objects; only abstract ports
+(MachineRepository, ProviderRegistryService, event/logging/error ports) are
+mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from orb.application.commands.machine_handlers import (
+    CleanupMachineResourcesHandler,
+    UpdateMachineProviderDataHandler,
+    UpdateMachineStatusHandler,
+)
+from orb.application.machine.commands import (
+    CleanupMachineResourcesCommand,
+    UpdateMachineProviderDataCommand,
+    UpdateMachineStatusCommand,
+)
+from orb.domain.base.exceptions import ApplicationError
+from orb.domain.base.operations import OperationResult
+from orb.domain.machine.aggregate import Machine
+from orb.domain.machine.exceptions import MachineNotFoundError
+from orb.domain.machine.machine_status import MachineStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_machine(
+    machine_id: str = "i-abc123",
+    status: MachineStatus = MachineStatus.RUNNING,
+    provider_name: str = "aws",
+    provider_data: dict | None = None,
+) -> Machine:
+    return Machine(
+        machine_id=machine_id,
+        template_id="tpl-1",
+        provider_type="aws",
+        provider_name=provider_name,
+        provider_api="RunInstances",
+        instance_type="t3.small",
+        image_id="ami-1",
+        status=status,
+        provider_data=provider_data or {},
+    )
+
+
+def _make_repo(machine: Machine | None) -> MagicMock:
+    repo = MagicMock()
+    repo.find_by_id.return_value = machine
+    return repo
+
+
+def _ports() -> dict:
+    return {
+        "event_publisher": MagicMock(),
+        "logger": MagicMock(),
+        "error_handler": MagicMock(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# UpdateMachineStatusHandler
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMachineStatusHandler:
+    @pytest.mark.asyncio
+    async def test_looks_up_machine_and_saves(self):
+        machine = _make_machine(status=MachineStatus.RUNNING)
+        repo = _make_repo(machine)
+        handler = UpdateMachineStatusHandler(machine_repository=repo, **_ports())
+
+        await handler.handle(UpdateMachineStatusCommand(machine_id="i-abc123", status="stopping"))
+
+        repo.find_by_id.assert_called_once_with("i-abc123")
+        repo.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_accepts_enum_status(self):
+        machine = _make_machine(status=MachineStatus.RUNNING)
+        repo = _make_repo(machine)
+        handler = UpdateMachineStatusHandler(machine_repository=repo, **_ports())
+
+        await handler.handle(
+            UpdateMachineStatusCommand(machine_id="i-abc123", status=MachineStatus.STOPPING)
+        )
+
+        repo.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises(self):
+        repo = _make_repo(None)
+        handler = UpdateMachineStatusHandler(machine_repository=repo, **_ports())
+
+        with pytest.raises(MachineNotFoundError):
+            await handler.handle(
+                UpdateMachineStatusCommand(machine_id="i-missing", status="stopping")
+            )
+        repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_machine_id_fails_validation(self):
+        repo = _make_repo(None)
+        handler = UpdateMachineStatusHandler(machine_repository=repo, **_ports())
+
+        with pytest.raises(ValueError):
+            await handler.handle(UpdateMachineStatusCommand(machine_id="", status="stopping"))
+
+    @pytest.mark.asyncio
+    async def test_missing_status_fails_validation(self):
+        repo = _make_repo(None)
+        handler = UpdateMachineStatusHandler(machine_repository=repo, **_ports())
+
+        with pytest.raises(ValueError):
+            await handler.handle(UpdateMachineStatusCommand(machine_id="i-abc123", status=""))
+
+
+# ---------------------------------------------------------------------------
+# CleanupMachineResourcesHandler
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupMachineResourcesHandler:
+    def _handler(self, repo: MagicMock, registry: MagicMock) -> CleanupMachineResourcesHandler:
+        return CleanupMachineResourcesHandler(
+            machine_repository=repo,
+            provider_registry_service=registry,
+            **_ports(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_dispatches_cleanup_and_terminalises(self):
+        machine = _make_machine(status=MachineStatus.RUNNING)
+        repo = _make_repo(machine)
+        registry = MagicMock()
+
+        async def _execute(provider_name, operation):
+            return OperationResult.success_result(data={})
+
+        registry.execute_operation = _execute
+        handler = self._handler(repo, registry)
+
+        await handler.handle(CleanupMachineResourcesCommand(machine_ids=["i-abc123"]))
+
+        repo.save.assert_called_once()
+        saved = repo.save.call_args.args[0]
+        assert saved.status == MachineStatus.TERMINATED
+
+    @pytest.mark.asyncio
+    async def test_missing_machine_skipped(self):
+        repo = _make_repo(None)
+        registry = MagicMock()
+        registry.execute_operation = MagicMock()
+        handler = self._handler(repo, registry)
+
+        await handler.handle(CleanupMachineResourcesCommand(machine_ids=["i-missing"]))
+
+        registry.execute_operation.assert_not_called()
+        repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_terminal_machine_skipped_without_force(self):
+        machine = _make_machine(status=MachineStatus.TERMINATED)
+        repo = _make_repo(machine)
+        registry = MagicMock()
+        registry.execute_operation = MagicMock()
+        handler = self._handler(repo, registry)
+
+        await handler.handle(CleanupMachineResourcesCommand(machine_ids=["i-abc123"]))
+
+        registry.execute_operation.assert_not_called()
+        repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_terminal_machine_cleaned_with_force(self):
+        machine = _make_machine(status=MachineStatus.TERMINATED)
+        repo = _make_repo(machine)
+        registry = MagicMock()
+
+        async def _execute(provider_name, operation):
+            return OperationResult.success_result(data={})
+
+        registry.execute_operation = _execute
+        handler = self._handler(repo, registry)
+
+        await handler.handle(
+            CleanupMachineResourcesCommand(machine_ids=["i-abc123"], force_cleanup=True)
+        )
+
+        repo.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_provider_failure_raises_without_force(self):
+        machine = _make_machine(status=MachineStatus.RUNNING)
+        repo = _make_repo(machine)
+        registry = MagicMock()
+
+        async def _execute(provider_name, operation):
+            return OperationResult.error_result(error_message="boom")
+
+        registry.execute_operation = _execute
+        handler = self._handler(repo, registry)
+
+        with pytest.raises(ApplicationError):
+            await handler.handle(CleanupMachineResourcesCommand(machine_ids=["i-abc123"]))
+        repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_raises_without_force(self):
+        machine = _make_machine(status=MachineStatus.RUNNING)
+        repo = _make_repo(machine)
+        registry = MagicMock()
+
+        async def _execute(provider_name, operation):
+            raise RuntimeError("registry down")
+
+        registry.execute_operation = _execute
+        handler = self._handler(repo, registry)
+
+        with pytest.raises(ApplicationError):
+            await handler.handle(CleanupMachineResourcesCommand(machine_ids=["i-abc123"]))
+        repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_terminalises_with_force(self):
+        machine = _make_machine(status=MachineStatus.RUNNING)
+        repo = _make_repo(machine)
+        registry = MagicMock()
+
+        async def _execute(provider_name, operation):
+            raise RuntimeError("registry down")
+
+        registry.execute_operation = _execute
+        handler = self._handler(repo, registry)
+
+        await handler.handle(
+            CleanupMachineResourcesCommand(machine_ids=["i-abc123"], force_cleanup=True)
+        )
+
+        repo.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_machine_ids_fails_validation(self):
+        repo = _make_repo(None)
+        registry = MagicMock()
+        handler = self._handler(repo, registry)
+
+        with pytest.raises(ValueError):
+            await handler.handle(CleanupMachineResourcesCommand(machine_ids=[]))
+
+
+# ---------------------------------------------------------------------------
+# UpdateMachineProviderDataHandler
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMachineProviderDataHandler:
+    @pytest.mark.asyncio
+    async def test_merges_provider_data_and_saves(self):
+        machine = _make_machine(provider_data={"a": 1, "b": 2})
+        repo = _make_repo(machine)
+        handler = UpdateMachineProviderDataHandler(machine_repository=repo, **_ports())
+
+        await handler.handle(
+            UpdateMachineProviderDataCommand(machine_id="i-abc123", updates={"b": 3, "c": 4})
+        )
+
+        repo.save.assert_called_once()
+        saved = repo.save.call_args.args[0]
+        assert saved.provider_data == {"a": 1, "b": 3, "c": 4}
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises(self):
+        repo = _make_repo(None)
+        handler = UpdateMachineProviderDataHandler(machine_repository=repo, **_ports())
+
+        with pytest.raises(MachineNotFoundError):
+            await handler.handle(
+                UpdateMachineProviderDataCommand(machine_id="i-missing", updates={"a": 1})
+            )
+        repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_machine_id_fails_validation(self):
+        repo = _make_repo(None)
+        handler = UpdateMachineProviderDataHandler(machine_repository=repo, **_ports())
+
+        with pytest.raises(ValueError):
+            await handler.handle(UpdateMachineProviderDataCommand(machine_id="", updates={"a": 1}))

--- a/tests/unit/application/commands/test_machine_command_handlers.py
+++ b/tests/unit/application/commands/test_machine_command_handlers.py
@@ -99,6 +99,36 @@ class TestUpdateMachineStatusHandler:
         repo.save.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_saves_machine_with_updated_status(self):
+        # Machine is immutable: update_status returns a new machine and does not
+        # mutate the original. The handler must persist the returned instance,
+        # so the machine handed to save() must carry the NEW status.
+        machine = _make_machine(status=MachineStatus.RUNNING)
+        repo = _make_repo(machine)
+        handler = UpdateMachineStatusHandler(machine_repository=repo, **_ports())
+
+        await handler.handle(UpdateMachineStatusCommand(machine_id="i-abc123", status="stopping"))
+
+        repo.save.assert_called_once()
+        saved = repo.save.call_args.args[0]
+        assert saved.status == MachineStatus.STOPPING
+
+    @pytest.mark.asyncio
+    async def test_publishes_status_changed_event(self):
+        # update_status attaches a MachineStatusChangedEvent to the returned
+        # aggregate; save() extracts it and the handler must publish it.
+        machine = _make_machine(status=MachineStatus.RUNNING)
+        repo = _make_repo(machine)
+        sentinel_event = object()
+        repo.save.return_value = [sentinel_event]
+        ports = _ports()
+        handler = UpdateMachineStatusHandler(machine_repository=repo, **ports)
+
+        await handler.handle(UpdateMachineStatusCommand(machine_id="i-abc123", status="stopping"))
+
+        ports["event_publisher"].publish.assert_called_once_with(sentinel_event)
+
+    @pytest.mark.asyncio
     async def test_not_found_raises(self):
         repo = _make_repo(None)
         handler = UpdateMachineStatusHandler(machine_repository=repo, **_ports())

--- a/tests/unit/application/commands/test_provider_command_handlers.py
+++ b/tests/unit/application/commands/test_provider_command_handlers.py
@@ -1,0 +1,281 @@
+"""Unit tests for application/commands/provider_handlers.py.
+
+Covers ExecuteProviderOperationHandler, RegisterProviderStrategyHandler and
+UpdateProviderHealthHandler: happy path, error/validation paths, and
+verification that the correct provider-registry port methods and event
+publishing are invoked. Only abstract ports are mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from orb.application.commands.provider_handlers import (
+    ExecuteProviderOperationHandler,
+    RegisterProviderStrategyHandler,
+    UpdateProviderHealthHandler,
+)
+from orb.application.provider.commands import (
+    ExecuteProviderOperationCommand,
+    RegisterProviderStrategyCommand,
+    UpdateProviderHealthCommand,
+)
+from orb.domain.base.operations import Operation, OperationResult, OperationType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ports() -> dict:
+    return {
+        "container": MagicMock(),
+        "logger": MagicMock(),
+        "event_publisher": MagicMock(),
+        "error_handler": MagicMock(),
+    }
+
+
+def _operation() -> Operation:
+    return Operation(
+        operation_type=OperationType.HEALTH_CHECK,
+        parameters={},
+    )
+
+
+def _res(command) -> dict:
+    """Narrow the optional CQRS result dict for assertions."""
+    assert command.result is not None
+    return command.result
+
+
+def _publisher(handler) -> MagicMock:
+    """Narrow the optional event publisher (a MagicMock in these tests)."""
+    assert handler.event_publisher is not None
+    return handler.event_publisher
+
+
+# ---------------------------------------------------------------------------
+# ExecuteProviderOperationHandler
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteProviderOperationHandler:
+    def _handler(self, registry: MagicMock) -> ExecuteProviderOperationHandler:
+        return ExecuteProviderOperationHandler(provider_registry_service=registry, **_ports())
+
+    @pytest.mark.asyncio
+    async def test_success_stores_result_and_publishes_event(self):
+        registry = MagicMock()
+
+        async def _execute(provider_id, operation):
+            return OperationResult.success_result(data={"ok": True})
+
+        registry.execute_operation = _execute
+        handler = self._handler(registry)
+        command = ExecuteProviderOperationCommand(operation=_operation(), strategy_override="aws")
+
+        await handler.handle(command)
+
+        assert _res(command)["success"] is True
+        assert _res(command)["data"] == {"ok": True}
+        _publisher(handler).publish.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_strategy_override_stores_failure(self):
+        registry = MagicMock()
+        handler = self._handler(registry)
+        command = ExecuteProviderOperationCommand(operation=_operation())
+
+        await handler.handle(command)
+
+        assert _res(command)["success"] is False
+        assert _res(command)["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_provider_failure_stores_error_message(self):
+        registry = MagicMock()
+
+        async def _execute(provider_id, operation):
+            return OperationResult.error_result(error_message="boom")
+
+        registry.execute_operation = _execute
+        handler = self._handler(registry)
+        command = ExecuteProviderOperationCommand(operation=_operation(), strategy_override="aws")
+
+        await handler.handle(command)
+
+        assert _res(command)["success"] is False
+        assert _res(command)["error_message"] == "boom"
+
+    @pytest.mark.asyncio
+    async def test_execute_exception_stores_failure(self):
+        registry = MagicMock()
+
+        async def _execute(provider_id, operation):
+            raise RuntimeError("registry down")
+
+        registry.execute_operation = _execute
+        handler = self._handler(registry)
+        command = ExecuteProviderOperationCommand(operation=_operation(), strategy_override="aws")
+
+        await handler.handle(command)
+
+        assert _res(command)["success"] is False
+        assert "registry down" in _res(command)["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_missing_operation_fails_validation(self):
+        registry = MagicMock()
+        handler = self._handler(registry)
+        command = ExecuteProviderOperationCommand(operation=_operation(), strategy_override="aws")
+        command.operation = None  # type: ignore[assignment]
+
+        with pytest.raises(ValueError):
+            await handler.handle(command)
+
+
+# ---------------------------------------------------------------------------
+# RegisterProviderStrategyHandler
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterProviderStrategyHandler:
+    def _handler(self, registry: MagicMock) -> RegisterProviderStrategyHandler:
+        return RegisterProviderStrategyHandler(provider_registry_service=registry, **_ports())
+
+    def _command(self) -> RegisterProviderStrategyCommand:
+        return RegisterProviderStrategyCommand(
+            strategy_name="aws-default",
+            provider_type="AWS",
+            strategy_config={"region": "us-east-1"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_registers_and_publishes_event(self):
+        registry = MagicMock()
+        registry.register_provider_strategy.return_value = True
+        handler = self._handler(registry)
+
+        command = self._command()
+        await handler.handle(command)
+
+        registry.register_provider_strategy.assert_called_once_with("aws", {"region": "us-east-1"})
+        _publisher(handler).publish.assert_called_once()
+        assert _res(command)["status"] == "registered"
+
+    @pytest.mark.asyncio
+    async def test_registration_failure_raises(self):
+        registry = MagicMock()
+        registry.register_provider_strategy.return_value = False
+        handler = self._handler(registry)
+
+        with pytest.raises(ValueError):
+            await handler.handle(self._command())
+
+    @pytest.mark.asyncio
+    async def test_missing_strategy_name_fails_validation(self):
+        registry = MagicMock()
+        handler = self._handler(registry)
+        command = RegisterProviderStrategyCommand(
+            strategy_name="", provider_type="AWS", strategy_config={}
+        )
+
+        with pytest.raises(ValueError):
+            await handler.handle(command)
+
+    @pytest.mark.asyncio
+    async def test_missing_provider_type_fails_validation(self):
+        registry = MagicMock()
+        handler = self._handler(registry)
+        command = RegisterProviderStrategyCommand(
+            strategy_name="aws-default", provider_type="", strategy_config={}
+        )
+
+        with pytest.raises(ValueError):
+            await handler.handle(command)
+
+
+# ---------------------------------------------------------------------------
+# UpdateProviderHealthHandler
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateProviderHealthHandler:
+    def _handler(self, registry: MagicMock) -> UpdateProviderHealthHandler:
+        return UpdateProviderHealthHandler(provider_registry_service=registry, **_ports())
+
+    @pytest.mark.asyncio
+    async def test_health_change_publishes_event_and_updates(self):
+        registry = MagicMock()
+        registry.check_strategy_health.return_value = {"is_healthy": True}
+        handler = self._handler(registry)
+
+        command = UpdateProviderHealthCommand(
+            provider_name="aws", health_status={"is_healthy": False}
+        )
+        await handler.handle(command)
+
+        registry.update_provider_health.assert_called_once()
+        _publisher(handler).publish.assert_called_once()
+        assert _res(command)["provider_name"] == "aws"
+
+    @pytest.mark.asyncio
+    async def test_no_event_when_health_unchanged(self):
+        registry = MagicMock()
+        registry.check_strategy_health.return_value = {"is_healthy": True}
+        handler = self._handler(registry)
+
+        command = UpdateProviderHealthCommand(
+            provider_name="aws", health_status={"is_healthy": True}
+        )
+        await handler.handle(command)
+
+        registry.update_provider_health.assert_called_once()
+        _publisher(handler).publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_health_report_publishes_event(self):
+        registry = MagicMock()
+        registry.check_strategy_health.return_value = None
+        handler = self._handler(registry)
+
+        command = UpdateProviderHealthCommand(
+            provider_name="aws", health_status={"is_healthy": True}
+        )
+        await handler.handle(command)
+
+        _publisher(handler).publish.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_failure_raises(self):
+        registry = MagicMock()
+        registry.check_strategy_health.return_value = {"is_healthy": True}
+        registry.update_provider_health.side_effect = RuntimeError("write failed")
+        handler = self._handler(registry)
+
+        command = UpdateProviderHealthCommand(
+            provider_name="aws", health_status={"is_healthy": False}
+        )
+        with pytest.raises(RuntimeError):
+            await handler.handle(command)
+
+    @pytest.mark.asyncio
+    async def test_missing_provider_name_fails_validation(self):
+        registry = MagicMock()
+        handler = self._handler(registry)
+        command = UpdateProviderHealthCommand(provider_name="", health_status={"is_healthy": True})
+
+        with pytest.raises(ValueError):
+            await handler.handle(command)
+
+    @pytest.mark.asyncio
+    async def test_missing_health_status_fails_validation(self):
+        registry = MagicMock()
+        handler = self._handler(registry)
+        command = UpdateProviderHealthCommand(provider_name="aws", health_status=None)
+
+        with pytest.raises(ValueError):
+            await handler.handle(command)

--- a/tests/unit/application/commands/test_request_creation_handlers.py
+++ b/tests/unit/application/commands/test_request_creation_handlers.py
@@ -462,7 +462,7 @@ class TestFilterMachines:
         self, machines: dict[str, MagicMock]
     ) -> CreateReturnRequestHandler:
         uow = MagicMock()
-        uow.machines.get_by_id.side_effect = lambda mid: machines.get(mid)
+        uow.machines.get_by_id.side_effect = machines.get
 
         @contextmanager
         def _create():
@@ -616,4 +616,165 @@ class TestCreateReturnRequestHandlerExecute:
         with pytest.raises(RuntimeError, match="boom"):
             await handler.execute_command(cmd)
 
-        handler.logger.error.assert_called()  # type: ignore[attr-defined]
+
+# ---------------------------------------------------------------------------
+# CreateReturnRequestHandler — _execute_deprovisioning_for_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestExecuteDeprovisioningForRequest:
+    def _handler(
+        self,
+        *,
+        group_by_resource=None,
+        deprovision_result=None,
+        deprovision_side_effect=None,
+        command_bus: AsyncMock | None = None,
+    ) -> CreateReturnRequestHandler:
+        handler = _make_return_handler()
+        grouping = MagicMock()
+        grouping.group_by_resource.return_value = group_by_resource or ([MagicMock()], [])
+        handler._machine_grouping_service = grouping
+        orchestrator = AsyncMock()
+        orchestrator.execute_deprovisioning = AsyncMock(
+            return_value=deprovision_result, side_effect=deprovision_side_effect
+        )
+        handler._deprovisioning_orchestrator = orchestrator
+        container = MagicMock()
+        container.get.return_value = command_bus or AsyncMock()
+        handler._container = container
+        return handler
+
+    @pytest.mark.asyncio
+    async def test_success_no_skipped_marks_terminating(self):
+        handler = self._handler(
+            group_by_resource=([MagicMock()], []),
+            deprovision_result={"success": True},
+        )
+        request = MagicMock()
+        request.request_id = "ret-1"
+
+        with (
+            patch.object(handler, "_update_machines_to_pending") as mock_pending,
+            patch.object(handler, "_update_request_to_terminating", new=AsyncMock()) as mock_term,
+        ):
+            await handler._execute_deprovisioning_for_request([_MACHINE_ID], request, "aws")
+
+        mock_pending.assert_called_once_with([_MACHINE_ID])
+        mock_term.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_success_with_skipped_marks_partial(self):
+        command_bus = AsyncMock()
+        handler = self._handler(
+            group_by_resource=([MagicMock()], ["m-skipped"]),
+            deprovision_result={"success": True},
+            command_bus=command_bus,
+        )
+        request = MagicMock()
+        request.request_id = "ret-1"
+
+        with patch.object(handler, "_update_machines_to_pending"):
+            await handler._execute_deprovisioning_for_request([_MACHINE_ID], request, "aws")
+
+        # A PARTIAL status update is dispatched via the command bus.
+        partial_calls = [
+            c
+            for c in command_bus.execute.await_args_list
+            if getattr(c.args[0], "status", None) == RequestStatus.PARTIAL
+        ]
+        assert partial_calls
+
+    @pytest.mark.asyncio
+    async def test_failure_marks_request_failed(self):
+        handler = self._handler(
+            group_by_resource=([MagicMock()], []),
+            deprovision_result={"success": False, "errors": ["nope"]},
+        )
+        request = MagicMock()
+        request.request_id = "ret-1"
+
+        with patch.object(handler, "_update_request_to_failed", new=AsyncMock()) as mock_failed:
+            await handler._execute_deprovisioning_for_request([_MACHINE_ID], request, "aws")
+
+        mock_failed.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_exception_marks_failed(self):
+        handler = self._handler(
+            group_by_resource=([MagicMock()], []),
+            deprovision_side_effect=RuntimeError("provider blew up"),
+        )
+        request = MagicMock()
+        request.request_id = "ret-1"
+
+        with patch.object(handler, "_update_request_to_failed", new=AsyncMock()) as mock_failed:
+            await handler._execute_deprovisioning_for_request([_MACHINE_ID], request, "aws")
+
+        mock_failed.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# CreateReturnRequestHandler — _cancel_validate_and_persist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCancelValidateAndPersist:
+    def test_persists_request_and_claims_machines(self):
+        machine = MagicMock()
+        machine.return_request_id = None
+        machine.model_copy.return_value = machine
+
+        uow = MagicMock()
+        uow.machines.get_by_id.return_value = machine
+        uow.requests.save.return_value = []
+
+        @contextmanager
+        def _create():
+            yield uow
+
+        factory = MagicMock()
+        factory.create_unit_of_work.side_effect = _create
+
+        handler = _make_return_handler(uow_factory=factory)
+        request = MagicMock()
+        request.request_id = "ret-1"
+
+        handler._cancel_validate_and_persist([_MACHINE_ID], request, force_return=False)
+
+        uow.requests.save.assert_called_once_with(request)
+        # Machine is claimed with the new return_request_id.
+        machine.model_copy.assert_called_with(update={"return_request_id": "ret-1"})
+        uow.machines.save.assert_called()
+
+    def test_force_cancels_stuck_request(self):
+        machine = MagicMock()
+        machine.return_request_id = "ret-00000000-0000-0000-0000-000000000009"
+        machine.model_copy.return_value = machine
+
+        stuck = MagicMock()
+        cancelled = MagicMock()
+        stuck.cancel.return_value = cancelled
+
+        uow = MagicMock()
+        uow.machines.get_by_id.return_value = machine
+        uow.requests.get_by_id.return_value = stuck
+        uow.requests.save.return_value = []
+
+        @contextmanager
+        def _create():
+            yield uow
+
+        factory = MagicMock()
+        factory.create_unit_of_work.side_effect = _create
+
+        handler = _make_return_handler(uow_factory=factory)
+        request = MagicMock()
+        request.request_id = "ret-1"
+
+        handler._cancel_validate_and_persist([_MACHINE_ID], request, force_return=True)
+
+        stuck.cancel.assert_called_once()
+        uow.requests.save.assert_any_call(cancelled)

--- a/tests/unit/application/commands/test_request_handlers_reexport.py
+++ b/tests/unit/application/commands/test_request_handlers_reexport.py
@@ -1,0 +1,34 @@
+"""Unit test for the request_handlers re-export module.
+
+request_handlers.py aggregates the request command handlers from their focused
+modules for backward-compatible imports. This test pins that public surface so a
+handler cannot be dropped from the aggregate without a failing test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orb.application.commands import request_handlers
+
+
+@pytest.mark.unit
+def test_all_declared_handlers_are_exported():
+    expected = {
+        "CreateMachineRequestHandler",
+        "CreateReturnRequestHandler",
+        "UpdateRequestStatusHandler",
+        "CancelRequestHandler",
+        "CompleteRequestHandler",
+        "PopulateMachineIdsHandler",
+        "SyncRequestHandler",
+    }
+    assert set(request_handlers.__all__) == expected
+
+
+@pytest.mark.unit
+def test_exported_names_resolve_to_handler_classes():
+    for name in request_handlers.__all__:
+        obj = getattr(request_handlers, name)
+        assert isinstance(obj, type)
+        assert name.endswith("Handler")

--- a/tests/unit/application/commands/test_sync_request_handler.py
+++ b/tests/unit/application/commands/test_sync_request_handler.py
@@ -1,0 +1,215 @@
+"""Unit tests for SyncRequestHandler and PopulateMachineIdsHandler edge paths.
+
+Covers application/commands/request_sync_handlers.py branches not exercised by
+the dispatch tests: the sync happy path, not-found handling, provider-error
+propagation, and the machine-id discovery error branch. Only abstract ports and
+application services are mocked.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orb.application.commands.request_sync_handlers import (
+    PopulateMachineIdsHandler,
+    SyncRequestHandler,
+)
+from orb.application.dto.commands import PopulateMachineIdsCommand, SyncRequestCommand
+from orb.domain.base.exceptions import EntityNotFoundError
+
+_VALID_REQUEST_ID = "req-00000000-0000-0000-0000-000000000001"
+
+
+def _make_uow_factory(request) -> MagicMock:
+    uow = MagicMock()
+    uow.requests.get_by_id.return_value = request
+    uow.requests.save = MagicMock()
+
+    @contextmanager
+    def _create():
+        yield uow
+
+    factory = MagicMock()
+    factory.create_unit_of_work.side_effect = _create
+    return factory
+
+
+def _ports() -> dict:
+    return {
+        "logger": MagicMock(),
+        "event_publisher": MagicMock(),
+        "error_handler": MagicMock(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# SyncRequestHandler
+# ---------------------------------------------------------------------------
+
+
+class TestSyncRequestHandler:
+    def _handler(self, request, container: MagicMock) -> SyncRequestHandler:
+        return SyncRequestHandler(
+            uow_factory=_make_uow_factory(request),
+            container=container,
+            **_ports(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_syncs_and_updates_status(self):
+        request = MagicMock()
+        machine_sync_service = MagicMock()
+        machine_sync_service.fetch_provider_machines = AsyncMock(return_value=([], {}))
+        machine_sync_service.sync_machines_with_provider = AsyncMock(return_value=([], []))
+        status_service = MagicMock()
+        status_service.determine_status_from_machines.return_value = ("completed", "done")
+        status_service.update_request_status = AsyncMock()
+
+        container = MagicMock()
+
+        def _get(cls):
+            name = getattr(cls, "__name__", "")
+            if name == "MachineSyncService":
+                return machine_sync_service
+            if name == "RequestStatusService":
+                return status_service
+            return MagicMock()
+
+        container.get.side_effect = _get
+
+        handler = self._handler(request, container)
+
+        with patch("orb.application.services.request_query_service.RequestQueryService") as MockQS:
+            qs = MockQS.return_value
+            qs.get_machines_for_request = AsyncMock(return_value=[])
+            await handler.handle(SyncRequestCommand(request_id=_VALID_REQUEST_ID))
+
+        status_service.update_request_status.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_status_update_when_status_unchanged(self):
+        request = MagicMock()
+        machine_sync_service = MagicMock()
+        machine_sync_service.fetch_provider_machines = AsyncMock(return_value=([], {}))
+        machine_sync_service.sync_machines_with_provider = AsyncMock(return_value=([], []))
+        status_service = MagicMock()
+        status_service.determine_status_from_machines.return_value = (None, None)
+        status_service.update_request_status = AsyncMock()
+
+        container = MagicMock()
+
+        def _get(cls):
+            name = getattr(cls, "__name__", "")
+            if name == "MachineSyncService":
+                return machine_sync_service
+            if name == "RequestStatusService":
+                return status_service
+            return MagicMock()
+
+        container.get.side_effect = _get
+        handler = self._handler(request, container)
+
+        with patch("orb.application.services.request_query_service.RequestQueryService") as MockQS:
+            qs = MockQS.return_value
+            qs.get_machines_for_request = AsyncMock(return_value=[])
+            await handler.handle(SyncRequestCommand(request_id=_VALID_REQUEST_ID))
+
+        status_service.update_request_status.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises_entity_not_found(self):
+        handler = self._handler(None, MagicMock())
+
+        with pytest.raises(EntityNotFoundError):
+            await handler.handle(SyncRequestCommand(request_id=_VALID_REQUEST_ID))
+
+    @pytest.mark.asyncio
+    async def test_provider_error_propagates(self):
+        request = MagicMock()
+        machine_sync_service = MagicMock()
+        machine_sync_service.fetch_provider_machines = AsyncMock(
+            side_effect=RuntimeError("provider down")
+        )
+        status_service = MagicMock()
+
+        container = MagicMock()
+
+        def _get(cls):
+            name = getattr(cls, "__name__", "")
+            if name == "MachineSyncService":
+                return machine_sync_service
+            if name == "RequestStatusService":
+                return status_service
+            return MagicMock()
+
+        container.get.side_effect = _get
+        handler = self._handler(request, container)
+
+        with patch("orb.application.services.request_query_service.RequestQueryService") as MockQS:
+            qs = MockQS.return_value
+            qs.get_machines_for_request = AsyncMock(return_value=[])
+            with pytest.raises(RuntimeError):
+                await handler.handle(SyncRequestCommand(request_id=_VALID_REQUEST_ID))
+
+
+# ---------------------------------------------------------------------------
+# PopulateMachineIdsHandler edge paths
+# ---------------------------------------------------------------------------
+
+
+class TestPopulateMachineIdsEdges:
+    def _handler(self, request, provider_selection_port) -> PopulateMachineIdsHandler:
+        container = MagicMock()
+        container.get.return_value = MagicMock()
+        return PopulateMachineIdsHandler(
+            uow_factory=_make_uow_factory(request),
+            container=container,
+            provider_selection_port=provider_selection_port,
+            **_ports(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_when_request_missing(self):
+        provider_selection_port = MagicMock()
+        provider_selection_port.execute_operation = AsyncMock()
+        handler = self._handler(None, provider_selection_port)
+
+        await handler.handle(PopulateMachineIdsCommand(request_id=_VALID_REQUEST_ID))
+
+        provider_selection_port.execute_operation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_population_not_needed(self):
+        request = MagicMock()
+        request.needs_machine_id_population.return_value = False
+        provider_selection_port = MagicMock()
+        provider_selection_port.execute_operation = AsyncMock()
+        handler = self._handler(request, provider_selection_port)
+
+        await handler.handle(PopulateMachineIdsCommand(request_id=_VALID_REQUEST_ID))
+
+        provider_selection_port.execute_operation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_discovery_error_is_swallowed(self):
+        request = MagicMock()
+        request.needs_machine_id_population.return_value = True
+        request.resource_ids = ["fleet-1"]
+        request.provider_api = "SpotFleet"
+        request.template_id = "tpl-1"
+        request.provider_name = "aws"
+
+        async def _boom(provider_name, operation):
+            raise RuntimeError("describe failed")
+
+        provider_selection_port = MagicMock()
+        provider_selection_port.execute_operation = _boom
+        handler = self._handler(request, provider_selection_port)
+
+        # Must not raise; discovery failure returns an empty id list.
+        await handler.handle(PopulateMachineIdsCommand(request_id=_VALID_REQUEST_ID))
+
+        request.update_machine_ids.assert_not_called()

--- a/tests/unit/application/commands/test_system_command_handlers.py
+++ b/tests/unit/application/commands/test_system_command_handlers.py
@@ -1,0 +1,199 @@
+"""Unit tests for application/commands/system_handlers.py.
+
+Covers ReloadProviderConfigHandler, RefreshTemplatesHandler and
+SetConfigurationHandler: happy path, error handling (results captured in
+command.result per CQRS), and verification that the correct configuration /
+template ports are invoked. Only abstract ports are mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orb.application.commands.system import (
+    RefreshTemplatesCommand,
+    ReloadProviderConfigCommand,
+    SetConfigurationCommand,
+)
+from orb.application.commands.system_handlers import (
+    RefreshTemplatesHandler,
+    ReloadProviderConfigHandler,
+    SetConfigurationHandler,
+)
+from orb.domain.base.ports import ConfigurationPort
+from orb.domain.base.ports.template_configuration_port import TemplateConfigurationPort
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ports() -> dict:
+    return {
+        "logger": MagicMock(),
+        "event_publisher": MagicMock(),
+        "error_handler": MagicMock(),
+    }
+
+
+def _container_returning(port_type, instance) -> MagicMock:
+    container = MagicMock()
+
+    def _get(requested):
+        if requested is port_type:
+            return instance
+        return MagicMock()
+
+    container.get.side_effect = _get
+    return container
+
+
+def _res(command) -> dict:
+    """Narrow the optional CQRS result dict for assertions."""
+    assert command.result is not None
+    return command.result
+
+
+# ---------------------------------------------------------------------------
+# ReloadProviderConfigHandler
+# ---------------------------------------------------------------------------
+
+
+class TestReloadProviderConfigHandler:
+    @pytest.mark.asyncio
+    async def test_reloads_and_reports_success(self):
+        provider_config = MagicMock()
+        provider_config.get_mode.return_value.value = "strategy"
+        active = MagicMock()
+        active.name = "aws"
+        provider_config.get_active_providers.return_value = [active]
+
+        config_manager = MagicMock()
+        config_manager.get_provider_config.return_value = provider_config
+        container = _container_returning(ConfigurationPort, config_manager)
+
+        handler = ReloadProviderConfigHandler(container=container, **_ports())
+        command = ReloadProviderConfigCommand(config_path="/tmp/x.yaml")
+
+        await handler.handle(command)
+
+        config_manager.reload.assert_called_once_with("/tmp/x.yaml")
+        assert _res(command)["status"] == "success"
+        assert _res(command)["active_providers"] == ["aws"]
+
+    @pytest.mark.asyncio
+    async def test_failure_captured_in_result(self):
+        config_manager = MagicMock()
+        config_manager.reload.side_effect = RuntimeError("bad config")
+        container = _container_returning(ConfigurationPort, config_manager)
+
+        handler = ReloadProviderConfigHandler(container=container, **_ports())
+        command = ReloadProviderConfigCommand(config_path="/tmp/x.yaml")
+
+        await handler.handle(command)
+
+        assert _res(command)["status"] == "failed"
+        assert "bad config" in _res(command)["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_provider_config_defaults(self):
+        config_manager = MagicMock()
+        config_manager.get_provider_config.return_value = None
+        container = _container_returning(ConfigurationPort, config_manager)
+
+        handler = ReloadProviderConfigHandler(container=container, **_ports())
+        command = ReloadProviderConfigCommand()
+
+        await handler.handle(command)
+
+        assert _res(command)["status"] == "success"
+        assert _res(command)["provider_mode"] == "strategy"
+        assert _res(command)["active_providers"] == []
+
+
+# ---------------------------------------------------------------------------
+# RefreshTemplatesHandler
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshTemplatesHandler:
+    @pytest.mark.asyncio
+    async def test_refreshes_and_reports_count(self):
+        tmpl = MagicMock()
+        tmpl.model_dump.return_value = {"template_id": "t1"}
+        template_manager = MagicMock()
+        template_manager.load_templates = AsyncMock(return_value=[tmpl])
+        container = _container_returning(TemplateConfigurationPort, template_manager)
+
+        handler = RefreshTemplatesHandler(container=container, **_ports())
+        command = RefreshTemplatesCommand(provider_name="aws")
+
+        await handler.handle(command)
+
+        template_manager.load_templates.assert_awaited_once_with("aws")
+        assert _res(command)["status"] == "success"
+        assert _res(command)["template_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_failure_captured_in_result(self):
+        template_manager = MagicMock()
+        template_manager.load_templates = AsyncMock(side_effect=RuntimeError("no source"))
+        container = _container_returning(TemplateConfigurationPort, template_manager)
+
+        handler = RefreshTemplatesHandler(container=container, **_ports())
+        command = RefreshTemplatesCommand()
+
+        await handler.handle(command)
+
+        assert _res(command)["status"] == "failed"
+        assert "no source" in _res(command)["error"]
+
+
+# ---------------------------------------------------------------------------
+# SetConfigurationHandler
+# ---------------------------------------------------------------------------
+
+
+class TestSetConfigurationHandler:
+    @pytest.mark.asyncio
+    async def test_sets_value_and_reports_success(self):
+        config_manager = MagicMock()
+        container = _container_returning(ConfigurationPort, config_manager)
+
+        handler = SetConfigurationHandler(container=container, **_ports())
+        command = SetConfigurationCommand(key="log.level", value="DEBUG")
+
+        await handler.handle(command)
+
+        config_manager.set_configuration_value.assert_called_once_with(
+            "log.level", "DEBUG"
+        )
+        assert _res(command)["status"] == "success"
+        assert _res(command)["key"] == "log.level"
+
+    @pytest.mark.asyncio
+    async def test_failure_captured_in_result(self):
+        config_manager = MagicMock()
+        config_manager.set_configuration_value.side_effect = RuntimeError("locked")
+        container = _container_returning(ConfigurationPort, config_manager)
+
+        handler = SetConfigurationHandler(container=container, **_ports())
+        command = SetConfigurationCommand(key="log.level", value="DEBUG")
+
+        await handler.handle(command)
+
+        assert _res(command)["status"] == "failed"
+        assert "locked" in _res(command)["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_key_fails_validation(self):
+        config_manager = MagicMock()
+        container = _container_returning(ConfigurationPort, config_manager)
+
+        handler = SetConfigurationHandler(container=container, **_ports())
+        command = SetConfigurationCommand(key="", value="DEBUG")
+
+        with pytest.raises(ValueError):
+            await handler.handle(command)

--- a/tests/unit/application/commands/test_system_command_handlers.py
+++ b/tests/unit/application/commands/test_system_command_handlers.py
@@ -167,11 +167,39 @@ class TestSetConfigurationHandler:
 
         await handler.handle(command)
 
-        config_manager.set_configuration_value.assert_called_once_with(
-            "log.level", "DEBUG"
-        )
+        config_manager.set_configuration_value.assert_called_once_with("log.level", "DEBUG")
         assert _res(command)["status"] == "success"
         assert _res(command)["key"] == "log.level"
+
+    @pytest.mark.asyncio
+    async def test_persists_to_disk_by_default(self):
+        config_manager = MagicMock()
+        config_manager.save_config.return_value = "/etc/orb/config.json"
+        container = _container_returning(ConfigurationPort, config_manager)
+
+        handler = SetConfigurationHandler(container=container, **_ports())
+        command = SetConfigurationCommand(key="log.level", value="DEBUG")
+
+        await handler.handle(command)
+
+        config_manager.save_config.assert_called_once_with(None)
+        assert _res(command)["persisted"] is True
+        assert _res(command)["persisted_path"] == "/etc/orb/config.json"
+
+    @pytest.mark.asyncio
+    async def test_no_persist_skips_disk_write(self):
+        config_manager = MagicMock()
+        container = _container_returning(ConfigurationPort, config_manager)
+
+        handler = SetConfigurationHandler(container=container, **_ports())
+        command = SetConfigurationCommand(key="log.level", value="DEBUG", persist=False)
+
+        await handler.handle(command)
+
+        config_manager.set_configuration_value.assert_called_once_with("log.level", "DEBUG")
+        config_manager.save_config.assert_not_called()
+        assert _res(command)["persisted"] is False
+        assert _res(command)["persisted_path"] is None
 
     @pytest.mark.asyncio
     async def test_failure_captured_in_result(self):

--- a/tests/unit/application/queries/test_bulk_handlers.py
+++ b/tests/unit/application/queries/test_bulk_handlers.py
@@ -49,8 +49,7 @@ def _make_templates_handler() -> GetMultipleTemplatesHandler:
     handler.error_handler = MagicMock()
     handler.uow_factory = MagicMock()
     handler._container = MagicMock()
-    handler._query_service = MagicMock()
-    handler._dto_factory = MagicMock()
+    handler._query_bus = MagicMock()
     return handler
 
 
@@ -60,8 +59,7 @@ def _make_machines_handler() -> GetMultipleMachinesHandler:
     handler.error_handler = MagicMock()
     handler.uow_factory = MagicMock()
     handler._container = MagicMock()
-    handler._query_service = MagicMock()
-    handler._dto_factory = MagicMock()
+    handler._query_bus = MagicMock()
     return handler
 
 
@@ -158,12 +156,9 @@ class TestGetMultipleRequestsHandler:
 class TestGetMultipleTemplatesHandler:
     async def test_all_active_templates_returned(self):
         handler = _make_templates_handler()
-        fake_dto_a = MagicMock()
-        fake_dto_b = MagicMock()
-        handler._query_service.get_template = AsyncMock(
-            side_effect=[MagicMock(active=True), MagicMock(active=True)]
-        )
-        handler._dto_factory.create_from_domain.side_effect = [fake_dto_a, fake_dto_b]
+        fake_dto_a = MagicMock(is_active=True)
+        fake_dto_b = MagicMock(is_active=True)
+        handler._query_bus.execute = AsyncMock(side_effect=[fake_dto_a, fake_dto_b])
 
         result = await handler.execute_query(
             GetMultipleTemplatesQuery(template_ids=["tmpl-a", "tmpl-b"], active_only=True)
@@ -175,7 +170,7 @@ class TestGetMultipleTemplatesHandler:
 
     async def test_inactive_template_excluded_when_active_only(self):
         handler = _make_templates_handler()
-        handler._query_service.get_template = AsyncMock(return_value=MagicMock(active=False))
+        handler._query_bus.execute = AsyncMock(return_value=MagicMock(is_active=False))
 
         result = await handler.execute_query(
             GetMultipleTemplatesQuery(template_ids=["tmpl-inactive"], active_only=True)
@@ -186,8 +181,7 @@ class TestGetMultipleTemplatesHandler:
 
     async def test_inactive_template_included_when_not_active_only(self):
         handler = _make_templates_handler()
-        handler._query_service.get_template = AsyncMock(return_value=MagicMock(active=False))
-        handler._dto_factory.create_from_domain.return_value = MagicMock()
+        handler._query_bus.execute = AsyncMock(return_value=MagicMock(is_active=False))
 
         result = await handler.execute_query(
             GetMultipleTemplatesQuery(template_ids=["tmpl-inactive"], active_only=False)
@@ -198,7 +192,7 @@ class TestGetMultipleTemplatesHandler:
 
     async def test_not_found_template_reported(self):
         handler = _make_templates_handler()
-        handler._query_service.get_template = AsyncMock(
+        handler._query_bus.execute = AsyncMock(
             side_effect=EntityNotFoundError("Template", "tmpl-gone")
         )
 
@@ -230,13 +224,7 @@ class TestGetMultipleMachinesHandler:
         dto_a = MachineDTO.model_validate({"machine_id": "mc-a", **_mc_fields})
         dto_b = MachineDTO.model_validate({"machine_id": "mc-b", **_mc_fields})
 
-        handler._query_service.get_machine = AsyncMock(
-            side_effect=[
-                MagicMock(machine_id="mc-a", request_id=None),
-                MagicMock(machine_id="mc-b", request_id=None),
-            ]
-        )
-        handler._dto_factory.create_from_domain.side_effect = [dto_a, dto_b]
+        handler._query_bus.execute = AsyncMock(side_effect=[dto_a, dto_b])
 
         result = await handler.execute_query(
             GetMultipleMachinesQuery(machine_ids=["mc-a", "mc-b"], include_requests=False)
@@ -248,7 +236,7 @@ class TestGetMultipleMachinesHandler:
 
     async def test_not_found_machine_reported(self):
         handler = _make_machines_handler()
-        handler._query_service.get_machine = AsyncMock(
+        handler._query_bus.execute = AsyncMock(
             side_effect=EntityNotFoundError("Machine", "mc-gone")
         )
 
@@ -260,13 +248,13 @@ class TestGetMultipleMachinesHandler:
 
     async def test_empty_id_list_returns_empty_batch(self):
         handler = _make_machines_handler()
-        handler._query_service.get_machine = AsyncMock()
+        handler._query_bus.execute = AsyncMock()
 
         result = await handler.execute_query(GetMultipleMachinesQuery(machine_ids=[]))
 
         assert result.found_count == 0
         assert result.total_requested == 0
-        handler._query_service.get_machine.assert_not_called()
+        handler._query_bus.execute.assert_not_called()
 
     async def test_partial_found_reports_not_found(self):
         from orb.application.machine.dto import MachineDTO
@@ -281,13 +269,12 @@ class TestGetMultipleMachinesHandler:
         }
         dto_a = MachineDTO.model_validate({"machine_id": "mc-a", **_mc_fields})
 
-        handler._query_service.get_machine = AsyncMock(
+        handler._query_bus.execute = AsyncMock(
             side_effect=[
-                MagicMock(machine_id="mc-a", request_id=None),
+                dto_a,
                 EntityNotFoundError("Machine", "mc-gone"),
             ]
         )
-        handler._dto_factory.create_from_domain.return_value = dto_a
 
         result = await handler.execute_query(
             GetMultipleMachinesQuery(machine_ids=["mc-a", "mc-gone"])

--- a/tests/unit/application/queries/test_bulk_handlers.py
+++ b/tests/unit/application/queries/test_bulk_handlers.py
@@ -92,7 +92,7 @@ class TestGetMultipleRequestsHandler:
         dto_b = _make_request_dto("req-b")
         handler._query_service.get_request = AsyncMock(side_effect=[MagicMock(), MagicMock()])
         handler._query_service.get_machines_for_request = AsyncMock(return_value=[])
-        handler._dto_factory.create_from_domain.side_effect = [dto_a, dto_b]
+        handler._dto_factory.create_from_domain = MagicMock(side_effect=[dto_a, dto_b])
 
         result = await handler.execute_query(
             GetMultipleRequestsQuery(request_ids=["req-a", "req-b"], include_machines=False)
@@ -110,7 +110,7 @@ class TestGetMultipleRequestsHandler:
             side_effect=[MagicMock(), EntityNotFoundError("Request", "req-missing")]
         )
         handler._query_service.get_machines_for_request = AsyncMock(return_value=[])
-        handler._dto_factory.create_from_domain.return_value = dto_a
+        handler._dto_factory.create_from_domain = MagicMock(return_value=dto_a)
 
         result = await handler.execute_query(
             GetMultipleRequestsQuery(request_ids=["req-a", "req-missing"])

--- a/tests/unit/application/queries/test_bulk_handlers_init.py
+++ b/tests/unit/application/queries/test_bulk_handlers_init.py
@@ -1,0 +1,125 @@
+"""Unit tests for bulk query handler construction and include-* branches.
+
+Complements test_bulk_handlers.py (which bypasses __init__ via object.__new__)
+by exercising the real __init__ wiring of GetMultipleRequestsHandler and the
+include_machines / include_requests enrichment branches in
+application/queries/bulk_handlers.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from orb.application.dto.bulk_queries import (
+    GetMultipleMachinesQuery,
+    GetMultipleRequestsQuery,
+)
+from orb.application.queries.bulk_handlers import (
+    GetMultipleMachinesHandler,
+    GetMultipleRequestsHandler,
+)
+
+
+def _make_request_dto(request_id: str = "req-a"):
+    from datetime import datetime, timezone
+
+    from orb.application.dto.responses import RequestDTO
+
+    return RequestDTO.model_validate(
+        {
+            "request_id": request_id,
+            "status": "complete",
+            "requested_count": 1,
+            "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        }
+    )
+
+
+def _make_machine_dto(machine_id: str = "mc-a"):
+    from orb.application.machine.dto import MachineDTO
+
+    return MachineDTO.model_validate(
+        {
+            "machine_id": machine_id,
+            "name": "i-test",
+            "status": "running",
+            "instance_type": "t3.small",
+            "private_ip": "10.0.0.1",
+            "result": "executing",
+        }
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestGetMultipleRequestsInit:
+    async def test_init_wires_services_and_include_machines(self):
+        with (
+            patch("orb.application.services.request_query_service.RequestQueryService") as MockQS,
+            patch("orb.application.factories.request_dto_factory.RequestDTOFactory") as MockFactory,
+        ):
+            qs = MockQS.return_value
+            qs.get_request = AsyncMock(return_value=MagicMock())
+            qs.get_machines_for_request = AsyncMock(return_value=["m1"])
+            MockFactory.return_value.create_from_domain.return_value = _make_request_dto()
+
+            handler = GetMultipleRequestsHandler(
+                uow_factory=MagicMock(),
+                logger=MagicMock(),
+                error_handler=MagicMock(),
+                container=MagicMock(),
+            )
+
+            result = await handler.execute_query(
+                GetMultipleRequestsQuery(request_ids=["req-a"], include_machines=True)
+            )
+
+        qs.get_machines_for_request.assert_awaited_once()
+        assert result.found_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestGetMultipleMachinesIncludeRequests:
+    """include_requests branch enriches each machine with its owning request."""
+
+    def _handler(self) -> GetMultipleMachinesHandler:
+        handler = object.__new__(GetMultipleMachinesHandler)
+        handler.logger = MagicMock()
+        handler.error_handler = MagicMock()
+        handler.uow_factory = MagicMock()
+        handler._container = MagicMock()
+        handler._query_service = MagicMock()
+        handler._dto_factory = MagicMock()
+        return handler
+
+    async def test_include_requests_fetches_owning_request(self):
+        handler = self._handler()
+        machine = MagicMock(machine_id="mc-a", request_id="req-a")
+        handler._query_service.get_machine = AsyncMock(return_value=machine)
+        handler._dto_factory.create_from_domain.return_value = _make_machine_dto()
+
+        with patch("orb.application.services.request_query_service.RequestQueryService") as MockRQS:
+            MockRQS.return_value.get_request = AsyncMock(return_value=MagicMock())
+
+            result = await handler.execute_query(
+                GetMultipleMachinesQuery(machine_ids=["mc-a"], include_requests=True)
+            )
+
+        MockRQS.return_value.get_request.assert_awaited_once_with("req-a")
+        assert result.found_count == 1
+
+    async def test_include_requests_skipped_when_no_request_id(self):
+        handler = self._handler()
+        machine = MagicMock(machine_id="mc-a", request_id=None)
+        handler._query_service.get_machine = AsyncMock(return_value=machine)
+        handler._dto_factory.create_from_domain.return_value = _make_machine_dto()
+
+        result = await handler.execute_query(
+            GetMultipleMachinesQuery(machine_ids=["mc-a"], include_requests=True)
+        )
+
+        # DTO built with request=None; no crash and machine is found.
+        assert result.found_count == 1

--- a/tests/unit/application/queries/test_bulk_handlers_init.py
+++ b/tests/unit/application/queries/test_bulk_handlers_init.py
@@ -1,9 +1,11 @@
-"""Unit tests for bulk query handler construction and include-* branches.
+"""Unit tests for bulk query handler construction and delegation.
 
 Complements test_bulk_handlers.py (which bypasses __init__ via object.__new__)
-by exercising the real __init__ wiring of GetMultipleRequestsHandler and the
-include_machines / include_requests enrichment branches in
-application/queries/bulk_handlers.py.
+by exercising the real __init__ wiring and query-bus delegation of the bulk
+handlers in application/queries/bulk_handlers.py. Constructing the handlers
+through their public constructors here guards against a regression where a
+handler's __init__ referenced a module that does not exist, which the
+object.__new__ tests could never catch.
 """
 
 from __future__ import annotations
@@ -15,10 +17,12 @@ import pytest
 from orb.application.dto.bulk_queries import (
     GetMultipleMachinesQuery,
     GetMultipleRequestsQuery,
+    GetMultipleTemplatesQuery,
 )
 from orb.application.queries.bulk_handlers import (
     GetMultipleMachinesHandler,
     GetMultipleRequestsHandler,
+    GetMultipleTemplatesHandler,
 )
 
 
@@ -82,44 +86,87 @@ class TestGetMultipleRequestsInit:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-class TestGetMultipleMachinesIncludeRequests:
-    """include_requests branch enriches each machine with its owning request."""
+class TestGetMultipleMachinesInit:
+    """Exercise the real __init__ wiring and query-bus delegation.
 
-    def _handler(self) -> GetMultipleMachinesHandler:
-        handler = object.__new__(GetMultipleMachinesHandler)
-        handler.logger = MagicMock()
-        handler.error_handler = MagicMock()
-        handler.uow_factory = MagicMock()
-        handler._container = MagicMock()
-        handler._query_service = MagicMock()
-        handler._dto_factory = MagicMock()
-        return handler
+    These construct the handler through its public constructor (no
+    object.__new__ bypass) so a broken import or a missing collaborator in
+    __init__ surfaces here rather than being silently skipped.
+    """
 
-    async def test_include_requests_fetches_owning_request(self):
-        handler = self._handler()
-        machine = MagicMock(machine_id="mc-a", request_id="req-a")
-        handler._query_service.get_machine = AsyncMock(return_value=machine)
-        handler._dto_factory.create_from_domain.return_value = _make_machine_dto()
+    def _handler(self, query_bus: MagicMock) -> GetMultipleMachinesHandler:
+        return GetMultipleMachinesHandler(
+            uow_factory=MagicMock(),
+            logger=MagicMock(),
+            error_handler=MagicMock(),
+            container=MagicMock(),
+            query_bus=query_bus,
+        )
 
-        with patch("orb.application.services.request_query_service.RequestQueryService") as MockRQS:
-            MockRQS.return_value.get_request = AsyncMock(return_value=MagicMock())
-
-            result = await handler.execute_query(
-                GetMultipleMachinesQuery(machine_ids=["mc-a"], include_requests=True)
-            )
-
-        MockRQS.return_value.get_request.assert_awaited_once_with("req-a")
-        assert result.found_count == 1
-
-    async def test_include_requests_skipped_when_no_request_id(self):
-        handler = self._handler()
-        machine = MagicMock(machine_id="mc-a", request_id=None)
-        handler._query_service.get_machine = AsyncMock(return_value=machine)
-        handler._dto_factory.create_from_domain.return_value = _make_machine_dto()
+    async def test_delegates_to_single_machine_query(self):
+        query_bus = MagicMock()
+        query_bus.execute = AsyncMock(return_value=_make_machine_dto())
+        handler = self._handler(query_bus)
 
         result = await handler.execute_query(
             GetMultipleMachinesQuery(machine_ids=["mc-a"], include_requests=True)
         )
 
-        # DTO built with request=None; no crash and machine is found.
+        query_bus.execute.assert_awaited_once()
         assert result.found_count == 1
+
+    async def test_not_found_reported(self):
+        from orb.domain.base.exceptions import EntityNotFoundError
+
+        query_bus = MagicMock()
+        query_bus.execute = AsyncMock(side_effect=EntityNotFoundError("Machine", "mc-gone"))
+        handler = self._handler(query_bus)
+
+        result = await handler.execute_query(GetMultipleMachinesQuery(machine_ids=["mc-gone"]))
+
+        assert result.found_count == 0
+        assert "mc-gone" in result.not_found_ids
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestGetMultipleTemplatesInit:
+    """Exercise the real __init__ wiring and query-bus delegation for templates.
+
+    Constructing through the public constructor and executing the query proves
+    the handler no longer references a non-existent template query service.
+    """
+
+    def _handler(self, query_bus: MagicMock) -> GetMultipleTemplatesHandler:
+        return GetMultipleTemplatesHandler(
+            uow_factory=MagicMock(),
+            logger=MagicMock(),
+            error_handler=MagicMock(),
+            container=MagicMock(),
+            query_bus=query_bus,
+        )
+
+    async def test_delegates_to_single_template_query(self):
+        query_bus = MagicMock()
+        query_bus.execute = AsyncMock(return_value=MagicMock(is_active=True))
+        handler = self._handler(query_bus)
+
+        result = await handler.execute_query(
+            GetMultipleTemplatesQuery(template_ids=["tmpl-a"], active_only=True)
+        )
+
+        query_bus.execute.assert_awaited_once()
+        assert result.found_count == 1
+        assert result.not_found_ids == []
+
+    async def test_not_found_reported(self):
+        from orb.domain.base.exceptions import EntityNotFoundError
+
+        query_bus = MagicMock()
+        query_bus.execute = AsyncMock(side_effect=EntityNotFoundError("Template", "tmpl-gone"))
+        handler = self._handler(query_bus)
+
+        result = await handler.execute_query(GetMultipleTemplatesQuery(template_ids=["tmpl-gone"]))
+
+        assert result.found_count == 0
+        assert "tmpl-gone" in result.not_found_ids

--- a/tests/unit/application/queries/test_list_requests_pipeline.py
+++ b/tests/unit/application/queries/test_list_requests_pipeline.py
@@ -1,0 +1,210 @@
+"""Unit tests for ListRequestsHandler pipeline branches.
+
+Exercises the filter/search/sort/pagination pipeline of
+application/queries/request_query_handlers.py::ListRequestsHandler that the
+existing request-type tests do not reach: provider/status/template filters,
+free-text ``q`` search, sort ordering, offset/limit slicing, limit clamping,
+and DTO-level ``filter_expressions``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from orb.application.request.queries import ListRequestsQuery
+
+
+def _make_request(
+    request_id="req-1",
+    template_id="tmpl-1",
+    provider_name="aws",
+    provider_type="aws",
+    provider_api="RunInstances",
+    status_value="pending",
+    machine_ids=None,
+):
+    return SimpleNamespace(
+        request_id=SimpleNamespace(value=request_id),
+        request_type=None,
+        template_id=template_id,
+        provider_api=provider_api,
+        provider_name=provider_name,
+        provider_type=provider_type,
+        status=SimpleNamespace(value=status_value),
+        machine_ids=machine_ids or [],
+    )
+
+
+def _run(all_requests, query, filter_side_effect=None):
+    from orb.application.queries.request_query_handlers import ListRequestsHandler
+
+    mock_filter_service = MagicMock()
+    mock_filter_service.apply_filters.side_effect = filter_side_effect or (lambda items, _: items)
+
+    mock_uow = MagicMock()
+    mock_uow.requests.find_all.return_value = all_requests
+    mock_uow.machines.find_by_ids.return_value = []
+    mock_uow.__enter__ = lambda s: s
+    mock_uow.__exit__ = MagicMock(return_value=False)
+
+    mock_uow_factory = MagicMock()
+    mock_uow_factory.create_unit_of_work.return_value = mock_uow
+
+    with patch("orb.application.queries.request_query_handlers.RequestDTOFactory") as MockFactory:
+        mock_dto_factory = MagicMock()
+        MockFactory.return_value = mock_dto_factory
+        mock_dto_factory.create_from_domain.side_effect = lambda req, machines: SimpleNamespace(
+            request_id=str(req.request_id.value),
+            template_id=req.template_id,
+        )
+
+        handler = ListRequestsHandler(
+            uow_factory=mock_uow_factory,
+            logger=MagicMock(),
+            error_handler=MagicMock(),
+            generic_filter_service=mock_filter_service,
+        )
+        return asyncio.run(handler.execute_query(query))
+
+
+class TestListRequestsPipeline:
+    def test_filter_by_provider_name(self):
+        reqs = [
+            _make_request("r1", provider_name="aws"),
+            _make_request("r2", provider_name="gcp"),
+        ]
+        result = _run(reqs, ListRequestsQuery(provider_name="aws"))
+        assert result.total_count == 1
+        assert result.total_unfiltered == 2
+        assert result.items[0].request_id == "r1"
+
+    def test_filter_by_provider_type(self):
+        reqs = [
+            _make_request("r1", provider_type="aws"),
+            _make_request("r2", provider_type="k8s"),
+        ]
+        result = _run(reqs, ListRequestsQuery(provider_type="k8s"))
+        assert result.total_count == 1
+        assert result.items[0].request_id == "r2"
+
+    def test_filter_by_status(self):
+        from orb.domain.request.value_objects import RequestStatus
+
+        reqs = [
+            _make_request("r1", status_value=RequestStatus.PENDING.value),
+            _make_request("r2", status_value=RequestStatus.COMPLETED.value),
+        ]
+        # RequestStatus comparison — set request.status to the enum for equality.
+        reqs[0].status = RequestStatus.PENDING
+        reqs[1].status = RequestStatus.COMPLETED
+        result = _run(reqs, ListRequestsQuery(status=RequestStatus.PENDING.value))
+        assert result.total_count == 1
+        assert result.items[0].request_id == "r1"
+
+    def test_filter_by_template_id(self):
+        reqs = [
+            _make_request("r1", template_id="tmpl-a"),
+            _make_request("r2", template_id="tmpl-b"),
+        ]
+        result = _run(reqs, ListRequestsQuery(template_id="tmpl-b"))
+        assert result.total_count == 1
+        assert result.items[0].request_id == "r2"
+
+    def test_free_text_search_matches_template(self):
+        reqs = [
+            _make_request("r1", template_id="web-server"),
+            _make_request("r2", template_id="db-server"),
+        ]
+        result = _run(reqs, ListRequestsQuery(q="web"))
+        assert result.total_count == 1
+        assert result.items[0].request_id == "r1"
+
+    def test_sort_descending_by_template(self):
+        reqs = [
+            _make_request("r1", template_id="aaa"),
+            _make_request("r2", template_id="zzz"),
+        ]
+        result = _run(reqs, ListRequestsQuery(sort="-template_id"))
+        assert [i.request_id for i in result.items] == ["r2", "r1"]
+
+    def test_sort_ascending_by_template(self):
+        reqs = [
+            _make_request("r1", template_id="zzz"),
+            _make_request("r2", template_id="aaa"),
+        ]
+        result = _run(reqs, ListRequestsQuery(sort="+template_id"))
+        assert [i.request_id for i in result.items] == ["r2", "r1"]
+
+    def test_offset_and_limit_slicing(self):
+        reqs = [_make_request(f"r{i}", template_id=f"t{i:02d}") for i in range(5)]
+        result = _run(reqs, ListRequestsQuery(sort="+template_id", offset=1, limit=2))
+        assert result.total_count == 5
+        assert [i.request_id for i in result.items] == ["r1", "r2"]
+
+    def test_zero_limit_returns_no_items_but_counts(self):
+        reqs = [_make_request(f"r{i}") for i in range(3)]
+        result = _run(reqs, ListRequestsQuery(limit=0))
+        assert result.total_count == 3
+        assert result.items == []
+
+    def test_limit_clamped_to_1000(self):
+        reqs = [_make_request(f"r{i}", template_id=f"t{i:04d}") for i in range(3)]
+        result = _run(reqs, ListRequestsQuery(limit=5000))
+        # No error; all 3 returned (fewer than the clamp).
+        assert result.total_count == 3
+        assert len(result.items) == 3
+
+    def test_filter_expressions_applied_on_dtos(self):
+        from orb.application.queries.request_query_handlers import ListRequestsHandler
+
+        class _DTO:
+            def __init__(self, request_id, template_id):
+                self.request_id = request_id
+                self.template_id = template_id
+
+            def model_dump(self):
+                return {"request_id": self.request_id, "template_id": self.template_id}
+
+        reqs = [
+            _make_request("r1", template_id="keep"),
+            _make_request("r2", template_id="drop"),
+        ]
+
+        mock_filter_service = MagicMock()
+        mock_filter_service.apply_filters.side_effect = lambda dicts, _: [
+            d for d in dicts if d["template_id"] == "keep"
+        ]
+
+        mock_uow = MagicMock()
+        mock_uow.requests.find_all.return_value = reqs
+        mock_uow.machines.find_by_ids.return_value = []
+        mock_uow.__enter__ = lambda s: s
+        mock_uow.__exit__ = MagicMock(return_value=False)
+        mock_uow_factory = MagicMock()
+        mock_uow_factory.create_unit_of_work.return_value = mock_uow
+
+        with (
+            patch(
+                "orb.application.queries.request_query_handlers.RequestDTOFactory"
+            ) as MockFactory,
+            patch("orb.application.queries.request_query_handlers.RequestDTO") as MockDTO,
+        ):
+            MockFactory.return_value.create_from_domain.side_effect = lambda req, machines: _DTO(
+                str(req.request_id.value), req.template_id
+            )
+            MockDTO.model_validate.side_effect = lambda d: _DTO(d["request_id"], d["template_id"])
+            handler = ListRequestsHandler(
+                uow_factory=mock_uow_factory,
+                logger=MagicMock(),
+                error_handler=MagicMock(),
+                generic_filter_service=mock_filter_service,
+            )
+            result = asyncio.run(
+                handler.execute_query(ListRequestsQuery(filter_expressions=["template_id==keep"]))
+            )
+
+        assert result.total_count == 2
+        assert len(result.items) == 1
+        assert result.items[0].template_id == "keep"

--- a/tests/unit/application/queries/test_list_return_requests_pipeline.py
+++ b/tests/unit/application/queries/test_list_return_requests_pipeline.py
@@ -1,0 +1,223 @@
+"""Unit tests for SyncAndListReturnRequestsHandler.
+
+Covers the read-through sync loop and the DTO filter/search/sort/pagination
+pipeline in application/queries/request_query_handlers.py that the existing
+active-requests tests do not reach.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from orb.application.dto.queries import SyncAndListReturnRequestsQuery
+
+
+def _make_return_request(request_id="ret-1", terminal=False, machine_ids=None):
+    status = SimpleNamespace(
+        is_terminal=lambda: terminal,
+        value="completed" if terminal else "in_progress",
+    )
+    return SimpleNamespace(
+        request_id=SimpleNamespace(value=request_id),
+        status=status,
+        machine_ids=machine_ids or [],
+    )
+
+
+def _make_dto(request_id, provider_name="aws", provider_type="aws", template_id="tmpl"):
+    class _DTO:
+        def __init__(self):
+            self.request_id = request_id
+            self.provider_name = provider_name
+            self.provider_type = provider_type
+            self.template_id = template_id
+
+        def model_dump(self):
+            return {
+                "request_id": self.request_id,
+                "provider_name": self.provider_name,
+                "provider_type": self.provider_type,
+                "template_id": self.template_id,
+            }
+
+    return _DTO()
+
+
+def _build_handler(return_requests, dtos, filter_side_effect=None, sync_side_effect=None):
+    from orb.application.queries.request_query_handlers import (
+        SyncAndListReturnRequestsHandler,
+    )
+
+    mock_uow = MagicMock()
+    mock_uow.requests.find_by_type.return_value = return_requests
+    mock_uow.machines.find_by_ids.return_value = []
+    mock_uow.__enter__ = lambda s: s
+    mock_uow.__exit__ = MagicMock(return_value=False)
+    mock_uow_factory = MagicMock()
+    mock_uow_factory.create_unit_of_work.return_value = mock_uow
+
+    mock_filter_service = MagicMock()
+    mock_filter_service.apply_filters.side_effect = filter_side_effect or (lambda items, _: items)
+
+    machine_sync = MagicMock()
+    machine_sync.fetch_provider_machines = AsyncMock(
+        side_effect=sync_side_effect, return_value=([], {})
+    )
+    machine_sync.sync_machines_with_provider = AsyncMock(return_value=([], []))
+
+    with patch("orb.application.queries.request_query_handlers.RequestDTOFactory") as MockFactory:
+        dto_iter = iter(dtos)
+        MockFactory.return_value.create_from_domain.side_effect = lambda req, machines: next(
+            dto_iter
+        )
+        handler = SyncAndListReturnRequestsHandler(
+            uow_factory=mock_uow_factory,
+            logger=MagicMock(),
+            error_handler=MagicMock(),
+            generic_filter_service=mock_filter_service,
+            machine_sync_service=machine_sync,
+        )
+
+    status_service = MagicMock()
+    status_service.determine_status_from_machines.return_value = (None, None)
+    status_service.update_request_status = AsyncMock()
+    handler._status_service = status_service
+
+    query_service = MagicMock()
+    query_service.get_machines_for_request = AsyncMock(return_value=[])
+    handler._query_service = query_service
+
+    return handler, status_service
+
+
+class TestSyncAndListReturnRequests:
+    def test_terminal_requests_skip_sync(self):
+        reqs = [_make_return_request("ret-1", terminal=True)]
+        handler, status_service = _build_handler(reqs, [_make_dto("ret-1")])
+        result = asyncio.run(handler.execute_query(SyncAndListReturnRequestsQuery()))
+        assert result.total_count == 1
+        status_service.update_request_status.assert_not_awaited()
+
+    def test_non_terminal_request_synced_and_status_updated(self):
+        reqs = [_make_return_request("ret-1", terminal=False)]
+        handler, status_service = _build_handler(reqs, [_make_dto("ret-1")])
+        status_service.determine_status_from_machines.return_value = (
+            "completed",
+            "done",
+        )
+        result = asyncio.run(handler.execute_query(SyncAndListReturnRequestsQuery()))
+        assert result.total_count == 1
+        status_service.update_request_status.assert_awaited_once()
+
+    def test_sync_failure_is_swallowed(self):
+        reqs = [_make_return_request("ret-1", terminal=False)]
+        handler, _ = _build_handler(
+            reqs,
+            [_make_dto("ret-1")],
+            sync_side_effect=RuntimeError("provider down"),
+        )
+        # Must not raise; stored state returned.
+        result = asyncio.run(handler.execute_query(SyncAndListReturnRequestsQuery()))
+        assert result.total_count == 1
+
+    def test_filter_by_provider_name(self):
+        reqs = [
+            _make_return_request("ret-1", terminal=True),
+            _make_return_request("ret-2", terminal=True),
+        ]
+        dtos = [
+            _make_dto("ret-1", provider_name="aws"),
+            _make_dto("ret-2", provider_name="gcp"),
+        ]
+        handler, _ = _build_handler(reqs, dtos)
+        result = asyncio.run(
+            handler.execute_query(SyncAndListReturnRequestsQuery(provider_name="aws"))
+        )
+        assert result.total_count == 1
+        assert result.items[0].request_id == "ret-1"
+
+    def test_filter_by_provider_type(self):
+        reqs = [
+            _make_return_request("ret-1", terminal=True),
+            _make_return_request("ret-2", terminal=True),
+        ]
+        dtos = [
+            _make_dto("ret-1", provider_type="aws"),
+            _make_dto("ret-2", provider_type="k8s"),
+        ]
+        handler, _ = _build_handler(reqs, dtos)
+        result = asyncio.run(
+            handler.execute_query(SyncAndListReturnRequestsQuery(provider_type="k8s"))
+        )
+        assert result.total_count == 1
+        assert result.items[0].request_id == "ret-2"
+
+    def test_free_text_search(self):
+        reqs = [
+            _make_return_request("ret-1", terminal=True),
+            _make_return_request("ret-2", terminal=True),
+        ]
+        dtos = [
+            _make_dto("ret-1", template_id="web"),
+            _make_dto("ret-2", template_id="db"),
+        ]
+        handler, _ = _build_handler(reqs, dtos)
+        result = asyncio.run(handler.execute_query(SyncAndListReturnRequestsQuery(q="web")))
+        assert result.total_count == 1
+        assert result.items[0].request_id == "ret-1"
+
+    def test_sort_descending(self):
+        reqs = [
+            _make_return_request("ret-1", terminal=True),
+            _make_return_request("ret-2", terminal=True),
+        ]
+        dtos = [
+            _make_dto("ret-1", template_id="aaa"),
+            _make_dto("ret-2", template_id="zzz"),
+        ]
+        handler, _ = _build_handler(reqs, dtos)
+        result = asyncio.run(
+            handler.execute_query(SyncAndListReturnRequestsQuery(sort="-template_id"))
+        )
+        assert [i.request_id for i in result.items] == ["ret-2", "ret-1"]
+
+    def test_offset_and_limit(self):
+        reqs = [_make_return_request(f"ret-{i}", terminal=True) for i in range(4)]
+        dtos = [_make_dto(f"ret-{i}", template_id=f"t{i}") for i in range(4)]
+        handler, _ = _build_handler(reqs, dtos)
+        result = asyncio.run(
+            handler.execute_query(
+                SyncAndListReturnRequestsQuery(sort="+template_id", offset=1, limit=2)
+            )
+        )
+        assert result.total_count == 4
+        assert [i.request_id for i in result.items] == ["ret-1", "ret-2"]
+
+    def test_machine_names_filter(self):
+        reqs = [
+            _make_return_request("ret-1", terminal=True),
+            _make_return_request("ret-2", terminal=True),
+        ]
+
+        class _DTOWithMachines:
+            def __init__(self, request_id, machine_name):
+                self.request_id = request_id
+                self.provider_name = "aws"
+                self.provider_type = "aws"
+                self._machine_name = machine_name
+
+            def model_dump(self):
+                return {"machines": [{"name": self._machine_name}]}
+
+        dtos = [
+            _DTOWithMachines("ret-1", "keep-me"),
+            _DTOWithMachines("ret-2", "drop-me"),
+        ]
+        handler, _ = _build_handler(reqs, dtos)
+        result = asyncio.run(
+            handler.execute_query(SyncAndListReturnRequestsQuery(machine_names=["keep-me"]))
+        )
+        assert result.total_count == 1
+        assert result.items[0].request_id == "ret-1"

--- a/tests/unit/application/services/orchestration/test_get_request_status_orchestrator.py
+++ b/tests/unit/application/services/orchestration/test_get_request_status_orchestrator.py
@@ -287,3 +287,77 @@ class TestGetRequestStatusOrchestrator:
         assert len(result.requests) == 2
         assert result.requests[0]["request_id"] == "req-p1"
         assert result.requests[1]["request_id"] == "req-p2"
+
+
+@pytest.mark.unit
+@pytest.mark.application
+class TestGetRequestStatusOrchestratorWait:
+    """Polling behaviour when ``wait=True``."""
+
+    @pytest.mark.asyncio
+    async def test_wait_false_does_not_poll(self, orchestrator, mock_query_bus):
+        r = MagicMock(spec=["model_dump"])
+        r.model_dump.return_value = {"request_id": "req-1", "status": "pending"}
+        mock_query_bus.execute.return_value = r
+        input = GetRequestStatusInput(request_ids=["req-1"], wait=False)
+        await orchestrator.execute(input)
+        assert mock_query_bus.execute.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_wait_returns_immediately_when_terminal(self, orchestrator, mock_query_bus):
+        r = MagicMock(spec=["model_dump"])
+        r.model_dump.return_value = {"request_id": "req-1", "status": "complete"}
+        mock_query_bus.execute.return_value = r
+        input = GetRequestStatusInput(request_ids=["req-1"], wait=True, timeout_seconds=300)
+        result = await orchestrator.execute(input)
+        # Only the initial fetch — already terminal, no extra polls.
+        assert mock_query_bus.execute.call_count == 1
+        assert result.requests[0]["status"] == "complete"
+
+    @pytest.mark.asyncio
+    async def test_wait_polls_until_terminal(self, orchestrator, mock_query_bus, monkeypatch):
+        pending = MagicMock(spec=["model_dump"])
+        pending.model_dump.return_value = {"request_id": "req-1", "status": "pending"}
+        done = MagicMock(spec=["model_dump"])
+        done.model_dump.return_value = {"request_id": "req-1", "status": "complete"}
+        mock_query_bus.execute.side_effect = [pending, pending, done]
+
+        async def _no_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr(
+            "orb.application.services.orchestration.get_request_status.asyncio.sleep", _no_sleep
+        )
+        input = GetRequestStatusInput(request_ids=["req-1"], wait=True, timeout_seconds=300)
+        result = await orchestrator.execute(input)
+        assert mock_query_bus.execute.call_count == 3
+        assert result.requests[0]["status"] == "complete"
+
+    @pytest.mark.asyncio
+    async def test_wait_stops_at_timeout_with_last_snapshot(
+        self, orchestrator, mock_query_bus, monkeypatch
+    ):
+        pending = MagicMock(spec=["model_dump"])
+        pending.model_dump.return_value = {"request_id": "req-1", "status": "pending"}
+        mock_query_bus.execute.return_value = pending
+
+        async def _no_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr(
+            "orb.application.services.orchestration.get_request_status.asyncio.sleep", _no_sleep
+        )
+        # timeout_seconds=2 with a 2s interval → one initial fetch + one poll, then stop.
+        input = GetRequestStatusInput(request_ids=["req-1"], wait=True, timeout_seconds=2)
+        result = await orchestrator.execute(input)
+        assert result.requests[0]["status"] == "pending"
+        assert mock_query_bus.execute.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_wait_treats_error_entry_as_terminal(self, orchestrator, mock_query_bus):
+        mock_query_bus.execute.side_effect = Exception("boom")
+        input = GetRequestStatusInput(request_ids=["req-1"], wait=True, timeout_seconds=300)
+        result = await orchestrator.execute(input)
+        # An errored entry short-circuits polling so the caller is not stuck.
+        assert mock_query_bus.execute.call_count == 1
+        assert result.requests[0]["error"] == "boom"

--- a/tests/unit/application/test_application_comprehensive.py
+++ b/tests/unit/application/test_application_comprehensive.py
@@ -414,8 +414,8 @@ class TestCQRSMigrationValidation:
             assert GetTemplateHandler is not None
         except ImportError:
             # Query handlers might be in different location
-            from orb.application.template.query_handlers import (
-                GetTemplateHandler,  # type: ignore[import]
+            from orb.application.template.query_handlers import (  # type: ignore[import]
+                GetTemplateHandler,
             )
 
             assert GetTemplateHandler is not None

--- a/tests/unit/architecture/test_cqrs_compliance.py
+++ b/tests/unit/architecture/test_cqrs_compliance.py
@@ -55,11 +55,11 @@ class TestCQRSCompliance:
         """Test that command handlers implement correct interface."""
 
         # Mock a command handler
-        class MockCommandHandler(ApplicationCommandHandler):
+        class FakeCommandHandler(ApplicationCommandHandler):
             def handle(self, command):
                 return {"status": "handled"}
 
-        handler = MockCommandHandler()
+        handler = FakeCommandHandler()
 
         # Should have handle method
         assert hasattr(handler, "handle")

--- a/tests/unit/cli/test_args_contract.py
+++ b/tests/unit/cli/test_args_contract.py
@@ -377,3 +377,56 @@ async def test_request_return_machines_uses_machine_ids_flag():
 
     call_input = orch.execute.call_args[0][0]
     assert "i-flag3" in call_input.machine_ids
+
+
+# ---------------------------------------------------------------------------
+# Help text standardization — every subcommand parser must document itself
+# ---------------------------------------------------------------------------
+
+
+def _collect_subparsers() -> list[tuple[str, str | None, argparse.ArgumentParser]]:
+    """Build the real parser and collect every sub-parser with its parent-side help.
+
+    Each entry is ``(command_name, help_text, sub_parser)`` where ``help_text`` is
+    the string shown in the parent's action list (stored on the pseudo-action) and
+    ``sub_parser.description`` is the long-form description shown on ``--help``.
+    """
+    from orb.cli.args import build_parser
+
+    parser, _ = build_parser()
+    collected: list[tuple[str, str | None, argparse.ArgumentParser]] = []
+
+    def walk(p: argparse.ArgumentParser) -> None:
+        for action in p._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                help_by_name = {
+                    ca.dest: ca.help
+                    for ca in action._choices_actions  # type: ignore[attr-defined]
+                }
+                for name, sub in action.choices.items():
+                    collected.append((name, help_by_name.get(name), sub))
+                    walk(sub)
+
+    walk(parser)
+    return collected
+
+
+def test_every_subparser_has_help_and_description():
+    subparsers = _collect_subparsers()
+    assert subparsers, "expected at least one sub-parser"
+    missing_help = [name for name, help_text, _ in subparsers if not help_text]
+    missing_description = [name for name, _, sub in subparsers if not sub.description]
+    assert not missing_description, f"sub-parsers missing description=: {missing_description}"
+    assert not missing_help, f"sub-parsers missing help text: {missing_help}"
+
+
+def test_every_argument_has_help():
+    subparsers = _collect_subparsers()
+    offenders: list[str] = []
+    for name, _help_text, sub in subparsers:
+        for action in sub._actions:
+            if isinstance(action, (argparse._HelpAction, argparse._SubParsersAction)):
+                continue
+            if action.help is None or action.help == "":
+                offenders.append(f"{name}:{action.dest}")
+    assert not offenders, f"add_argument() calls missing help=: {offenders}"

--- a/tests/unit/cli/test_factory_system.py
+++ b/tests/unit/cli/test_factory_system.py
@@ -124,6 +124,16 @@ class TestCreateSetConfigurationCommand:
         assert cmd.key == "log.level"
         assert cmd.value == "DEBUG"
 
+    def test_persist_defaults_true(self, factory):
+        cmd = factory.create_set_configuration_command(key="log.level", value="DEBUG")
+        assert cmd.persist is True
+
+    def test_persist_can_be_disabled(self, factory):
+        cmd = factory.create_set_configuration_command(
+            key="log.level", value="DEBUG", persist=False
+        )
+        assert cmd.persist is False
+
 
 @pytest.mark.unit
 class TestCreateGetSystemConfigQuery:

--- a/tests/unit/cli/test_response_formatter.py
+++ b/tests/unit/cli/test_response_formatter.py
@@ -7,14 +7,14 @@ from orb.application.dto.base import BaseDTO, BaseResponse
 from orb.cli.response_formatter import CLIResponseFormatter, create_cli_formatter
 
 
-class MockDTO(BaseDTO):
+class FakeDTO(BaseDTO):
     """Mock DTO for testing."""
 
     name: str
     value: int
 
 
-class MockArgs:
+class FakeArgs:
     """Mock CLI args for testing."""
 
     def __init__(self, format_type="json", resource=None, action=None):
@@ -31,7 +31,7 @@ class TestCLIResponseFormatter(unittest.TestCase):
         formatter = CLIResponseFormatter()
         data = {"message": "success", "count": 5}
 
-        result = formatter.format_response(data, MockArgs("json"))
+        result = formatter.format_response(data, FakeArgs("json"))
 
         self.assertIn('"message": "success"', result)
         self.assertIn('"count": 5', result)
@@ -41,7 +41,7 @@ class TestCLIResponseFormatter(unittest.TestCase):
         formatter = CLIResponseFormatter()
         response = BaseResponse(success=True, message="Operation completed")
 
-        result = formatter.format_response(response, MockArgs("json"))
+        result = formatter.format_response(response, FakeArgs("json"))
 
         self.assertEqual(result, '"Operation completed"')
 
@@ -52,7 +52,7 @@ class TestCLIResponseFormatter(unittest.TestCase):
             success=False, message="Operation failed", error_code="VALIDATION_ERROR"
         )
 
-        result = formatter.format_response(response, MockArgs("json"))
+        result = formatter.format_response(response, FakeArgs("json"))
 
         self.assertIsInstance(result, tuple)
         formatted_output, exit_code = result
@@ -63,9 +63,9 @@ class TestCLIResponseFormatter(unittest.TestCase):
     def test_format_dto(self):
         """Test formatting DTO object."""
         formatter = CLIResponseFormatter()
-        dto = MockDTO(name="test", value=42)
+        dto = FakeDTO(name="test", value=42)
 
-        result = formatter.format_response(dto, MockArgs("json"))
+        result = formatter.format_response(dto, FakeArgs("json"))
 
         self.assertIn('"name": "test"', result)
         self.assertIn('"value": 42', result)
@@ -77,7 +77,7 @@ class TestCLIResponseFormatter(unittest.TestCase):
         data = {"template_id": "test", "instance_type": "t3.micro"}
 
         result = formatter.format_response(
-            data, MockArgs("json", resource="templates", action="show")
+            data, FakeArgs("json", resource="templates", action="show")
         )
 
         self.assertIn('"template_id": "test"', result)
@@ -92,7 +92,7 @@ class TestCLIResponseFormatter(unittest.TestCase):
             "error_code": "INTERNAL_ERROR",
         }
 
-        result = formatter.format_response(error_data, MockArgs("json"))
+        result = formatter.format_response(error_data, FakeArgs("json"))
 
         self.assertIsInstance(result, tuple)
         formatted_output, exit_code = result
@@ -104,7 +104,7 @@ class TestCLIResponseFormatter(unittest.TestCase):
         formatter = CLIResponseFormatter()
         data = {"status": "success", "message": "Completed", "exit_code": 0}
 
-        result = formatter.format_response(data, MockArgs("json"))
+        result = formatter.format_response(data, FakeArgs("json"))
 
         self.assertIsInstance(result, tuple)
         formatted_output, exit_code = result
@@ -121,7 +121,7 @@ class TestCLIResponseFormatter(unittest.TestCase):
             ]
         }
 
-        result = formatter.format_response(data, MockArgs("table"))
+        result = formatter.format_response(data, FakeArgs("table"))
 
         self.assertIn("t1", result)
         self.assertIn("t3.micro", result)
@@ -166,7 +166,7 @@ class TestCLIResponseFormatter(unittest.TestCase):
             def to_dict(self):
                 raise RuntimeError("Formatting failed")
 
-        result = formatter.format_response(BadObject(), MockArgs("json"))
+        result = formatter.format_response(BadObject(), FakeArgs("json"))
 
         self.assertIsInstance(result, tuple)
         formatted_output, exit_code = result

--- a/tests/unit/config/test_configuration_manager_coverage.py
+++ b/tests/unit/config/test_configuration_manager_coverage.py
@@ -450,8 +450,121 @@ class TestSave:
         mgr = ConfigurationManager(config_dict={})
         mgr._raw_config = {"x": 1}
 
-        with pytest.raises(ConfigurationError, match="Failed to save"):
-            mgr.save("/nonexistent_directory_abc/output.json")
+        # A path under a location the process cannot create/write must surface
+        # as a ConfigurationError rather than a raw OSError.
+        with patch("os.replace", side_effect=OSError("boom")):
+            with pytest.raises(ConfigurationError, match="Failed to save"):
+                mgr.save("/nonexistent_directory_abc/output.json")
+
+    def test_save_creates_parent_directories(self, tmp_path):
+        from orb.config.managers.configuration_manager import ConfigurationManager
+
+        raw = {"key": "value"}
+        mgr = ConfigurationManager(config_dict=raw)
+        mgr._raw_config = raw
+
+        out = tmp_path / "nested" / "deeper" / "output.json"
+        mgr.save(str(out))
+
+        assert json.loads(out.read_text()) == raw
+
+    def test_save_is_atomic_no_temp_files_left_on_success(self, tmp_path):
+        from orb.config.managers.configuration_manager import ConfigurationManager
+
+        raw = {"key": "value"}
+        mgr = ConfigurationManager(config_dict=raw)
+        mgr._raw_config = raw
+
+        out = tmp_path / "output.json"
+        mgr.save(str(out))
+
+        # Only the target file should exist — no orphaned .tmp scratch files.
+        remaining = list(tmp_path.iterdir())
+        assert remaining == [out]
+
+    def test_save_leaves_no_temp_file_and_preserves_original_on_failure(self, tmp_path):
+        from orb.config.managers.configuration_manager import ConfigurationManager
+        from orb.domain.base.exceptions import ConfigurationError
+
+        out = tmp_path / "output.json"
+        out.write_text(json.dumps({"original": True}))
+
+        mgr = ConfigurationManager(config_dict={})
+        mgr._raw_config = {"new": True}
+
+        # Fail the atomic rename; the original file must stay intact and no
+        # temp scratch file should be left behind.
+        with patch("os.replace", side_effect=OSError("rename failed")):
+            with pytest.raises(ConfigurationError, match="Failed to save"):
+                mgr.save(str(out))
+
+        assert json.loads(out.read_text()) == {"original": True}
+        assert list(tmp_path.iterdir()) == [out]
+
+
+# ---------------------------------------------------------------------------
+# save() persists the user's OWN config, not the merged/expanded runtime config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSavePersistsOnlyUserConfig:
+    """A 'config set' persist must write back the user's original file content
+    with the one edit applied — never the loader-merged, env-expanded runtime
+    config. Regression guard for the persist path baking in package/strategy
+    defaults and replacing ``${VAR}`` placeholders with their plaintext values.
+    """
+
+    def test_set_then_save_preserves_placeholders_and_stays_minimal(self, tmp_path, monkeypatch):
+        from orb.config.managers.configuration_manager import ConfigurationManager
+
+        # A minimal, hand-authored user config with an env-var placeholder for a
+        # secret. The env var is set so the loader WOULD expand it at runtime.
+        monkeypatch.setenv("DB_PASSWORD", "super-secret-plaintext")
+        user_config = {
+            "storage": {"sql_strategy": {"password": "${DB_PASSWORD}"}},
+        }
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(user_config))
+        original_text = config_path.read_text()
+
+        # Real load path — no mocking of the loader.
+        mgr = ConfigurationManager(config_file=str(config_path))
+        mgr.set("environment", "staging")
+        mgr.save(str(config_path))
+
+        on_disk = json.loads(config_path.read_text())
+
+        # (1) The ${VAR} placeholder must survive verbatim — the plaintext secret
+        # must never be written to disk.
+        assert on_disk["storage"]["sql_strategy"]["password"] == "${DB_PASSWORD}"
+        assert "super-secret-plaintext" not in config_path.read_text()
+
+        # (2) The file must not have gained package/strategy default keys — it
+        # stays essentially as minimal as the user authored it (their one key
+        # plus the single new key).
+        assert set(on_disk.keys()) == {"storage", "environment"}
+
+        # (3) The new set key was applied and persisted.
+        assert on_disk["environment"] == "staging"
+
+        # Sanity: without the fix the file would balloon far past the original.
+        assert len(config_path.read_text()) < 2 * len(original_text)
+
+    def test_save_from_in_memory_dict_uses_original_not_merged(self, tmp_path):
+        from orb.config.managers.configuration_manager import ConfigurationManager
+
+        user_config = {"request": {"default_timeout": 111}}
+        mgr = ConfigurationManager(config_dict=user_config)
+        mgr.set("request.default_timeout", 222)
+
+        out = tmp_path / "config.json"
+        mgr.save(str(out))
+
+        on_disk = json.loads(out.read_text())
+        # Only the user's own section is written, with the edit applied — no
+        # merged defaults (e.g. no top-level "version", "provider", "logging").
+        assert on_disk == {"request": {"default_timeout": 222}}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/domain/test_base_entities.py
+++ b/tests/unit/domain/test_base_entities.py
@@ -16,7 +16,7 @@ from orb.domain.base.value_objects import (
 )
 
 
-class MockEntity(Entity):
+class FakeEntity(Entity):
     """Test entity for testing base Entity functionality."""
 
     name: str
@@ -29,7 +29,7 @@ class TestBaseEntity:
 
     def test_entity_creation(self):
         """Test basic entity creation."""
-        entity = MockEntity(id="test-1", name="Test Entity", value=42)
+        entity = FakeEntity(id="test-1", name="Test Entity", value=42)
 
         assert entity.id == "test-1"
         assert entity.name == "Test Entity"
@@ -39,9 +39,9 @@ class TestBaseEntity:
 
     def test_entity_equality(self):
         """Test entity equality based on ID and type."""
-        entity1 = MockEntity(id="test-1", name="Entity 1")
-        entity2 = MockEntity(id="test-1", name="Entity 2")  # Different name, same ID
-        entity3 = MockEntity(id="test-2", name="Entity 1")  # Same name, different ID
+        entity1 = FakeEntity(id="test-1", name="Entity 1")
+        entity2 = FakeEntity(id="test-1", name="Entity 2")  # Different name, same ID
+        entity3 = FakeEntity(id="test-2", name="Entity 1")  # Same name, different ID
 
         assert entity1 == entity2  # Same ID and type
         assert entity1 != entity3  # Different ID
@@ -53,16 +53,16 @@ class TestBaseEntity:
         class OtherEntity(Entity):
             name: str
 
-        entity1 = MockEntity(id="test-1", name="Test")
+        entity1 = FakeEntity(id="test-1", name="Test")
         entity2 = OtherEntity(id="test-1", name="Test")
 
         assert entity1 != entity2  # Different types
 
     def test_entity_hash(self):
         """Test entity hashing based on ID and type."""
-        entity1 = MockEntity(id="test-1", name="Entity 1")
-        entity2 = MockEntity(id="test-1", name="Entity 2")
-        entity3 = MockEntity(id="test-2", name="Entity 1")
+        entity1 = FakeEntity(id="test-1", name="Entity 1")
+        entity2 = FakeEntity(id="test-1", name="Entity 2")
+        entity3 = FakeEntity(id="test-2", name="Entity 1")
 
         assert hash(entity1) == hash(entity2)  # Same ID and type
         assert hash(entity1) != hash(entity3)  # Different ID
@@ -70,7 +70,7 @@ class TestBaseEntity:
     def test_entity_validation(self):
         """Test entity validation."""
         # Valid entity
-        entity = MockEntity(id="test-1", name="Valid Entity")
+        entity = FakeEntity(id="test-1", name="Valid Entity")
         assert entity.name == "Valid Entity"
 
         # Test validation on assignment
@@ -80,18 +80,18 @@ class TestBaseEntity:
     def test_entity_with_timestamps(self):
         """Test entity with timestamp fields."""
         now = datetime.now(timezone.utc)
-        entity = MockEntity(id="test-1", name="Timestamped Entity", created_at=now, updated_at=now)
+        entity = FakeEntity(id="test-1", name="Timestamped Entity", created_at=now, updated_at=now)
 
         assert entity.created_at == now
         assert entity.updated_at == now
 
     def test_entity_none_id(self):
         """Test entity with None ID."""
-        entity = MockEntity(name="No ID Entity")
+        entity = FakeEntity(name="No ID Entity")
         assert entity.id is None
 
         # Entities with None ID are considered equal since None == None
-        entity2 = MockEntity(name="Another No ID Entity")
+        entity2 = FakeEntity(name="Another No ID Entity")
         assert entity == entity2
 
 

--- a/tests/unit/infrastructure/test_infrastructure_comprehensive.py
+++ b/tests/unit/infrastructure/test_infrastructure_comprehensive.py
@@ -405,7 +405,9 @@ class TestLoggingComprehensive:
     def test_logger_singleton_exists(self):
         """Test that logger singleton exists."""
         try:
-            from orb.infrastructure.logging.logger_singleton import LoggerSingleton
+            from orb.infrastructure.logging.logger_singleton import (  # type: ignore[import]
+                LoggerSingleton,
+            )
 
             assert LoggerSingleton is not None
         except ImportError:
@@ -451,8 +453,8 @@ class TestTemplateInfrastructureComprehensive:
     def test_format_converter_exists(self):
         """Test that format converter exists."""
         try:
-            from orb.infrastructure.template.format_converter import (
-                FormatConverter,  # type: ignore[import]
+            from orb.infrastructure.template.format_converter import (  # type: ignore[import]
+                FormatConverter,
             )
 
             assert FormatConverter is not None

--- a/tests/unit/interface/test_request_command_handlers_new.py
+++ b/tests/unit/interface/test_request_command_handlers_new.py
@@ -150,6 +150,40 @@ class TestHandleGetRequestStatus:
         assert "r-1" in call_input.request_ids
         assert isinstance(result, InterfaceResponse)
 
+    @pytest.mark.asyncio
+    async def test_wait_and_timeout_forwarded_to_orchestrator(self):
+        from orb.application.ports.scheduler_port import SchedulerPort
+        from orb.application.services.orchestration.get_request_status import (
+            GetRequestStatusOrchestrator,
+        )
+
+        fmt = _make_formatter()
+        orch = AsyncMock(spec=GetRequestStatusOrchestrator)
+        orch.execute.return_value = GetRequestStatusOutput(requests=[{"request_id": "r-1"}])
+        scheduler = MagicMock(spec=SchedulerPort)
+
+        container = MagicMock()
+        container.get.side_effect = lambda t: {
+            GetRequestStatusOrchestrator: orch,
+            ResponseFormattingService: fmt,
+            SchedulerPort: scheduler,
+        }.get(t, MagicMock())
+
+        args = Namespace(
+            _container=container,
+            all=False,
+            request_ids=["r-1"],
+            flag_request_ids=None,
+            verbose=False,
+            wait=True,
+            timeout=120,
+        )
+        await handle_get_request_status(args)
+
+        call_input = orch.execute.call_args[0][0]
+        assert call_input.wait is True
+        assert call_input.timeout_seconds == 120
+
 
 @pytest.mark.unit
 class TestHandleRequestMachines:

--- a/tests/unit/providers/test_provider_interface.py
+++ b/tests/unit/providers/test_provider_interface.py
@@ -4,7 +4,7 @@ import pytest
 
 from orb.domain.machine.machine_identifiers import MachineId
 from orb.infrastructure.interfaces.provider import ProviderConfig
-from tests.fixtures.mock_provider import MockProvider, create_mock_provider
+from tests.fixtures.mock_provider import FakeProvider, create_mock_provider
 
 
 @pytest.mark.unit
@@ -14,7 +14,7 @@ class TestProviderPort:
     @pytest.mark.parametrize(
         "provider_type,provider_class",
         [
-            ("mock", MockProvider),
+            ("mock", FakeProvider),
         ],
     )
     def test_provider_interface_compliance(self, provider_type: str, provider_class):
@@ -42,7 +42,7 @@ class TestProviderPort:
         registry = {}
 
         # Register mock provider
-        registry["mock"] = MockProvider
+        registry["mock"] = FakeProvider
 
         assert "mock" in registry
 
@@ -50,7 +50,7 @@ class TestProviderPort:
         config = ProviderConfig(provider_type="mock")
         provider = registry["mock"]()
         provider.initialize(config)
-        assert isinstance(provider, MockProvider)
+        assert isinstance(provider, FakeProvider)
         assert provider.provider_type == "mock"
 
     def test_provider_configuration_validation(self):
@@ -136,7 +136,7 @@ class TestProviderPort:
         config = ProviderConfig(provider_type="mock")
         provider.initialize(config)
 
-        # MockProvider.validate_template requires both image_id and instance_type
+        # FakeProvider.validate_template requires both image_id and instance_type
         valid_template = {
             "image_id": "ami-12345678",
             "instance_type": "t2.micro",

--- a/tests/unit/providers/test_providers_comprehensive.py
+++ b/tests/unit/providers/test_providers_comprehensive.py
@@ -709,8 +709,8 @@ class TestAWSPersistenceComprehensive:
     def test_dynamodb_strategy_exists(self):
         """Test that DynamoDB strategy exists."""
         try:
-            from orb.infrastructure.storage.dynamodb.strategy import (
-                DynamoDBStorageStrategy,  # type: ignore[import]
+            from orb.infrastructure.storage.dynamodb.strategy import (  # type: ignore[import]
+                DynamoDBStorageStrategy,
             )
 
             assert DynamoDBStorageStrategy is not None

--- a/tests/unit/sdk/test_sdk_client.py
+++ b/tests/unit/sdk/test_sdk_client.py
@@ -312,6 +312,93 @@ class TestConvenienceMethods:
         assert result == {"request_id": "req-123", "status": "pending", "machine_ids": []}
 
     @pytest.mark.asyncio
+    async def test_request_machines_forwards_wait_kwargs(self):
+        from orb.application.services.orchestration.dtos import AcquireMachinesOutput
+        from orb.interface.response_formatting_service import ResponseFormattingService
+
+        sdk = _initialized_sdk()
+        mock_container = MagicMock()
+        sdk._container = mock_container
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.execute = AsyncMock(
+            return_value=AcquireMachinesOutput(request_id="req-1", status="complete")
+        )
+        mock_scheduler = MagicMock()
+        mock_scheduler.format_request_response.side_effect = lambda raw: raw
+
+        def _get(cls):
+            if cls is ResponseFormattingService:
+                return ResponseFormattingService(mock_scheduler)
+            return mock_orchestrator
+
+        mock_container.get.side_effect = _get
+        mock_container.get_optional.return_value = None
+
+        await sdk.request_machines("tmpl-1", 3, wait=True, timeout_seconds=120)
+
+        dto = mock_orchestrator.execute.call_args[0][0]
+        assert dto.wait is True
+        assert dto.timeout_seconds == 120
+
+    @pytest.mark.asyncio
+    async def test_return_machines_forwards_wait_kwargs(self):
+        from orb.application.services.orchestration.dtos import ReturnMachinesOutput
+        from orb.interface.response_formatting_service import ResponseFormattingService
+
+        sdk = _initialized_sdk()
+        mock_container = MagicMock()
+        sdk._container = mock_container
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.execute = AsyncMock(
+            return_value=ReturnMachinesOutput(request_id="ret-1", status="complete")
+        )
+        mock_scheduler = MagicMock()
+        mock_scheduler.format_request_response.side_effect = lambda raw: raw
+
+        def _get(cls):
+            if cls is ResponseFormattingService:
+                return ResponseFormattingService(mock_scheduler)
+            return mock_orchestrator
+
+        mock_container.get.side_effect = _get
+        mock_container.get_optional.return_value = None
+
+        await sdk.return_machines(["m-1"], wait=True, timeout_seconds=90)
+
+        dto = mock_orchestrator.execute.call_args[0][0]
+        assert dto.wait is True
+        assert dto.timeout_seconds == 90
+
+    @pytest.mark.asyncio
+    async def test_get_request_status_forwards_wait_kwargs(self):
+        from orb.application.services.orchestration.dtos import GetRequestStatusOutput
+        from orb.interface.response_formatting_service import ResponseFormattingService
+
+        sdk = _initialized_sdk()
+        mock_container = MagicMock()
+        sdk._container = mock_container
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.execute = AsyncMock(
+            return_value=GetRequestStatusOutput(requests=[{"request_id": "req-1"}])
+        )
+        mock_scheduler = MagicMock()
+        mock_scheduler.format_request_status_response.side_effect = lambda reqs: {"requests": reqs}
+
+        def _get(cls):
+            if cls is ResponseFormattingService:
+                return ResponseFormattingService(mock_scheduler)
+            return mock_orchestrator
+
+        mock_container.get.side_effect = _get
+        mock_container.get_optional.return_value = None
+
+        await sdk.get_request_status(request_ids=["req-1"], wait=True, timeout_seconds=60)
+
+        dto = mock_orchestrator.execute.call_args[0][0]
+        assert dto.wait is True
+        assert dto.timeout_seconds == 60
+
+    @pytest.mark.asyncio
     async def test_show_template_raises_when_not_initialized(self):
         sdk = _make_sdk()
         with pytest.raises(SDKError, match="not initialized"):

--- a/tests/unit/sdk/test_sdk_constructor_overrides.py
+++ b/tests/unit/sdk/test_sdk_constructor_overrides.py
@@ -113,3 +113,73 @@ class TestORBClientSchedulerOverride:
 
         mock_cm.override_scheduler_strategy.assert_called_once_with("hostfactory")
         mock_container.register_instance.assert_called_once_with(mock_cm_cls, mock_cm)
+
+
+# ---------------------------------------------------------------------------
+# SDKConfig.dry_run
+# ---------------------------------------------------------------------------
+
+
+class TestSDKConfigDryRun:
+    def test_dry_run_default_is_false(self):
+        assert SDKConfig.from_dict({}).dry_run is False
+
+    def test_dry_run_parsed_from_dict(self):
+        config = SDKConfig.from_dict({"dry_run": True})
+        assert config.dry_run is True
+
+    def test_dry_run_not_in_custom_config(self):
+        config = SDKConfig.from_dict({"dry_run": True})
+        assert "dry_run" not in config.custom_config
+
+    def test_dry_run_round_trips_through_to_dict(self):
+        assert SDKConfig(dry_run=True).to_dict()["dry_run"] is True
+
+    def test_dry_run_from_env(self, monkeypatch):
+        monkeypatch.setenv("ORB_DRY_RUN", "true")
+        assert SDKConfig.from_env().dry_run is True
+
+    def test_dry_run_from_env_default_off(self, monkeypatch):
+        monkeypatch.delenv("ORB_DRY_RUN", raising=False)
+        assert SDKConfig.from_env().dry_run is False
+
+
+# ---------------------------------------------------------------------------
+# ORBClient.initialize() — dry_run override
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestORBClientDryRunOverride:
+    async def _init_client(self, **client_kwargs):
+        mock_app, mock_container, _, mock_cm = _make_initialize_mocks()
+
+        with (
+            patch("orb.sdk.client.create_container", return_value=mock_container),
+            patch("orb.sdk.client.Application", return_value=mock_app),
+            patch("orb.sdk.client.SDKMethodDiscovery") as mock_discovery_cls,
+            patch("orb.sdk.client.ConfigurationManager", return_value=mock_cm),
+        ):
+            mock_discovery = MagicMock()
+            mock_discovery.discover_cqrs_methods = AsyncMock(return_value={})
+            mock_discovery.list_available_methods = MagicMock(return_value=[])
+            mock_discovery_cls.return_value = mock_discovery
+
+            sdk = ORBClient(**client_kwargs)
+            await sdk.initialize()
+
+        return sdk, mock_app
+
+    async def test_dry_run_kwarg_forwarded_to_app_initialize(self):
+        sdk, mock_app = await self._init_client(dry_run=True)
+        assert sdk._config.dry_run is True
+        mock_app.initialize.assert_awaited_once_with(dry_run=True)
+
+    async def test_dry_run_from_config_dict_forwarded(self):
+        _, mock_app = await self._init_client(config={"dry_run": True})
+        mock_app.initialize.assert_awaited_once_with(dry_run=True)
+
+    async def test_no_dry_run_defaults_to_false(self):
+        sdk, mock_app = await self._init_client()
+        assert sdk._config.dry_run is False
+        mock_app.initialize.assert_awaited_once_with(dry_run=False)

--- a/tests/unit/test_asg_stack_deleted.py
+++ b/tests/unit/test_asg_stack_deleted.py
@@ -1,30 +1,26 @@
 """Verify the dead ASG query stack has been fully removed."""
 
+import importlib
+
 import pytest
 
 
 def test_asg_query_port_not_importable():
     """ASGQueryPort should not exist in domain ports."""
     with pytest.raises(ImportError):
-        from orb.domain.base.ports.asg_query_port import (
-            ASGQueryPort,  # noqa: F401  # type: ignore[import]
-        )
+        importlib.import_module("orb.domain.base.ports.asg_query_port")
 
 
 def test_asg_query_adapter_not_importable():
     """ASGQueryAdapter should not exist in infrastructure adapters."""
     with pytest.raises(ImportError):
-        from orb.infrastructure.adapters.asg_query_adapter import (
-            ASGQueryAdapter,  # noqa: F401  # type: ignore[import]
-        )
+        importlib.import_module("orb.infrastructure.adapters.asg_query_adapter")
 
 
 def test_asg_metadata_service_not_importable():
     """ASGMetadataService should not exist in application services."""
     with pytest.raises(ImportError):
-        from orb.application.services.asg_metadata_service import (
-            ASGMetadataService,  # noqa: F401  # type: ignore[import]
-        )
+        importlib.import_module("orb.application.services.asg_metadata_service")
 
 
 def test_sync_request_handler_has_no_asg_query_port_param():

--- a/tests/unit/test_injectable_migration.py
+++ b/tests/unit/test_injectable_migration.py
@@ -13,7 +13,7 @@ from orb.domain.base.ports import ConfigurationPort, LoggingPort
 from orb.infrastructure.di.container import DIContainer
 
 
-class MockConfigurationPort(ConfigurationPort):
+class FakeConfigurationPort(ConfigurationPort):
     """Mock implementation of ConfigurationPort for testing."""
 
     def __init__(self):
@@ -189,7 +189,7 @@ class TestInjectableMigration(unittest.TestCase):
         self.container.register_factory(LoggingPort, lambda c: logger)
 
         # Register configuration
-        mock_config = MockConfigurationPort()
+        mock_config = FakeConfigurationPort()
         self.container.register_singleton(ConfigurationPort, lambda c: mock_config)
 
         # Register AWS config with valid authentication

--- a/tests/unit/test_install_dev_tools_security.py
+++ b/tests/unit/test_install_dev_tools_security.py
@@ -25,7 +25,7 @@ _DEV_TOOLS_PATH = str(Path(__file__).parents[2] / "dev-tools" / "setup")
 if _DEV_TOOLS_PATH not in sys.path:
     sys.path.insert(0, _DEV_TOOLS_PATH)
 
-from install_dev_tools import DevToolsInstaller  # noqa: E402
+from install_dev_tools import DevToolsInstaller  # type: ignore[import]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Description
Extends CLI/SDK/REST blocking mode, persists `orb config set` edits, adds real-time UI request updates, and broadens handler and AWS fleet test coverage.

- **`--wait` / `--poll` blocking mode** — extended across CLI, SDK, and REST via request-DTO fields, so callers can block until a request reaches a terminal state (with a bounded timeout).
- **SDK `dry_run` override** on `ORBClient`.
- **`orb config set` disk persistence** — persists the user's edit to their config file, writing back only the user's own content (env-var `${VAR}` placeholders preserved verbatim, package defaults never baked in).
- **CLI help text** standardized across commands (every sub-parser has a description, guarded by a contract test).
- **UI live updates** — request-list rows update in real time via the existing SSE endpoint.
- **Command/query handler coverage** — unit tests for every command and query handler module (happy-path, error, and port-interaction cases; only abstract ports mocked).
- **AWS fleet coverage** — real describe→format→count fulfilment assertions for ASG/EC2Fleet/SpotFleet (moto provisions real instances), contract-parity tests, and circuit-breaker retry-runtime coverage.
- **Test hygiene** — renamed hand-rolled `Mock*` test doubles to `Fake*`.

## Type of Change
- [x] New feature
- [x] Bug fix
- [x] Code cleanup or refactor

## How Has This Been Tested?
- [x] Unit tests added/updated
- The config-set persistence path has a regression test asserting env-var placeholders survive a round-trip and package defaults are never written.

## Reviewers
@finos/open-resource-broker-maintainers
