### PR TITLE
fix(health): split liveness/readiness and stop optional providers forcing 503

### DIFF
--- a/sdk/csharp/src/FINOS.OpenResourceBroker/OrbClient.cs
+++ b/sdk/csharp/src/FINOS.OpenResourceBroker/OrbClient.cs
@@ -326,8 +326,46 @@ public sealed class OrbClient : IAsyncDisposable
     }
 
     // ---------------------------------------------------------------------------
-    // System / Observability — 4 operations
+    // System / Observability — 6 operations
     // ---------------------------------------------------------------------------
+
+    /// <summary>livenessCheck — GET /livez
+    ///
+    /// The liveness probe returns 200 whenever the process is up and never gates
+    /// on any dependency or provider, so it is safe to poll as a container
+    /// liveness check.</summary>
+    public async Task<Dictionary<string, object?>> LivenessAsync(CancellationToken ct = default)
+        => await GetAsync<Dictionary<string, object?>>("/livez", ct: ct).ConfigureAwait(false);
+
+    /// <summary>readinessCheck — GET /readyz
+    ///
+    /// The readiness probe returns 200 unless a core dependency (storage/database)
+    /// is unhealthy, in which case it returns 503. A 503 carries a valid not-ready
+    /// body and is accepted as data rather than an error (mirroring HealthAsync),
+    /// so status-based retry is skipped and the not-ready status is returned
+    /// directly.</summary>
+    public async Task<Dictionary<string, object?>> ReadinessAsync(CancellationToken ct = default)
+    {
+        CheckHealth();
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/readyz");
+        req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        AddSchedulerHeader(req);
+        // 503 (not-ready) is a normal steady-state result we accept as valid data
+        // below; skip status-based retry so it returns immediately. Network-error
+        // retry is intentionally left intact.
+        req.Options.Set(RetryDelegatingHandler.SkipStatusRetryOption, true);
+        var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseContentRead, ct).ConfigureAwait(false);
+        if (resp.StatusCode != System.Net.HttpStatusCode.OK &&
+            resp.StatusCode != System.Net.HttpStatusCode.ServiceUnavailable)
+        {
+            var errBody = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            throw OrbApiException.ForStatus((int)resp.StatusCode,
+                ExtractErrorMessage(errBody) ?? resp.ReasonPhrase ?? "readiness check failed",
+                ExtractErrorCode(errBody), errBody, ExtractRequestId(resp));
+        }
+        var json = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        return JsonSerializer.Deserialize<Dictionary<string, object?>>(json, JsonOpts) ?? [];
+    }
 
     /// <summary>healthCheck — GET /health</summary>
     public async Task<Dictionary<string, object?>> HealthAsync(CancellationToken ct = default)

--- a/sdk/csharp/tests/unit/OperationCompletenessTests.cs
+++ b/sdk/csharp/tests/unit/OperationCompletenessTests.cs
@@ -62,11 +62,11 @@ public class OperationCompletenessTests
     }
 
     [Fact]
-    public void SpecDeclaresExactly46Operations()
+    public void SpecDeclaresExactly48Operations()
     {
         // Mirrors Go's operation-count sentinel: a spec that grows or shrinks
         // forces a deliberate update rather than silently under-covering.
-        Assert.Equal(46, SpecOperationIds().Count);
+        Assert.Equal(48, SpecOperationIds().Count);
     }
 
     [Fact]

--- a/sdk/go/orb/client_ops.go
+++ b/sdk/go/orb/client_ops.go
@@ -58,6 +58,66 @@ func (c *Client) Health(ctx context.Context) (*HealthResponse, error) {
 	return &out, nil
 }
 
+// LivenessResponse is returned by Liveness.
+type LivenessResponse struct {
+	Status string `json:"status"`
+}
+
+// Liveness checks the ORB server's liveness (operationId livenessCheck).
+//
+// The liveness probe (GET /livez) returns 200 whenever the process is up and
+// never gates on any dependency or provider, so it is safe to poll as a
+// container liveness check.
+func (c *Client) Liveness(ctx context.Context) (*LivenessResponse, error) {
+	var resp LivenessResponse
+	if err := c.get(ctx, "/livez", &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ReadinessResponse is returned by Readiness.
+type ReadinessResponse struct {
+	Status string `json:"status"`
+}
+
+// Readiness checks the ORB server's readiness (operationId readinessCheck).
+//
+// The readiness probe (GET /readyz) returns 200 unless a core dependency
+// (storage/database) is unhealthy, in which case it returns 503. A 503 is a
+// valid, expected result carrying a parsed readiness body rather than an
+// error — mirroring Health — so a readiness-poll loop observes the not-ready
+// status directly. Other non-2xx statuses are still surfaced as errors.
+func (c *Client) Readiness(ctx context.Context) (*ReadinessResponse, error) {
+	if err := c.checkHealth(); err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/readyz", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	// A 503 (not-ready) must be observed directly rather than retried away.
+	transport.DisableRetry(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	defer resp.Body.Close()
+
+	// 503 is a valid not-ready response, not an error.
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusServiceUnavailable {
+		return nil, parseAPIError(resp)
+	}
+
+	var out ReadinessResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // MetricsResponse holds raw Prometheus-style metric text.
 type MetricsResponse struct {
 	Body string

--- a/sdk/go/orb/conformance_test.go
+++ b/sdk/go/orb/conformance_test.go
@@ -95,13 +95,13 @@ func (r *recorder) record(method, path string) {
 
 // TestSpecConformance drives every client operation against a recording server
 // and asserts that (a) each issued request matches a spec operation (no wrong
-// verb / stale path), and (b) all 46 spec operations are exercised (no silent
+// verb / stale path), and (b) all 48 spec operations are exercised (no silent
 // under-coverage). This runs without a live orb, closing the static-conformance
 // gap independently of the integration leg.
 func TestSpecConformance(t *testing.T) {
 	ops := specOperations(t)
-	if len(ops) != 46 {
-		t.Fatalf("expected 46 spec operations, got %d (spec changed — update coverage)", len(ops))
+	if len(ops) != 48 {
+		t.Fatalf("expected 48 spec operations, got %d (spec changed — update coverage)", len(ops))
 	}
 
 	rec := &recorder{hits: make(map[string]bool)}
@@ -148,6 +148,8 @@ func TestSpecConformance(t *testing.T) {
 	// Exercise every client operation. Errors are ignored: the recording server
 	// is the assertion surface — we only care about the (method, path) issued.
 	_, _ = c.Health(ctx)
+	_, _ = c.Liveness(ctx)
+	_, _ = c.Readiness(ctx)
 	_, _ = c.Metrics(ctx)
 	_, _ = c.Info(ctx)
 	_, _ = c.GetDashboardSummary(ctx)

--- a/sdk/java/src/main/java/org/finos/openresourcebroker/sdk/client/OrbClient.java
+++ b/sdk/java/src/main/java/org/finos/openresourcebroker/sdk/client/OrbClient.java
@@ -98,8 +98,42 @@ public class OrbClient implements Closeable {
     }
 
     // ======================================================================
-    // System / Observability — 4 operations
+    // System / Observability — 6 operations
     // ======================================================================
+
+    /**
+     * livenessCheck — GET /livez
+     *
+     * <p>The liveness probe returns {@code 200} whenever the process is up and
+     * never gates on any dependency or provider, so it is safe to poll as a
+     * container liveness check.
+     */
+    public Map<String, Object> liveness() throws Exception {
+        return get("/livez", null, new TypeReference<>() {});
+    }
+
+    /**
+     * readinessCheck — GET /readyz
+     *
+     * <p>The readiness probe returns {@code 200} unless a core dependency
+     * (storage/database) is unhealthy, in which case it returns {@code 503}.
+     * A {@code 503} carries a valid not-ready body and is data, not an error
+     * (mirroring {@link #health()}), so this call never throws on {@code 503}
+     * and is never retry-looped.  Other {@code >= 400} statuses still throw.
+     */
+    public Map<String, Object> readiness() throws Exception {
+        checkHealth();
+        RawHttpClient.HttpResult result = http.getNoRetry("/readyz", null);
+        int status = result.statusCode();
+        // 503 is a valid not-ready response, not an error.
+        if (status >= 400 && status != 503) {
+            throwApiException(status, result.body(), result.headers());
+        }
+        if (result.body() == null || result.body().isBlank()) {
+            return null;
+        }
+        return mapper.readValue(result.body(), new TypeReference<>() {});
+    }
 
     /**
      * healthCheck — GET /health

--- a/sdk/java/src/test/java/org/finos/openresourcebroker/sdk/unit/OperationCompletenessTest.java
+++ b/sdk/java/src/test/java/org/finos/openresourcebroker/sdk/unit/OperationCompletenessTest.java
@@ -70,10 +70,10 @@ class OperationCompletenessTest {
     }
 
     @Test
-    void specDeclaresExactly46Operations() throws Exception {
+    void specDeclaresExactly48Operations() throws Exception {
         // Mirrors Go's operation-count sentinel: a spec that grows or shrinks
         // forces a deliberate update rather than silently under-covering.
-        assertEquals(46, specOperationIds().size(),
+        assertEquals(48, specOperationIds().size(),
                 "spec operation count changed — update coverage");
     }
 

--- a/sdk/kotlin/src/main/kotlin/org/finos/openresourcebroker/sdk/client/OrbClient.kt
+++ b/sdk/kotlin/src/main/kotlin/org/finos/openresourcebroker/sdk/client/OrbClient.kt
@@ -349,8 +349,42 @@ class OrbClient private constructor(
     }
 
     // ---------------------------------------------------------------------------
-    // System / Observability — 4 operations
+    // System / Observability — 6 operations
     // ---------------------------------------------------------------------------
+
+    /** livenessCheck — GET /livez
+     *
+     * The liveness probe returns 200 whenever the process is up and never gates
+     * on any dependency or provider, so it is safe to poll as a container
+     * liveness check.
+     */
+    suspend fun liveness(): Map<String, Any?> {
+        val resp = get("/livez")
+        return executeRaw(resp)
+    }
+
+    /** readinessCheck — GET /readyz
+     *
+     * The readiness probe returns 200 unless a core dependency (storage/database)
+     * is unhealthy, in which case it returns 503. The 503 carries a valid
+     * not-ready body rather than an error (mirroring [health]), so [httpNoRetry]
+     * is used and the not-ready status is returned to the caller directly.
+     */
+    suspend fun readiness(): Map<String, Any?> {
+        checkHealth()
+        val req = Request.Builder()
+            .url("$baseUrl/readyz")
+            .get()
+            .header("Accept", "application/json")
+            .also { rb -> schedulerHeaders().forEach { (k, v) -> rb.header(k, v) } }
+            .build()
+        // Use the no-retry client: 503 from /readyz is semantically valid (server
+        // is up but a core dependency is down) and must not cause a retry loop.
+        val resp = httpNoRetry.newCall(req).execute()
+        val body = resp.body?.string() ?: "{}"
+        resp.close()
+        return parseJson(body)
+    }
 
     /** healthCheck — GET /health
      *

--- a/sdk/kotlin/src/test/kotlin/org/finos/openresourcebroker/sdk/unit/OperationCompletenessTest.kt
+++ b/sdk/kotlin/src/test/kotlin/org/finos/openresourcebroker/sdk/unit/OperationCompletenessTest.kt
@@ -52,10 +52,10 @@ class OperationCompletenessTest {
     }
 
     @Test
-    fun specDeclaresExactly46Operations() {
+    fun specDeclaresExactly48Operations() {
         // Mirrors Go's operation-count sentinel: a spec that grows or shrinks
         // forces a deliberate update rather than silently under-covering.
-        assertEquals(46, specOperationIds().size, "spec operation count changed — update coverage")
+        assertEquals(48, specOperationIds().size, "spec operation count changed — update coverage")
     }
 
     @Test

--- a/sdk/spec/openapi.json
+++ b/sdk/spec/openapi.json
@@ -65,7 +65,7 @@
           "System"
         ],
         "summary": "Readiness Check",
-        "description": "Readiness probe.\n\nReturns 200 unless a CORE dependency (storage/database) is\nunhealthy, in which case it returns 503. Provider-connectivity\nchecks (aws, ec2, kubernetes_api) do NOT gate readiness, so an\nunreachable optional provider cannot take the service out of\nrotation.",
+        "description": "Readiness probe.\n\nReturns 503 when a CORE dependency is not fully healthy, otherwise\n200. Core dependencies are storage/database plus \u2014 in a\nsingle-provider deployment \u2014 the sole provider's connectivity: a\nbroken sole provider means the pod cannot serve provisioning\nrequests, so it must be taken out of rotation. In a multi-provider\ndeployment, provider connectivity is classified non-core, so a single\nunreachable optional provider does NOT gate readiness.\n\nBoth ``unhealthy`` and ``degraded`` core states map to 503: a\nconnectivity failure surfaces as ``degraded``, and for a sole\n(core) provider that still means not-ready.",
         "operationId": "readinessCheck",
         "responses": {
           "200": {

--- a/sdk/spec/openapi.json
+++ b/sdk/spec/openapi.json
@@ -37,6 +37,50 @@
         }
       }
     },
+    "/livez": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Liveness Check",
+        "description": "Liveness probe.\n\nReturns 200 whenever the process is up. Never gates on any\ndependency or provider \u2014 a liveness failure means the process\nshould be restarted, which is not the right response to an\nunreachable downstream dependency.",
+        "operationId": "livenessCheck",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Livenesscheck"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/readyz": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Readiness Check",
+        "description": "Readiness probe.\n\nReturns 200 unless a CORE dependency (storage/database) is\nunhealthy, in which case it returns 503. Provider-connectivity\nchecks (aws, ec2, kubernetes_api) do NOT gate readiness, so an\nunreachable optional provider cannot take the service out of\nrotation.",
+        "operationId": "readinessCheck",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Readinesscheck"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/metrics": {
       "get": {
         "tags": [

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -275,8 +275,42 @@ export class OrbClient {
   }
 
   // ---------------------------------------------------------------------------
-  // System / Observability — 4 operations
+  // System / Observability — 6 operations
   // ---------------------------------------------------------------------------
+
+  /**
+   * livenessCheck — GET /livez
+   *
+   * The liveness probe returns 200 whenever the process is up and never gates
+   * on any dependency or provider, so it is safe to poll as a container
+   * liveness check.
+   */
+  async liveness(): Promise<{ status: string }> {
+    return this.get<{ status: string }>("/livez");
+  }
+
+  /**
+   * readinessCheck — GET /readyz
+   *
+   * The readiness probe returns 200 unless a core dependency (storage/database)
+   * is unhealthy, in which case it returns 503. A 503 is a valid not-ready
+   * body rather than an error (mirroring health()), so a readiness-poll loop
+   * observes the not-ready status directly. Other non-2xx statuses still throw.
+   */
+  async readiness(): Promise<{ status: string }> {
+    this.checkHealth();
+    const resp = await this.http.get<{ status: string }>(
+      "/readyz",
+      disableRetry({
+        headers: { Accept: "application/json", ...this.schedulerHeaders() },
+      })
+    );
+    // 503 = not-ready but valid readiness body; do not treat as an error.
+    if (resp.status >= 400 && resp.status !== 503) {
+      throw parseApiError(this.makeAxiosError(resp));
+    }
+    return resp.data;
+  }
 
   /**
    * healthCheck — GET /health

--- a/sdk/typescript/tests/unit/completeness.test.ts
+++ b/sdk/typescript/tests/unit/completeness.test.ts
@@ -44,7 +44,7 @@ describe("SDK operation completeness vs OpenAPI spec", () => {
   it("declares exactly the operations the spec defines (guards against drift)", () => {
     // Mirrors Go's operation-count sentinel: if the spec grows or shrinks,
     // this forces a deliberate update rather than silently under-covering.
-    expect(operationIds.length).toBe(46);
+    expect(operationIds.length).toBe(48);
   });
 
   it("covers every spec operationId in the hand-written client", () => {

--- a/src/orb/api/middleware/audit_log_middleware.py
+++ b/src/orb/api/middleware/audit_log_middleware.py
@@ -25,7 +25,17 @@ class AuditLogMiddleware(BaseHTTPMiddleware):
     """
 
     SAFE_PATHS: frozenset[str] = frozenset(
-        {"/health", "/ping", "/info", "/metrics", "/orb/health", "/orb/info", "/orb/metrics"}
+        {
+            "/health",
+            "/livez",
+            "/readyz",
+            "/ping",
+            "/info",
+            "/metrics",
+            "/orb/health",
+            "/orb/info",
+            "/orb/metrics",
+        }
     )
     SAFE_VERBS: frozenset[str] = frozenset({"GET", "HEAD", "OPTIONS"})
 

--- a/src/orb/api/middleware/read_only_middleware.py
+++ b/src/orb/api/middleware/read_only_middleware.py
@@ -11,6 +11,8 @@ _SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
 _ALLOWED_PATHS = frozenset(
     {
         "/health",
+        "/livez",
+        "/readyz",
         "/ping",
         "/info",
         "/metrics",

--- a/src/orb/api/server.py
+++ b/src/orb/api/server.py
@@ -396,7 +396,8 @@ def create_fastapi_app(server_config: Any) -> Any:
             auth_port: Any = _LoopbackAdminAuthWrapper(auth_strategy)
 
             # Build the excluded-paths list for auth middleware.
-            # /health is always public (liveness probe, no sensitive detail).
+            # /health, /livez, /readyz are always public probe endpoints
+            # (no sensitive detail) so orchestrators can poll them unauthenticated.
             # /favicon.ico is static UI chrome, not sensitive.
             # /docs, /redoc, /openapi.json are excluded ONLY when
             # docs.require_auth=False — by default they are protected so that
@@ -404,7 +405,7 @@ def create_fastapi_app(server_config: Any) -> Any:
             _docs_require_auth: bool = getattr(
                 getattr(server_config, "docs", None), "require_auth", True
             )
-            _excluded: list[str] = ["/health", "/favicon.ico"]
+            _excluded: list[str] = ["/health", "/livez", "/readyz", "/favicon.ico"]
             if not _docs_require_auth:
                 _excluded.extend(["/docs", "/redoc", "/openapi.json"])
             else:
@@ -526,6 +527,36 @@ def create_fastapi_app(server_config: Any) -> Any:
             status = {"status": "unknown"}
 
         status = {"service": "open-resource-broker", "version": __version__, **status}
+        http_status = 503 if status.get("status") == "unhealthy" else 200
+        return JSONResponse(content=status, status_code=http_status)  # type: ignore[misc]
+
+    @app.get("/livez", tags=["System"], operation_id="livenessCheck")
+    async def liveness_check() -> Any:  # type: ignore[misc]
+        """Liveness probe.
+
+        Returns 200 whenever the process is up. Never gates on any
+        dependency or provider — a liveness failure means the process
+        should be restarted, which is not the right response to an
+        unreachable downstream dependency.
+        """
+        return JSONResponse(content={"status": "alive"}, status_code=200)  # type: ignore[misc]
+
+    @app.get("/readyz", tags=["System"], operation_id="readinessCheck")
+    async def readiness_check(health_port: Any = Depends(get_health_check_port)) -> Any:  # type: ignore[misc]
+        """Readiness probe.
+
+        Returns 200 unless a CORE dependency (storage/database) is
+        unhealthy, in which case it returns 503. Provider-connectivity
+        checks (aws, ec2, kubernetes_api) do NOT gate readiness, so an
+        unreachable optional provider cannot take the service out of
+        rotation.
+        """
+        try:
+            health_port.run_all_checks()
+            status = health_port.get_readiness()
+        except Exception:
+            status = {"status": "unknown"}
+
         http_status = 503 if status.get("status") == "unhealthy" else 200
         return JSONResponse(content=status, status_code=http_status)  # type: ignore[misc]
 

--- a/src/orb/api/server.py
+++ b/src/orb/api/server.py
@@ -545,11 +545,17 @@ def create_fastapi_app(server_config: Any) -> Any:
     async def readiness_check(health_port: Any = Depends(get_health_check_port)) -> Any:  # type: ignore[misc]
         """Readiness probe.
 
-        Returns 200 unless a CORE dependency (storage/database) is
-        unhealthy, in which case it returns 503. Provider-connectivity
-        checks (aws, ec2, kubernetes_api) do NOT gate readiness, so an
-        unreachable optional provider cannot take the service out of
-        rotation.
+        Returns 503 when a CORE dependency is not fully healthy, otherwise
+        200. Core dependencies are storage/database plus — in a
+        single-provider deployment — the sole provider's connectivity: a
+        broken sole provider means the pod cannot serve provisioning
+        requests, so it must be taken out of rotation. In a multi-provider
+        deployment, provider connectivity is classified non-core, so a single
+        unreachable optional provider does NOT gate readiness.
+
+        Both ``unhealthy`` and ``degraded`` core states map to 503: a
+        connectivity failure surfaces as ``degraded``, and for a sole
+        (core) provider that still means not-ready.
         """
         try:
             health_port.run_all_checks()
@@ -557,7 +563,7 @@ def create_fastapi_app(server_config: Any) -> Any:
         except Exception:
             status = {"status": "unknown"}
 
-        http_status = 503 if status.get("status") == "unhealthy" else 200
+        http_status = 503 if status.get("status") in ("unhealthy", "degraded") else 200
         return JSONResponse(content=status, status_code=http_status)  # type: ignore[misc]
 
     # Add metrics endpoint

--- a/src/orb/domain/base/ports/health_check_port.py
+++ b/src/orb/domain/base/ports/health_check_port.py
@@ -8,11 +8,22 @@ class HealthCheckPort(ABC):
     """Abstract port for health check monitoring."""
 
     @abstractmethod
-    def register_check(self, name: str, check_fn: Any, *, force: bool = False) -> None:
+    def register_check(
+        self, name: str, check_fn: Any, *, force: bool = False, kind: str = "system"
+    ) -> None:
         """Register a named health check function.
 
         ``force=True`` overwrites an existing registration. Without it,
         re-registering the same name is a no-op.
+
+        ``kind`` classifies the check for readiness gating:
+
+        * ``"core"``     — a core dependency (storage/database) whose failure
+          means the service cannot serve requests. Gates ``get_readiness``.
+        * ``"provider"`` — provider-API connectivity (aws, ec2, kubernetes_api).
+          Surfaced in the full status but does NOT gate readiness, so an
+          unreachable optional provider cannot take the service out of rotation.
+        * ``"system"``   — host-level signals (cpu/disk); the default.
         """
         pass
 
@@ -29,4 +40,13 @@ class HealthCheckPort(ABC):
     @abstractmethod
     def get_status(self) -> dict[str, Any]:
         """Get the current health status summary."""
+        pass
+
+    @abstractmethod
+    def get_readiness(self) -> dict[str, Any]:
+        """Get the readiness status derived from core-dependency checks only.
+
+        Provider-connectivity checks are excluded so an unreachable optional
+        provider does not make the service report as not-ready.
+        """
         pass

--- a/src/orb/monitoring/health.py
+++ b/src/orb/monitoring/health.py
@@ -395,7 +395,15 @@ def register_deserialize_skip_counter_check(
             dependencies=["database"],
         )
 
-    health_check.register_check("storage.deserialize", _check_deserialize_skip_counters, force=True)
+    # Deliberately kind="system" (the default), NOT "core": a non-zero skip
+    # counter means some rows returned incomplete (a data-quality signal), and
+    # the only "unhealthy" path is a transient failure to READ the counter — in
+    # neither case can the storage backend not serve reads (that capability is
+    # covered by the separate "core" ``database`` check). So this must not gate
+    # readiness / take the pod out of rotation.
+    health_check.register_check(
+        "storage.deserialize", _check_deserialize_skip_counters, force=True, kind="system"
+    )
 
 
 def register_storage_health_checks(

--- a/src/orb/monitoring/health.py
+++ b/src/orb/monitoring/health.py
@@ -65,6 +65,9 @@ class HealthCheck(HealthCheckPort):
         self._logger = logger
         self.config = config
         self.checks: dict[str, Callable[[], HealthStatus]] = {}
+        # Classification of each check for readiness gating. Keyed by check
+        # name; values are "core", "provider", or "system".
+        self.check_kinds: dict[str, str] = {}
         self.status_history: dict[str, list[HealthStatus]] = {}
         self._lock = threading.Lock()
 
@@ -94,18 +97,25 @@ class HealthCheck(HealthCheckPort):
         # Register default health checks
         self._register_default_checks()
 
-    def register_check(self, name: str, check_fn: Any, *, force: bool = False) -> None:
+    def register_check(
+        self, name: str, check_fn: Any, *, force: bool = False, kind: str = "system"
+    ) -> None:
         """Register a named health check function.
 
         First-write-wins by default. Pass ``force=True`` to overwrite an
         existing registration — used by the bootstrap to replace the
         placeholder ``database`` check with a storage-backed one once the
         active StoragePort is resolved.
+
+        ``kind`` classifies the check for readiness gating (``"core"``,
+        ``"provider"``, or ``"system"``). Only ``"core"`` checks gate
+        ``get_readiness``.
         """
         with self._lock:
             if name in self.checks and not force:
                 return
             self.checks[name] = check_fn
+            self.check_kinds[name] = kind
             self.status_history.setdefault(name, [])
 
     def run_check(self, name: str) -> dict[str, Any]:
@@ -128,6 +138,35 @@ class HealthCheck(HealthCheckPort):
             }
 
         # Derive overall status from latest per-check statuses
+        statuses = [v["status"] for v in checks_status.values() if v is not None]
+        if "unhealthy" in statuses:
+            overall = "unhealthy"
+        elif "degraded" in statuses:
+            overall = "degraded"
+        elif statuses:
+            overall = "healthy"
+        else:
+            overall = "unknown"
+
+        return {"status": overall, "checks": checks_status}
+
+    def get_readiness(self) -> dict[str, Any]:
+        """Get readiness derived from core-dependency checks only.
+
+        Only checks registered with ``kind="core"`` (storage/database) gate
+        readiness. Provider-connectivity checks (aws, ec2, kubernetes_api)
+        are excluded, so an unreachable optional provider does not make the
+        service report as not-ready. With no core-check history the status
+        derives to ``"unknown"``.
+        """
+        with self._lock:
+            core_names = {name for name, kind in self.check_kinds.items() if kind == "core"}
+            checks_status = {
+                name: (history[-1].to_dict() if history else None)
+                for name, history in self.status_history.items()
+                if name in core_names
+            }
+
         statuses = [v["status"] for v in checks_status.values() if v is not None]
         if "unhealthy" in statuses:
             overall = "unhealthy"
@@ -169,10 +208,10 @@ class HealthCheck(HealthCheckPort):
 
     def _register_default_checks(self) -> None:
         """Register default health checks. Called from __init__."""
-        self.register_check("system", self._check_system_health)
-        self.register_check("disk", self._check_disk_health)
-        self.register_check("database", self._check_database_health)
-        self.register_check("application", self._check_application_health)
+        self.register_check("system", self._check_system_health, kind="system")
+        self.register_check("disk", self._check_disk_health, kind="system")
+        self.register_check("database", self._check_database_health, kind="core")
+        self.register_check("application", self._check_application_health, kind="system")
 
     def _check_system_health(self) -> HealthStatus:
         """Check CPU and memory pressure.
@@ -412,5 +451,6 @@ def register_storage_health_checks(
 
     # Replace the placeholder ``database`` check installed by the
     # HealthCheck constructor. force=True is required because the
-    # default is first-write-wins.
-    health_check.register_check("database", _check_storage_backend_health, force=True)
+    # default is first-write-wins. Storage is a core dependency, so it
+    # gates readiness.
+    health_check.register_check("database", _check_storage_backend_health, force=True, kind="core")

--- a/src/orb/providers/aws/health.py
+++ b/src/orb/providers/aws/health.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError, ClientError
 
 from orb.domain.base.ports.health_check_port import HealthCheckPort
 from orb.monitoring.health import HealthStatus
@@ -15,6 +15,8 @@ def register_aws_health_checks(
     health_check: HealthCheckPort,
     aws_client: "AWSClient",
     storage_strategy: str = "json",  # kept for back-compat with callers
+    *,
+    kind: str = "provider",
 ) -> None:
     """Register AWS-specific health checks (``aws``, ``ec2``).
 
@@ -28,6 +30,10 @@ def register_aws_health_checks(
         health_check: The application HealthCheckPort to register checks on.
         aws_client: Authenticated AWS client used by the checks.
         storage_strategy: Ignored; retained for back-compat.
+        kind: Readiness classification for the connectivity checks
+            (``"core"`` when AWS is the sole enabled provider so a broken
+            provider gates ``/readyz``; ``"provider"`` otherwise). See
+            ``providers.health_scoping.connectivity_check_kind``.
     """
     _ = storage_strategy
 
@@ -65,8 +71,13 @@ def register_aws_health_checks(
                 details={"instance_count": instance_count, "api_status": "available"},
                 dependencies=["aws", "ec2"],
             )
-        except ClientError as e:
-            # Connectivity/permission failure — degraded, not a hard failure.
+        except (ClientError, BotoCoreError) as e:
+            # Both API errors (ClientError, e.g. AuthFailure) and connection
+            # failures (BotoCoreError subclasses such as EndpointConnectionError
+            # / ConnectTimeoutError raised by an unreachable endpoint) are
+            # connectivity/permission signals — degraded, not a hard failure.
+            # /health maps degraded -> 200, so an unreachable EC2 endpoint no
+            # longer forces the endpoint to 503.
             return HealthStatus(
                 name="ec2",
                 status="degraded",
@@ -74,5 +85,5 @@ def register_aws_health_checks(
                 dependencies=["aws", "ec2"],
             )
 
-    health_check.register_check("aws", _check_aws_health, kind="provider")
-    health_check.register_check("ec2", _check_ec2_health, kind="provider")
+    health_check.register_check("aws", _check_aws_health, kind=kind)
+    health_check.register_check("ec2", _check_ec2_health, kind=kind)

--- a/src/orb/providers/aws/health.py
+++ b/src/orb/providers/aws/health.py
@@ -45,9 +45,12 @@ def register_aws_health_checks(
                 dependencies=["aws"],
             )
         except Exception as e:
+            # An unreachable provider API is a degraded signal, not a hard
+            # failure of the process. /health maps degraded -> 200, so a
+            # single unreachable provider no longer forces the endpoint to 503.
             return HealthStatus(
                 name="aws",
-                status="unhealthy",
+                status="degraded",
                 details={"error": str(e)},
                 dependencies=["aws"],
             )
@@ -63,12 +66,13 @@ def register_aws_health_checks(
                 dependencies=["aws", "ec2"],
             )
         except ClientError as e:
+            # Connectivity/permission failure — degraded, not a hard failure.
             return HealthStatus(
                 name="ec2",
-                status="unhealthy",
+                status="degraded",
                 details={"error": str(e)},
                 dependencies=["aws", "ec2"],
             )
 
-    health_check.register_check("aws", _check_aws_health)
-    health_check.register_check("ec2", _check_ec2_health)
+    health_check.register_check("aws", _check_aws_health, kind="provider")
+    health_check.register_check("ec2", _check_ec2_health, kind="provider")

--- a/src/orb/providers/aws/registration.py
+++ b/src/orb/providers/aws/registration.py
@@ -96,8 +96,14 @@ def create_aws_strategy(provider_config: Any) -> Any:
             from orb.domain.base.ports.health_check_port import HealthCheckPort
             from orb.infrastructure.di.container import get_container
             from orb.providers.aws.health import register_aws_health_checks
+            from orb.providers.health_scoping import is_default_provider_instance
 
-            if strategy.aws_client is not None:
+            # Register connectivity checks only for the default/active instance
+            # so a secondary AWS instance cannot drag the overall status down.
+            provider_cfg = config_port.get_provider_config() if config_port else None
+            if strategy.aws_client is not None and is_default_provider_instance(
+                provider_name, provider_cfg
+            ):
                 health_check = get_container().get(HealthCheckPort)
                 _storage_strategy = "json"
                 if config_port is not None:

--- a/src/orb/providers/aws/registration.py
+++ b/src/orb/providers/aws/registration.py
@@ -96,7 +96,10 @@ def create_aws_strategy(provider_config: Any) -> Any:
             from orb.domain.base.ports.health_check_port import HealthCheckPort
             from orb.infrastructure.di.container import get_container
             from orb.providers.aws.health import register_aws_health_checks
-            from orb.providers.health_scoping import is_default_provider_instance
+            from orb.providers.health_scoping import (
+                connectivity_check_kind,
+                is_default_provider_instance,
+            )
 
             # Register connectivity checks only for the default/active instance
             # so a secondary AWS instance cannot drag the overall status down.
@@ -109,7 +112,14 @@ def create_aws_strategy(provider_config: Any) -> Any:
                 if config_port is not None:
                     with suppress(Exception):
                         _storage_strategy = config_port.get_storage_strategy()
-                register_aws_health_checks(health_check, strategy.aws_client, _storage_strategy)
+                # When AWS is the sole enabled provider its connectivity gates
+                # readiness (kind="core"); with multiple providers it does not.
+                register_aws_health_checks(
+                    health_check,
+                    strategy.aws_client,
+                    _storage_strategy,
+                    kind=connectivity_check_kind(provider_cfg),
+                )
 
         # Set provider name for identification
         if hasattr(strategy, "name") and provider_name:

--- a/src/orb/providers/aws/strategy/aws_provider_strategy.py
+++ b/src/orb/providers/aws/strategy/aws_provider_strategy.py
@@ -844,11 +844,26 @@ class AWSProviderStrategy(ProviderStrategy):
         return result
 
     def register_health_checks(self, health_check: HealthCheck) -> None:
-        """Register AWS-specific health checks if client is available."""
+        """Register AWS-specific health checks if this is the default instance.
+
+        Connectivity-check registration MUST go through the
+        ``is_default_provider_instance`` scoping gate so a secondary AWS
+        instance does not register a check that drags the overall status down,
+        and the readiness ``kind`` is chosen by ``connectivity_check_kind`` so
+        a sole broken provider gates ``/readyz``. This mirrors
+        ``create_aws_strategy`` (aws/registration.py). This method has no live
+        caller today, but the gate is applied here so a future re-wire cannot
+        silently reintroduce secondary-provider status drag.
+        """
         if self.aws_client is None:
             return
         from orb.providers.aws.health import register_aws_health_checks
+        from orb.providers.health_scoping import (
+            connectivity_check_kind,
+            is_default_provider_instance,
+        )
 
+        provider_cfg = None
         storage_strategy = "json"
         if self._config_port is not None:
             try:
@@ -859,7 +874,20 @@ class AWSProviderStrategy(ProviderStrategy):
                     storage_strategy,
                     e,
                 )
-        register_aws_health_checks(health_check, self.aws_client, storage_strategy)
+            try:
+                provider_cfg = self._config_port.get_provider_config()
+            except Exception as e:
+                self._logger.debug("Could not resolve provider config from config port: %s", e)
+
+        if not is_default_provider_instance(self._provider_name, provider_cfg):
+            return
+
+        register_aws_health_checks(
+            health_check,
+            self.aws_client,
+            storage_strategy,
+            kind=connectivity_check_kind(provider_cfg),
+        )
 
     def cleanup(self) -> None:
         """Clean up AWS provider resources."""

--- a/src/orb/providers/health_scoping.py
+++ b/src/orb/providers/health_scoping.py
@@ -16,7 +16,11 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-__all__ = ["is_default_provider_instance"]
+__all__ = [
+    "connectivity_check_kind",
+    "count_enabled_provider_instances",
+    "is_default_provider_instance",
+]
 
 
 def _resolve_default_instance_name(provider_config: Any) -> Optional[str]:
@@ -65,3 +69,34 @@ def is_default_provider_instance(provider_name: Optional[str], provider_config: 
         return True
 
     return provider_name == default_name
+
+
+def count_enabled_provider_instances(provider_config: Any) -> int:
+    """Return the number of enabled provider instances in *provider_config*.
+
+    Returns ``0`` when the config cannot be resolved. Instances without an
+    explicit ``enabled`` flag are treated as enabled (matching the schema
+    default).
+    """
+    if provider_config is None:
+        return 0
+    providers = getattr(provider_config, "providers", None) or []
+    return sum(1 for instance in providers if getattr(instance, "enabled", True))
+
+
+def connectivity_check_kind(provider_config: Any) -> str:
+    """Return the readiness ``kind`` for a provider-connectivity check.
+
+    When the default provider is the ONLY enabled instance, its connectivity
+    is a core dependency: a broken sole provider means the service cannot serve
+    any provisioning request, so ``/readyz`` must reflect that (returns
+    ``"core"`` → the check gates readiness). When MULTIPLE providers are enabled
+    a single unreachable one must not take the pod out of rotation, so the check
+    is classified ``"provider"`` (surfaced in ``/health`` but excluded from
+    readiness).
+
+    Fails safe: when the enabled-instance count cannot be resolved (0), the
+    check is treated as ``"provider"`` so an unresolved config never forces a
+    single-provider-style readiness gate that could wedge a pod.
+    """
+    return "core" if count_enabled_provider_instances(provider_config) == 1 else "provider"

--- a/src/orb/providers/health_scoping.py
+++ b/src/orb/providers/health_scoping.py
@@ -1,0 +1,67 @@
+"""Scope provider connectivity health checks to the default/active instance.
+
+Provider-connectivity checks (``aws``, ``ec2``, ``kubernetes_api``) should
+only be registered for the default/active provider instance. A secondary
+enabled instance — for example a k8s provider pointed at an unreachable
+cluster running alongside a primary AWS provider — must not register a
+connectivity check, so it cannot drag the overall status down.
+
+The default/active instance is resolved the same way provider selection
+resolves it (see ``ProviderSelectionService._select_default_provider``):
+``provider_config.default_provider_instance`` when set, otherwise the
+first enabled instance.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+__all__ = ["is_default_provider_instance"]
+
+
+def _resolve_default_instance_name(provider_config: Any) -> Optional[str]:
+    """Return the name of the default/active provider instance, or ``None``.
+
+    Mirrors provider-selection precedence: an explicit
+    ``default_provider_instance`` wins; otherwise the first enabled instance.
+    """
+    explicit = getattr(provider_config, "default_provider_instance", None)
+    if explicit:
+        return str(explicit)
+
+    providers = getattr(provider_config, "providers", None) or []
+    for instance in providers:
+        if getattr(instance, "enabled", True):
+            return getattr(instance, "name", None)
+    return None
+
+
+def is_default_provider_instance(provider_name: Optional[str], provider_config: Any) -> bool:
+    """Return ``True`` when *provider_name* is the default/active instance.
+
+    Deliberately fails open: when the provider config cannot be resolved, or
+    when ``provider_name`` is unknown (type-level construction with no
+    instance context), the connectivity check should still register so that
+    single-provider deployments keep their probe. Only a *named* secondary
+    instance that is demonstrably not the default is suppressed.
+
+    Args:
+        provider_name: The instance name the check would be registered for.
+            ``None`` means the caller has no instance context.
+        provider_config: The resolved provider configuration root, or ``None``.
+
+    Returns:
+        ``True`` if the check should register (default/active or ambiguous),
+        ``False`` only when *provider_name* is a known non-default instance.
+    """
+    if provider_config is None:
+        return True
+    if provider_name is None:
+        return True
+
+    default_name = _resolve_default_instance_name(provider_config)
+    if default_name is None:
+        # No resolvable default — do not suppress.
+        return True
+
+    return provider_name == default_name

--- a/src/orb/providers/k8s/health.py
+++ b/src/orb/providers/k8s/health.py
@@ -46,11 +46,15 @@ def register_k8s_health_checks(
                 dependencies=["kubernetes_api"],
             )
         except Exception as exc:
+            # An unreachable API server is a degraded signal for this provider,
+            # not a hard failure of the process. /health maps degraded -> 200,
+            # so a single unreachable cluster no longer forces the endpoint to
+            # 503.
             return HealthStatus(
                 name="kubernetes_api",
-                status="unhealthy",
+                status="degraded",
                 details={"error": str(exc)},
                 dependencies=["kubernetes_api"],
             )
 
-    health_check.register_check("kubernetes_api", _check_kubernetes_api_health)
+    health_check.register_check("kubernetes_api", _check_kubernetes_api_health, kind="provider")

--- a/src/orb/providers/k8s/health.py
+++ b/src/orb/providers/k8s/health.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:  # pragma: no cover — type-checking only
 def register_k8s_health_checks(
     health_check: HealthCheckPort,
     kubernetes_client: K8sClient,
+    *,
+    kind: str = "provider",
 ) -> None:
     """Register Kubernetes-specific health checks with the given HealthCheck instance.
 
@@ -29,6 +31,10 @@ def register_k8s_health_checks(
     Args:
         health_check: The application HealthCheckPort to register checks on.
         kubernetes_client: Authenticated K8sClient used by the checks.
+        kind: Readiness classification for the connectivity check
+            (``"core"`` when Kubernetes is the sole enabled provider so a
+            broken provider gates ``/readyz``; ``"provider"`` otherwise). See
+            ``providers.health_scoping.connectivity_check_kind``.
     """
 
     def _check_kubernetes_api_health() -> HealthStatus:
@@ -57,4 +63,4 @@ def register_k8s_health_checks(
                 dependencies=["kubernetes_api"],
             )
 
-    health_check.register_check("kubernetes_api", _check_kubernetes_api_health, kind="provider")
+    health_check.register_check("kubernetes_api", _check_kubernetes_api_health, kind=kind)

--- a/src/orb/providers/k8s/registration.py
+++ b/src/orb/providers/k8s/registration.py
@@ -195,10 +195,17 @@ def create_k8s_strategy(provider_config: Any) -> Any:
         with suppress(Exception):
             from orb.domain.base.ports.health_check_port import HealthCheckPort
             from orb.infrastructure.di.container import get_container
+            from orb.providers.health_scoping import is_default_provider_instance
             from orb.providers.k8s.health import register_k8s_health_checks
 
-            health_check = get_container().get(HealthCheckPort)
-            register_k8s_health_checks(health_check, strategy.kubernetes_client)
+            # Register the connectivity check only for the default/active
+            # instance. A secondary k8s instance (e.g. one pointed at an
+            # unreachable cluster) must not register a check that could drag
+            # the overall status down.
+            provider_cfg = config_port.get_provider_config() if config_port else None
+            if is_default_provider_instance(provider_name, provider_cfg):
+                health_check = get_container().get(HealthCheckPort)
+                register_k8s_health_checks(health_check, strategy.kubernetes_client)
 
         if provider_name:
             strategy._provider_name = provider_name  # type: ignore[assignment]

--- a/src/orb/providers/k8s/registration.py
+++ b/src/orb/providers/k8s/registration.py
@@ -195,7 +195,10 @@ def create_k8s_strategy(provider_config: Any) -> Any:
         with suppress(Exception):
             from orb.domain.base.ports.health_check_port import HealthCheckPort
             from orb.infrastructure.di.container import get_container
-            from orb.providers.health_scoping import is_default_provider_instance
+            from orb.providers.health_scoping import (
+                connectivity_check_kind,
+                is_default_provider_instance,
+            )
             from orb.providers.k8s.health import register_k8s_health_checks
 
             # Register the connectivity check only for the default/active
@@ -205,7 +208,13 @@ def create_k8s_strategy(provider_config: Any) -> Any:
             provider_cfg = config_port.get_provider_config() if config_port else None
             if is_default_provider_instance(provider_name, provider_cfg):
                 health_check = get_container().get(HealthCheckPort)
-                register_k8s_health_checks(health_check, strategy.kubernetes_client)
+                # When k8s is the sole enabled provider its connectivity gates
+                # readiness (kind="core"); with multiple providers it does not.
+                register_k8s_health_checks(
+                    health_check,
+                    strategy.kubernetes_client,
+                    kind=connectivity_check_kind(provider_cfg),
+                )
 
         if provider_name:
             strategy._provider_name = provider_name  # type: ignore[assignment]

--- a/src/orb/providers/k8s/services/health_check_service.py
+++ b/src/orb/providers/k8s/services/health_check_service.py
@@ -134,11 +134,19 @@ class K8sHealthCheckService:
         self,
         health_check: HealthCheck,
         kubernetes_client: K8sClient,
+        *,
+        kind: str = "provider",
     ) -> None:
-        """Register Kubernetes-specific health checks."""
+        """Register Kubernetes-specific health checks.
+
+        ``kind`` is the readiness classification for the connectivity check;
+        the caller (the strategy) decides it via
+        ``providers.health_scoping.connectivity_check_kind`` after applying the
+        default-instance scoping gate.
+        """
         from orb.providers.k8s.health import register_k8s_health_checks
 
-        register_k8s_health_checks(health_check, kubernetes_client)
+        register_k8s_health_checks(health_check, kubernetes_client, kind=kind)
 
 
 __all__ = ["K8sHealthCheckService"]

--- a/src/orb/providers/k8s/strategy/k8s_provider_strategy.py
+++ b/src/orb/providers/k8s/strategy/k8s_provider_strategy.py
@@ -1093,8 +1093,8 @@ class K8sProviderStrategy(ProviderStrategy):
         if self._config_port is not None:
             try:
                 provider_cfg = self._config_port.get_provider_config()
-            except Exception:
-                pass
+            except Exception as e:
+                self._logger.debug("Could not resolve provider config from config port: %s", e)
 
         if not is_default_provider_instance(self._provider_name, provider_cfg):
             return

--- a/src/orb/providers/k8s/strategy/k8s_provider_strategy.py
+++ b/src/orb/providers/k8s/strategy/k8s_provider_strategy.py
@@ -1065,7 +1065,17 @@ class K8sProviderStrategy(ProviderStrategy):
     # ------------------------------------------------------------------
 
     def register_health_checks(self, health_check: HealthCheck) -> None:
-        """Register Kubernetes-specific health checks if the client is reachable."""
+        """Register Kubernetes health checks if this is the default instance.
+
+        Connectivity-check registration MUST go through the
+        ``is_default_provider_instance`` scoping gate so a secondary k8s
+        instance does not register a check that drags the overall status down,
+        and the readiness ``kind`` is chosen by ``connectivity_check_kind`` so
+        a sole broken provider gates ``/readyz``. This mirrors
+        ``create_k8s_strategy`` (k8s/registration.py). This method has no live
+        caller today, but the gate is applied here so a future re-wire cannot
+        silently reintroduce secondary-provider status drag.
+        """
         try:
             client = self.kubernetes_client
         except Exception as exc:
@@ -1073,7 +1083,25 @@ class K8sProviderStrategy(ProviderStrategy):
                 "Skipping Kubernetes health-check registration: %s", exc, exc_info=True
             )
             return
-        self._health_check_service.register_health_checks(health_check, client)
+
+        from orb.providers.health_scoping import (
+            connectivity_check_kind,
+            is_default_provider_instance,
+        )
+
+        provider_cfg = None
+        if self._config_port is not None:
+            try:
+                provider_cfg = self._config_port.get_provider_config()
+            except Exception:
+                pass
+
+        if not is_default_provider_instance(self._provider_name, provider_cfg):
+            return
+
+        self._health_check_service.register_health_checks(
+            health_check, client, kind=connectivity_check_kind(provider_cfg)
+        )
 
     # ------------------------------------------------------------------
     # Native-spec resolution — kept on the strategy because it owns the

--- a/tests/unit/api/test_liveness_readiness_endpoints.py
+++ b/tests/unit/api/test_liveness_readiness_endpoints.py
@@ -1,0 +1,144 @@
+"""Tests for the /livez and /readyz probe endpoints.
+
+- /livez  : liveness — always 200 while the process is up; never gates
+            on any dependency or provider.
+- /readyz : readiness — 200 unless a CORE dependency (storage/database)
+            is unhealthy; provider connectivity must NOT gate it.
+- /health : unchanged full detail + status mapping (back-compat).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+import orb.api.dependencies as deps
+from orb.api.server import create_fastapi_app
+from orb.config.schemas.server_schema import AuthConfig, ServerConfig
+
+
+def _make_client(health_port) -> TestClient:
+    server_config = ServerConfig(  # type: ignore[call-arg]
+        enabled=True,
+        auth=AuthConfig(enabled=False, strategy="replace"),  # type: ignore[call-arg]
+    )
+
+    def _stub_routes(app):
+        app.include_router(APIRouter())
+
+    with patch("orb.api.server._register_routers") as mock_register:
+        mock_register.side_effect = _stub_routes
+        app = create_fastapi_app(server_config)
+    app.dependency_overrides[deps.get_health_check_port] = lambda: health_port
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestLivez:
+    def test_livez_returns_200_when_up(self) -> None:
+        health_port = MagicMock()
+        client = _make_client(health_port)
+        resp = client.get("/livez")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "alive"
+
+    def test_livez_returns_200_even_when_dependency_unhealthy(self) -> None:
+        """Liveness must never gate on dependency health."""
+        health_port = MagicMock()
+        health_port.get_readiness.return_value = {"status": "unhealthy"}
+        health_port.get_status.return_value = {"status": "unhealthy"}
+        client = _make_client(health_port)
+        resp = client.get("/livez")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "alive"
+        # Liveness must not even consult dependency health.
+        health_port.get_readiness.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestReadyz:
+    def test_readyz_200_when_only_provider_unhealthy(self) -> None:
+        """A failing provider-connectivity check must not fail readiness."""
+        health_port = MagicMock()
+        health_port.get_readiness.return_value = {"status": "healthy"}
+        client = _make_client(health_port)
+        resp = client.get("/readyz")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "healthy"
+
+    def test_readyz_200_when_readiness_unknown(self) -> None:
+        health_port = MagicMock()
+        health_port.get_readiness.return_value = {"status": "unknown"}
+        client = _make_client(health_port)
+        resp = client.get("/readyz")
+        assert resp.status_code == 200
+
+    def test_readyz_200_when_readiness_degraded(self) -> None:
+        health_port = MagicMock()
+        health_port.get_readiness.return_value = {"status": "degraded"}
+        client = _make_client(health_port)
+        resp = client.get("/readyz")
+        assert resp.status_code == 200
+
+    def test_readyz_503_when_core_dependency_unhealthy(self) -> None:
+        health_port = MagicMock()
+        health_port.get_readiness.return_value = {
+            "status": "unhealthy",
+            "checks": {"database": {"status": "unhealthy"}},
+        }
+        client = _make_client(health_port)
+        resp = client.get("/readyz")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "unhealthy"
+
+    def test_readyz_runs_checks_before_reading_readiness(self) -> None:
+        health_port = MagicMock()
+        health_port.get_readiness.return_value = {"status": "healthy"}
+        client = _make_client(health_port)
+        client.get("/readyz")
+        health_port.run_all_checks.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestHealthUnchanged:
+    def test_health_returns_full_body(self) -> None:
+        health_port = MagicMock()
+        health_port.get_status.return_value = {
+            "status": "healthy",
+            "checks": {"database": {"status": "healthy"}},
+        }
+        client = _make_client(health_port)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert data["service"] == "open-resource-broker"
+        assert "version" in data
+        assert "checks" in data
+
+    def test_health_200_when_provider_degraded(self) -> None:
+        """After the provider-degraded change, a degraded provider keeps
+        /health at 200 with its full detailed body."""
+        health_port = MagicMock()
+        health_port.get_status.return_value = {
+            "status": "degraded",
+            "checks": {"kubernetes_api": {"status": "degraded"}},
+        }
+        client = _make_client(health_port)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "degraded"
+
+    def test_health_503_when_unhealthy(self) -> None:
+        """Back-compat: an overall 'unhealthy' status still maps to 503."""
+        health_port = MagicMock()
+        health_port.get_status.return_value = {"status": "unhealthy"}
+        client = _make_client(health_port)
+        resp = client.get("/health")
+        assert resp.status_code == 503

--- a/tests/unit/api/test_liveness_readiness_endpoints.py
+++ b/tests/unit/api/test_liveness_readiness_endpoints.py
@@ -78,12 +78,15 @@ class TestReadyz:
         resp = client.get("/readyz")
         assert resp.status_code == 200
 
-    def test_readyz_200_when_readiness_degraded(self) -> None:
+    def test_readyz_503_when_readiness_degraded(self) -> None:
+        """get_readiness only reports 'degraded' when a CORE check is degraded
+        (e.g. the sole provider's connectivity, which fails as degraded). A
+        degraded core dependency means not-ready → 503."""
         health_port = MagicMock()
         health_port.get_readiness.return_value = {"status": "degraded"}
         client = _make_client(health_port)
         resp = client.get("/readyz")
-        assert resp.status_code == 200
+        assert resp.status_code == 503
 
     def test_readyz_503_when_core_dependency_unhealthy(self) -> None:
         health_port = MagicMock()

--- a/tests/unit/monitoring/test_health_readiness.py
+++ b/tests/unit/monitoring/test_health_readiness.py
@@ -134,3 +134,86 @@ class TestReadinessClassification:
         assert status["status"] == "degraded"
         assert "aws" in status["checks"]
         assert "database" in status["checks"]
+
+
+@pytest.mark.unit
+class TestSoleProviderReadinessGating:
+    """Sole enabled provider gates readiness (kind='core'); multi-provider does not.
+
+    A connectivity failure surfaces as 'degraded'. When the provider is the sole
+    enabled instance its check is registered kind='core', so a degraded sole
+    provider makes readiness 'degraded' (which /readyz maps to 503). With
+    multiple providers the connectivity check is kind='provider' and does not
+    gate readiness.
+    """
+
+    def test_sole_provider_unreachable_makes_readiness_not_ready(self, tmp_path) -> None:
+        hc = _make_health_check(tmp_path)
+        hc.register_check(
+            "database",
+            lambda: HealthStatus("database", "healthy", {}),
+            kind="core",
+            force=True,
+        )
+        # Sole provider → its connectivity is core; unreachable = degraded.
+        hc.register_check(
+            "aws",
+            lambda: HealthStatus("aws", "degraded", {"error": "unreachable"}),
+            kind="core",
+        )
+        hc.run_check("database")
+        hc.run_check("aws")
+
+        readiness = hc.get_readiness()
+        # 'degraded' core dependency → /readyz maps this to 503 (not-ready).
+        assert readiness["status"] == "degraded"
+
+    def test_multi_provider_secondary_unreachable_stays_ready(self, tmp_path) -> None:
+        hc = _make_health_check(tmp_path)
+        hc.register_check(
+            "database",
+            lambda: HealthStatus("database", "healthy", {}),
+            kind="core",
+            force=True,
+        )
+        # Multiple providers: default healthy (core-not; provider), secondary
+        # unreachable (provider). Neither provider check gates readiness.
+        hc.register_check(
+            "aws",
+            lambda: HealthStatus("aws", "healthy", {}),
+            kind="provider",
+        )
+        hc.register_check(
+            "kubernetes_api",
+            lambda: HealthStatus("kubernetes_api", "degraded", {"error": "unreachable"}),
+            kind="provider",
+        )
+        hc.run_check("database")
+        hc.run_check("aws")
+        hc.run_check("kubernetes_api")
+
+        readiness = hc.get_readiness()
+        assert readiness["status"] == "healthy"
+
+    def test_multi_provider_default_unreachable_stays_ready(self, tmp_path) -> None:
+        """Intended: with multiple providers even the DEFAULT provider's
+        connectivity is non-core, so a degraded default does NOT gate readiness.
+        Only a sole-provider deployment gates on provider connectivity."""
+        hc = _make_health_check(tmp_path)
+        hc.register_check(
+            "database",
+            lambda: HealthStatus("database", "healthy", {}),
+            kind="core",
+            force=True,
+        )
+        # Default provider connectivity registered kind='provider' (multi mode).
+        hc.register_check(
+            "aws",
+            lambda: HealthStatus("aws", "degraded", {"error": "unreachable"}),
+            kind="provider",
+        )
+        hc.run_check("database")
+        hc.run_check("aws")
+
+        readiness = hc.get_readiness()
+        assert readiness["status"] == "healthy"

--- a/tests/unit/monitoring/test_health_readiness.py
+++ b/tests/unit/monitoring/test_health_readiness.py
@@ -1,0 +1,136 @@
+"""Unit tests for readiness classification of health checks.
+
+Readiness (``/readyz``) must gate only on CORE dependency checks
+(storage / database).  Provider-connectivity checks (aws, ec2,
+kubernetes_api) must NOT gate readiness, so an unreachable optional
+provider cannot take the whole service out of rotation.
+
+The classification is explicit: ``register_check`` accepts a ``kind``
+argument (``"core"`` | ``"provider"`` | ``"system"``) and
+``get_readiness`` derives its status from the ``core`` checks only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orb.monitoring.health import HealthCheck, HealthCheckConfig, HealthStatus
+
+
+def _config(tmp_path: Path) -> HealthCheckConfig:
+    return HealthCheckConfig(health_dir=tmp_path / "health")
+
+
+def _make_health_check(tmp_path: Path) -> HealthCheck:
+    return HealthCheck(config=_config(tmp_path))
+
+
+@pytest.mark.unit
+class TestReadinessClassification:
+    def test_register_check_accepts_kind(self, tmp_path) -> None:
+        hc = _make_health_check(tmp_path)
+        hc.register_check(
+            "myprovider",
+            lambda: HealthStatus("myprovider", "healthy", {}),
+            kind="provider",
+        )
+        assert "myprovider" in hc.checks
+
+    def test_provider_failure_does_not_affect_readiness(self, tmp_path) -> None:
+        """An unhealthy provider-connectivity check leaves readiness healthy."""
+        hc = _make_health_check(tmp_path)
+        hc.register_check(
+            "database",
+            lambda: HealthStatus("database", "healthy", {}),
+            kind="core",
+            force=True,
+        )
+        hc.register_check(
+            "kubernetes_api",
+            lambda: HealthStatus("kubernetes_api", "unhealthy", {"error": "unreachable"}),
+            kind="provider",
+        )
+        hc.run_check("database")
+        hc.run_check("kubernetes_api")
+
+        readiness = hc.get_readiness()
+        assert readiness["status"] == "healthy"
+
+    def test_core_dependency_failure_makes_readiness_unhealthy(self, tmp_path) -> None:
+        """An unhealthy CORE (database) check makes readiness unhealthy."""
+        hc = _make_health_check(tmp_path)
+        hc.register_check(
+            "database",
+            lambda: HealthStatus("database", "unhealthy", {"error": "conn lost"}),
+            kind="core",
+            force=True,
+        )
+        hc.register_check(
+            "aws",
+            lambda: HealthStatus("aws", "healthy", {}),
+            kind="provider",
+        )
+        hc.run_check("database")
+        hc.run_check("aws")
+
+        readiness = hc.get_readiness()
+        assert readiness["status"] == "unhealthy"
+
+    def test_degraded_provider_does_not_affect_readiness(self, tmp_path) -> None:
+        hc = _make_health_check(tmp_path)
+        hc.register_check(
+            "database",
+            lambda: HealthStatus("database", "healthy", {}),
+            kind="core",
+            force=True,
+        )
+        hc.register_check(
+            "aws",
+            lambda: HealthStatus("aws", "degraded", {"error": "unreachable"}),
+            kind="provider",
+        )
+        hc.run_check("database")
+        hc.run_check("aws")
+
+        readiness = hc.get_readiness()
+        assert readiness["status"] == "healthy"
+
+    def test_readiness_unknown_when_no_core_checks_run(self, tmp_path) -> None:
+        """With no core-check history, readiness derives to 'unknown'
+        rather than being dragged down by provider checks."""
+        hc = _make_health_check(tmp_path)
+        hc.register_check(
+            "aws",
+            lambda: HealthStatus("aws", "unhealthy", {}),
+            kind="provider",
+        )
+        hc.run_check("aws")
+
+        readiness = hc.get_readiness()
+        assert readiness["status"] == "unknown"
+
+    def test_get_status_still_reflects_all_checks(self, tmp_path) -> None:
+        """get_status (backing /health) is unchanged: any unhealthy check —
+        including a provider one — still surfaces in the overall status."""
+        hc = _make_health_check(tmp_path)
+        hc.register_check(
+            "database",
+            lambda: HealthStatus("database", "healthy", {}),
+            kind="core",
+            force=True,
+        )
+        hc.register_check(
+            "aws",
+            lambda: HealthStatus("aws", "degraded", {}),
+            kind="provider",
+        )
+        hc.run_check("database")
+        hc.run_check("aws")
+
+        status = hc.get_status()
+        # Provider degraded still surfaces in the full /health body.
+        assert status["status"] == "degraded"
+        assert "aws" in status["checks"]
+        assert "database" in status["checks"]

--- a/tests/unit/providers/test_health_check_scoping.py
+++ b/tests/unit/providers/test_health_check_scoping.py
@@ -16,7 +16,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from orb.providers.health_scoping import is_default_provider_instance
+from orb.providers.health_scoping import (
+    connectivity_check_kind,
+    count_enabled_provider_instances,
+    is_default_provider_instance,
+)
 
 
 def _provider(name: str, ptype: str, enabled: bool = True):
@@ -83,3 +87,33 @@ class TestIsDefaultProviderInstance:
         """With no resolvable provider config, do not suppress the check —
         fall back to registering so single-provider setups still probe."""
         assert is_default_provider_instance("aws-main", None) is True
+
+
+@pytest.mark.unit
+class TestConnectivityCheckKind:
+    def test_sole_enabled_provider_is_core(self) -> None:
+        """A single enabled provider gates readiness: its connectivity is core."""
+        cfg = _provider_config([_provider("aws-main", "aws")])
+        assert count_enabled_provider_instances(cfg) == 1
+        assert connectivity_check_kind(cfg) == "core"
+
+    def test_multiple_enabled_providers_is_provider(self) -> None:
+        """With multiple enabled providers a single failure must not gate
+        readiness, so connectivity is classified non-core."""
+        cfg = _provider_config([_provider("aws-main", "aws"), _provider("k8s_ms-karpenter", "k8s")])
+        assert count_enabled_provider_instances(cfg) == 2
+        assert connectivity_check_kind(cfg) == "provider"
+
+    def test_sole_enabled_among_disabled_is_core(self) -> None:
+        """Only the enabled count matters: one enabled + one disabled = sole."""
+        cfg = _provider_config(
+            [_provider("aws-main", "aws"), _provider("k8s_old", "k8s", enabled=False)]
+        )
+        assert count_enabled_provider_instances(cfg) == 1
+        assert connectivity_check_kind(cfg) == "core"
+
+    def test_no_config_is_provider(self) -> None:
+        """Unresolved config → non-core, so an unknown config never forces a
+        single-provider-style readiness gate that could wedge a pod."""
+        assert count_enabled_provider_instances(None) == 0
+        assert connectivity_check_kind(None) == "provider"

--- a/tests/unit/providers/test_health_check_scoping.py
+++ b/tests/unit/providers/test_health_check_scoping.py
@@ -1,0 +1,85 @@
+"""Provider health checks register only for the default/active provider.
+
+A connectivity check must be registered for the default/active provider
+instance only — never for a secondary enabled instance.  An unreachable
+secondary provider must not even register a check, so it cannot drag the
+overall status down.
+
+The default/active instance is determined the same way provider
+selection does it: ``provider_config.default_provider_instance`` when set,
+otherwise the first enabled instance.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from orb.providers.health_scoping import is_default_provider_instance
+
+
+def _provider(name: str, ptype: str, enabled: bool = True):
+    p = MagicMock()
+    p.name = name
+    p.type = ptype
+    p.enabled = enabled
+    return p
+
+
+def _provider_config(providers, default_instance=None):
+    cfg = MagicMock()
+    cfg.providers = providers
+    cfg.default_provider_instance = default_instance
+    return cfg
+
+
+@pytest.mark.unit
+class TestIsDefaultProviderInstance:
+    def test_explicit_default_instance_matches(self) -> None:
+        providers = [
+            _provider("aws-main", "aws"),
+            _provider("k8s_ms-karpenter", "k8s"),
+        ]
+        cfg = _provider_config(providers, default_instance="aws-main")
+        assert is_default_provider_instance("aws-main", cfg) is True
+
+    def test_secondary_instance_is_not_default(self) -> None:
+        providers = [
+            _provider("aws-main", "aws"),
+            _provider("k8s_ms-karpenter", "k8s"),
+        ]
+        cfg = _provider_config(providers, default_instance="aws-main")
+        assert is_default_provider_instance("k8s_ms-karpenter", cfg) is False
+
+    def test_first_enabled_is_default_when_unset(self) -> None:
+        providers = [
+            _provider("aws-main", "aws"),
+            _provider("k8s_ms-karpenter", "k8s"),
+        ]
+        cfg = _provider_config(providers, default_instance=None)
+        assert is_default_provider_instance("aws-main", cfg) is True
+        assert is_default_provider_instance("k8s_ms-karpenter", cfg) is False
+
+    def test_disabled_first_instance_is_skipped(self) -> None:
+        providers = [
+            _provider("aws-main", "aws", enabled=False),
+            _provider("k8s_ms-karpenter", "k8s", enabled=True),
+        ]
+        cfg = _provider_config(providers, default_instance=None)
+        # aws-main is disabled, so the first *enabled* instance is the default.
+        assert is_default_provider_instance("k8s_ms-karpenter", cfg) is True
+        assert is_default_provider_instance("aws-main", cfg) is False
+
+    def test_unnamed_instance_registers_by_default(self) -> None:
+        """When the instance name is unknown (type-level construction with no
+        instance context) the check registers rather than being silently
+        dropped — single-provider deployments must keep their probe."""
+        providers = [_provider("aws-main", "aws")]
+        cfg = _provider_config(providers, default_instance="aws-main")
+        assert is_default_provider_instance(None, cfg) is True
+
+    def test_no_config_registers_by_default(self) -> None:
+        """With no resolvable provider config, do not suppress the check —
+        fall back to registering so single-provider setups still probe."""
+        assert is_default_provider_instance("aws-main", None) is True

--- a/tests/unit/providers/test_provider_health_degraded.py
+++ b/tests/unit/providers/test_provider_health_degraded.py
@@ -55,6 +55,22 @@ class TestAWSHealthDegraded:
         assert result.status == "degraded"
         assert "error" in result.details
 
+    def test_ec2_endpoint_connection_error_is_degraded(self) -> None:
+        """A genuinely unreachable EC2 endpoint raises EndpointConnectionError,
+        which is a BotoCoreError (NOT a ClientError). It must still yield
+        'degraded' so an unreachable endpoint does not force /health to 503."""
+        from botocore.exceptions import EndpointConnectionError
+
+        aws_client = MagicMock()
+        aws_client.ec2_client.describe_instances.side_effect = EndpointConnectionError(
+            endpoint_url="https://ec2.example.com"
+        )
+        captured = self._register_and_capture(aws_client)
+
+        result = captured["ec2"]()
+        assert result.status == "degraded"
+        assert "error" in result.details
+
     def test_aws_success_still_healthy(self) -> None:
         aws_client = MagicMock()
         aws_client.sts_client.get_caller_identity.return_value = {

--- a/tests/unit/providers/test_provider_health_degraded.py
+++ b/tests/unit/providers/test_provider_health_degraded.py
@@ -1,0 +1,102 @@
+"""Provider-connectivity failures must surface as 'degraded', not 'unhealthy'.
+
+An unreachable provider API (exception on the connectivity probe) is a
+degraded signal, not a hard failure of the process.  Since ``/health``
+maps degraded -> 200, this keeps a single unreachable provider from
+forcing the whole endpoint to 503.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.unit
+class TestAWSHealthDegraded:
+    def _register_and_capture(self, aws_client):
+        from orb.providers.aws.health import register_aws_health_checks
+
+        captured: dict[str, object] = {}
+
+        health_check = MagicMock()
+
+        def _capture(name, fn, **kwargs):
+            captured[name] = fn
+
+        health_check.register_check.side_effect = _capture
+        register_aws_health_checks(health_check, aws_client, storage_strategy="json")
+        return captured
+
+    def test_aws_connectivity_failure_is_degraded(self) -> None:
+        aws_client = MagicMock()
+        aws_client.sts_client.get_caller_identity.side_effect = Exception("unreachable")
+        captured = self._register_and_capture(aws_client)
+
+        result = captured["aws"]()
+        assert result.status == "degraded"
+        assert "error" in result.details
+
+    def test_ec2_connectivity_failure_is_degraded(self) -> None:
+        from botocore.exceptions import ClientError
+
+        aws_client = MagicMock()
+        aws_client.ec2_client.describe_instances.side_effect = ClientError(
+            {"Error": {"Code": "AuthFailure", "Message": "no creds"}},
+            "DescribeInstances",
+        )
+        captured = self._register_and_capture(aws_client)
+
+        result = captured["ec2"]()
+        assert result.status == "degraded"
+        assert "error" in result.details
+
+    def test_aws_success_still_healthy(self) -> None:
+        aws_client = MagicMock()
+        aws_client.sts_client.get_caller_identity.return_value = {
+            "Account": "123456789012",
+            "UserId": "AID",
+            "Arn": "arn:aws:iam::123456789012:user/x",
+        }
+        captured = self._register_and_capture(aws_client)
+
+        result = captured["aws"]()
+        assert result.status == "healthy"
+
+
+@pytest.mark.unit
+class TestK8sHealthDegraded:
+    def _register_and_capture(self, kubernetes_client):
+        from orb.providers.k8s.health import register_k8s_health_checks
+
+        captured: dict[str, object] = {}
+
+        health_check = MagicMock()
+
+        def _capture(name, fn, **kwargs):
+            captured[name] = fn
+
+        health_check.register_check.side_effect = _capture
+        register_k8s_health_checks(health_check, kubernetes_client)
+        return captured
+
+    def test_k8s_api_connectivity_failure_is_degraded(self) -> None:
+        kubernetes_client = MagicMock()
+        kubernetes_client.core_v1.get_api_resources.side_effect = Exception("unreachable")
+        captured = self._register_and_capture(kubernetes_client)
+
+        result = captured["kubernetes_api"]()
+        assert result.status == "degraded"
+        assert "error" in result.details
+
+    def test_k8s_api_success_still_healthy(self) -> None:
+        kubernetes_client = MagicMock()
+        resources = MagicMock()
+        resources.resources = [MagicMock(), MagicMock()]
+        resources.group_version = "v1"
+        kubernetes_client.core_v1.get_api_resources.return_value = resources
+        captured = self._register_and_capture(kubernetes_client)
+
+        result = captured["kubernetes_api"]()
+        assert result.status == "healthy"

--- a/tests/unit/providers/test_provider_health_degraded.py
+++ b/tests/unit/providers/test_provider_health_degraded.py
@@ -8,17 +8,20 @@ forcing the whole endpoint to 503.
 
 from __future__ import annotations
 
+from typing import Callable
 from unittest.mock import MagicMock
 
 import pytest
 
+from orb.monitoring.health import HealthStatus
+
 
 @pytest.mark.unit
 class TestAWSHealthDegraded:
-    def _register_and_capture(self, aws_client):
+    def _register_and_capture(self, aws_client) -> dict[str, Callable[[], HealthStatus]]:
         from orb.providers.aws.health import register_aws_health_checks
 
-        captured: dict[str, object] = {}
+        captured: dict[str, Callable[[], HealthStatus]] = {}
 
         health_check = MagicMock()
 
@@ -67,10 +70,10 @@ class TestAWSHealthDegraded:
 
 @pytest.mark.unit
 class TestK8sHealthDegraded:
-    def _register_and_capture(self, kubernetes_client):
+    def _register_and_capture(self, kubernetes_client) -> dict[str, Callable[[], HealthStatus]]:
         from orb.providers.k8s.health import register_k8s_health_checks
 
-        captured: dict[str, object] = {}
+        captured: dict[str, Callable[[], HealthStatus]] = {}
 
         health_check = MagicMock()
 


### PR DESCRIPTION
## Description

`GET /health` returned HTTP 503 whenever **any** enabled provider's connectivity check failed. That check reports "unhealthy" when a provider API is unreachable, which forced the aggregate `/health` status to "unhealthy" for the whole service. In a multi-provider deployment — e.g. a primary AWS provider alongside a secondary Kubernetes provider pointed at an unreachable cluster — a single unreachable optional provider took the entire endpoint down, so any consumer gating on `/health` (including a Kubernetes probe) treated the service as never-ready even though the core service was fully functional.

This change separates the concerns behind a single overloaded endpoint:

1. **Provider connectivity is now a degraded signal, not a hard failure.** An unreachable provider API — STS / EC2 / Kubernetes API, including botocore connection errors (e.g. endpoint-connection / connect-timeout) as well as API errors — reports "degraded" rather than "unhealthy". Since `/health` already maps degraded to 200, an unreachable provider no longer forces 503. Genuine core-dependency failures are unaffected.

2. **New `/livez` and `/readyz` probe endpoints.** `/health` is kept unchanged for back-compat and full detail.
   - `/livez` (liveness) returns 200 whenever the process is up and never consults any dependency.
   - `/readyz` (readiness) returns 503 when a **core** dependency is not fully healthy, otherwise 200. Storage / database is always core. Provider connectivity does **not** gate readiness in a **multi-provider** deployment — a dead secondary provider (or even the default) leaves `/readyz` at 200 so the replica stays in rotation. **But when the default provider is the sole enabled provider**, its connectivity check is classified core, so a single-provider deployment whose only provider is unreachable correctly reports not-ready (`/readyz` 503). Because a connectivity failure surfaces as "degraded", `/readyz` treats a degraded core dependency as not-ready as well as an unhealthy one.

3. **Provider connectivity checks are scoped to the default/active provider instance.** Previously a check was registered for every enabled instance, so a secondary provider could register a probe that dragged the aggregate status down. Registration is now gated on the default/active instance (explicit `default_provider_instance`, otherwise the first enabled instance), matching provider-selection precedence.

To support readiness gating, health checks are classified by kind at registration time (`core`, `provider`, `system`); readiness is derived from `core` checks only. The default provider's connectivity is classified `core` only when it is the sole enabled provider, and `provider` otherwise.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes the case where a single unreachable provider forced `/health` to 503 for the whole service.

## How Has This Been Tested?

- [x] Unit tests added/updated

New unit tests cover: `/livez` returning 200 even when a dependency is unhealthy; `/readyz` returning 200 when only a provider-connectivity check fails in a multi-provider setup and 503 when a core dependency (database) is unhealthy; the sole-vs-multi readiness gating — a sole enabled provider's connectivity classified core so an unreachable sole provider makes `/readyz` not-ready, while a dead secondary (or the default) in a multi-provider setup does not; provider-connectivity failures mapping to "degraded" for the AWS (`aws`, `ec2` — including a botocore connection error, not only an API error) and Kubernetes checks; `/health` retaining its full detailed body and existing status mapping; and connectivity-check registration being scoped to the default/active instance so a secondary enabled instance registers no check. Provider clients are mocked to simulate an unreachable API — no live cloud access required.

## Test Configuration
* Python version: 3.12+
* OS: macOS / Linux
* AWS region: n/a (unit tests mock provider clients)
* Dependencies changed: none

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The readiness classification is explicit rather than name-based: `register_check` takes a `kind` argument (`core` / `provider` / `system`). Storage/database registers as `core`. The AWS (`aws`, `ec2`) and Kubernetes (`kubernetes_api`) connectivity probes register as `core` when their provider is the sole enabled instance and `provider` otherwise, so only a single-provider deployment gates readiness on provider connectivity. Instance scoping fails open — when the instance name or provider config cannot be resolved, the check still registers so single-provider deployments keep their probe.

## Performance Impact

- [x] No significant performance impact

## Security Considerations

- [x] No security implications

`/livez` and `/readyz`, like `/health`, are exempt from authentication so orchestrators can poll them without credentials — standard for Kubernetes liveness/readiness probes. They expose no sensitive detail: `/livez` returns only `{"status": "alive"}`, and `/readyz` returns only the readiness status derived from core dependency checks. Both are also allowed under read-only mode and skipped by the audit log, matching the existing treatment of `/health`.

## Deployment Notes

Operators should point their Kubernetes probes at the new dedicated endpoints instead of `/health`:

- `livenessProbe` → `GET /livez` — succeeds whenever the process is up; use it to detect a wedged process, not downstream outages.
- `readinessProbe` → `GET /readyz` — takes a replica out of rotation when a core dependency is down. Core is storage/database always, plus the sole provider's connectivity in a single-provider deployment. In a multi-provider deployment an unreachable secondary (or default) provider does not remove the replica from service.

Example manifest fragment:

```yaml
livenessProbe:
  httpGet:
    path: /livez
    port: 8000
  initialDelaySeconds: 5
  periodSeconds: 10
readinessProbe:
  httpGet:
    path: /readyz
    port: 8000
  initialDelaySeconds: 5
  periodSeconds: 10
```

`/health` remains available and unchanged (full detailed body) for dashboards and manual inspection.

## Reviewers

@finos/open-resource-broker-maintainers
