### PR TITLE
fix: recover review fixes (audit log, HTTPS proxy, config, --wait, SSE) + enable npm OIDC publishing

### DIFF
--- a/.github/workflows/reusable-sdk-publish.yml
+++ b/.github/workflows/reusable-sdk-publish.yml
@@ -99,10 +99,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-    - name: Set up Node.js 20 (with npm registry auth)
+    - name: Set up Node.js (with npm registry auth)
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
       with:
-        node-version: '20'
+        # npm OIDC trusted publishing requires Node >= 22.14.0 (in addition to
+        # npm CLI >= 11.5.1); on Node 20 the publish never performs the OIDC
+        # exchange and falls back to token auth, failing with ENEEDAUTH on the
+        # trusted path. Token/GitHub-Packages publishing works on any Node, but
+        # the shared setup must satisfy the strictest (trusted) path.
+        node-version: '22'
         # Point npm at the destination registry so setup-node writes the matching
         # auth line into .npmrc for NODE_AUTH_TOKEN.
         #   github            -> npm.pkg.github.com  (GITHUB_TOKEN auth)
@@ -174,6 +179,10 @@ jobs:
         NODE_AUTH_TOKEN: ${{ matrix.destination == 'github' && secrets.GITHUB_TOKEN || (inputs.auth-mode == 'token' && secrets.NODE_AUTH_TOKEN || '') }}
       run: |
         cd sdk/typescript
+        # Record the toolchain versions: trusted publishing needs Node >= 22.14
+        # and npm >= 11.5.1, and an OIDC failure otherwise surfaces only as an
+        # opaque ENEEDAUTH — so make the active versions explicit in the log.
+        echo "node: $(node --version), npm: $(npm --version)"
         if [[ "${{ inputs.dry-run }}" == "true" ]]; then
           npm publish --access public --dry-run
           echo "npm -> ${{ matrix.destination }}: dry-run OK (nothing published)"

--- a/sdk/spec/openapi.json
+++ b/sdk/spec/openapi.json
@@ -1856,7 +1856,7 @@
           "Events"
         ],
         "summary": "Global Server-Sent Events stream",
-        "description": "Subscribe once per page load. Receives push deltas for machines, requests, templates, and a heartbeat every 15 s.  Supports ?since= for replay and ?type= for filtering.  Add ?since_seq= alongside ?since= to enable gap-detection: if history has overflowed a replay_truncated sentinel is emitted first (seq_id 0).",
+        "description": "Subscribe once per page load. Receives push deltas for machines, requests, templates, and a heartbeat every 15 s.  Supports ?since= for replay and ?type= for filtering.  Add ?since_seq= (the Last-Event-ID of the last event received, sent automatically by standard SSE clients on reconnect) to enable gap-detection: replay resumes after that id, and if history has overflowed a replay_truncated sentinel is emitted first (seq_id 0).  Every real event carries an id: line so clients get Last-Event-ID semantics.",
         "operationId": "streamEvents",
         "parameters": [
           {

--- a/src/orb/api/middleware/__init__.py
+++ b/src/orb/api/middleware/__init__.py
@@ -2,6 +2,7 @@
 
 from .audit_log_middleware import AuditLogMiddleware
 from .auth_middleware import AuthMiddleware
+from .forwarded_proto_middleware import ForwardedProtoMiddleware
 from .logging_middleware import LoggingMiddleware
 from .rate_limit_middleware import RateLimitMiddleware
 from .read_only_middleware import ReadOnlyMiddleware
@@ -10,6 +11,7 @@ from .security_headers_middleware import SecurityHeadersMiddleware
 __all__: list[str] = [
     "AuditLogMiddleware",
     "AuthMiddleware",
+    "ForwardedProtoMiddleware",
     "LoggingMiddleware",
     "RateLimitMiddleware",
     "ReadOnlyMiddleware",

--- a/src/orb/api/middleware/forwarded_proto_middleware.py
+++ b/src/orb/api/middleware/forwarded_proto_middleware.py
@@ -1,0 +1,76 @@
+"""Resolve the request scheme from ``X-Forwarded-Proto`` behind a trusted proxy.
+
+When ORB runs behind a reverse proxy / load balancer that terminates TLS and
+forwards plain HTTP to the application, the ASGI ``scope["scheme"]`` seen by the
+app is ``"http"`` even though the client spoke HTTPS to the proxy.  With
+``require_https=True`` the ``HTTPSRedirectMiddleware`` would then issue a 307
+redirect to ``https://``, the proxy would forward the follow-up request as
+plain HTTP again, and the client would be trapped in an infinite redirect loop.
+
+This middleware fixes the loop at its source: when the *direct* peer is a
+configured trusted proxy, it rewrites ``scope["scheme"]`` from the
+``X-Forwarded-Proto`` header before downstream middleware (including the HTTPS
+redirect) inspect it.  Requests from untrusted peers are left untouched, so a
+client cannot spoof the scheme to bypass HTTPS enforcement.
+
+The trust model deliberately mirrors ``get_real_client_ip`` /
+``trusted_proxies`` used by the auth and rate-limit middleware: the forwarded
+header is only honoured when the connection originates from a known proxy.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+_FORWARDABLE_SCHEMES = {"http", "https", "ws", "wss"}
+
+
+class ForwardedProtoMiddleware:
+    """Rewrite ``scope["scheme"]`` from ``X-Forwarded-Proto`` for trusted proxies.
+
+    Args:
+        app: The wrapped ASGI application.
+        trusted_proxies: IP addresses of reverse proxies that are trusted to set
+            the ``X-Forwarded-Proto`` header.  When empty the middleware is a
+            no-op — the forwarded header is never honoured, so no client can
+            influence the resolved scheme.
+    """
+
+    def __init__(self, app: ASGIApp, trusted_proxies: list[str] | None = None) -> None:
+        self.app = app
+        self._trusted_proxies: frozenset[str] = frozenset(trusted_proxies or [])
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if (
+            scope["type"] in ("http", "websocket")
+            and self._trusted_proxies
+            and self._direct_peer_is_trusted(scope)
+        ):
+            forwarded_proto = self._forwarded_proto(scope)
+            if forwarded_proto in _FORWARDABLE_SCHEMES:
+                # Normalise http/https to ws/wss for websocket connections so the
+                # scheme stays consistent with the connection type.
+                if scope["type"] == "websocket":
+                    forwarded_proto = forwarded_proto.replace("http", "ws")
+                scope["scheme"] = forwarded_proto
+        await self.app(scope, receive, send)
+
+    def _direct_peer_is_trusted(self, scope: Scope) -> bool:
+        """Return True when the immediate connection peer is a trusted proxy."""
+        client = scope.get("client")
+        direct_ip = client[0] if client else None
+        return bool(direct_ip and direct_ip in self._trusted_proxies)
+
+    @staticmethod
+    def _forwarded_proto(scope: Scope) -> str | None:
+        """Return the last ``X-Forwarded-Proto`` value (lower-cased) or None."""
+        value: str | None = None
+        for name, raw in scope.get("headers", []):
+            if name == b"x-forwarded-proto":
+                # A proxy may append; the closest (rightmost/last) proxy's value
+                # is the most reliable, matching the XFF right-to-left model.
+                value = raw.decode("latin1").split(",")[-1].strip().lower()
+        return value

--- a/src/orb/api/routers/events.py
+++ b/src/orb/api/routers/events.py
@@ -470,7 +470,15 @@ async def stream_events(
                 history = sse_event_bus.history_since_with_seq(since_dt)
             else:
                 history = []
+            # Track the highest seq_id replayed from history so the live loop can
+            # de-dupe. subscribe() runs BEFORE this history snapshot, so any event
+            # published in that window lands in BOTH the history and the live
+            # queue; without this cursor it would be emitted twice with the same
+            # id:. The reserved sentinel seq_id 0 never advances the cursor.
+            max_replayed_seq = 0
             for event_type, payload, seq_id in history:
+                if seq_id and seq_id > max_replayed_seq:
+                    max_replayed_seq = seq_id
                 if _allowed(event_type, type_filter):
                     yield _format_sse(event_type, payload, seq_id)
 
@@ -492,6 +500,11 @@ async def stream_events(
                 # that predates the seq_id contract still streams (id: omitted).
                 event_type, payload = item[0], item[1]
                 seq_id = item[2] if len(item) > 2 else None
+                # De-dupe the history/live overlap: skip any live item whose
+                # seq_id was already replayed from history. Only real events carry
+                # a seq_id; legacy 2-tuples (seq_id=None) always pass through.
+                if seq_id is not None and seq_id <= max_replayed_seq:
+                    continue
                 if _allowed(event_type, type_filter):
                     yield _format_sse(event_type, payload, seq_id)
         finally:

--- a/src/orb/api/routers/events.py
+++ b/src/orb/api/routers/events.py
@@ -4,10 +4,17 @@ Provides a single persistent connection that the UI subscribes to once per page
 load, receiving push deltas for machines, requests, templates, and heartbeats.
 
 Wire protocol (standard SSE):
+    id: <seq_id>        (present for every real event; absent for heartbeat
+                         and the replay_truncated sentinel, whose reserved
+                         seq_id 0 must never be adopted as a Last-Event-ID)
     event: <type>
     data: {"json": "..."}
 
     (blank line terminates each event)
+
+    The ``id:`` line carries the monotonic ``seq_id`` so standard SSE clients
+    get Last-Event-ID semantics: on reconnect a client re-opens the stream with
+    ``?since_seq=<last id>`` and the server replays only events after that id.
 
 Event types emitted:
     machine.created / machine.updated / machine.deleted
@@ -17,10 +24,13 @@ Event types emitted:
 
 Query parameters:
     ?since=<ISO>        optional – replay events newer than this timestamp (best-effort)
-    ?since_seq=<int>    optional – combined with ?since= to enable gap-detection.
-                        When the server cannot fully serve the requested range
-                        (oldest surviving history entry is newer than since_seq+1),
-                        a synthetic sentinel event is emitted first:
+    ?since_seq=<int>    optional – the Last-Event-ID (seq_id) of the last event the
+                        client received; standard SSE clients resend it on reconnect.
+                        Enables gap-detection and works with OR without ?since= (when
+                        alone, replay resumes from the oldest retained event after
+                        since_seq).  When the server cannot fully serve the requested
+                        range (oldest surviving history entry is newer than
+                        since_seq+1), a synthetic sentinel event is emitted first:
                             event: replay_truncated
                             data: {"type": "replay_truncated", "since": <int>, "seq_id": 0}
                         seq_id 0 is reserved for this sentinel and is never issued by
@@ -72,6 +82,10 @@ logger = logging.getLogger(__name__)
 _HEARTBEAT_INTERVAL: float = 15.0  # seconds
 _QUEUE_MAXSIZE: int = 256  # drop oldest on overflow rather than blocking
 
+# Lower bound for "replay everything retained" when a client reconnects with
+# ?since_seq= but no ?since= timestamp — every recorded event has ts > _EPOCH.
+_EPOCH: datetime = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
 # Monotonic sequence counter — starts at 1.  seq_id 0 is reserved for the
 # replay_truncated sentinel and is never issued by this counter.
 _seq_counter = itertools.count(1)
@@ -112,21 +126,21 @@ class _SseEventBus:
     """
 
     def __init__(self) -> None:
-        self._subscribers: set[asyncio.Queue[Optional[tuple[str, dict]]]] = set()
+        self._subscribers: set[asyncio.Queue[Optional[tuple]]] = set()
         self._subscribers_lock: asyncio.Lock = asyncio.Lock()
         # Store recent events for ?since= replay (capped ring-buffer backed by deque
         # so append is O(1) and maxlen enforces the cap without manual slicing).
         self._history_max: int = 512
         self._history: deque[tuple[datetime, str, dict, int]] = deque(maxlen=self._history_max)
 
-    async def subscribe(self) -> asyncio.Queue[Optional[tuple[str, dict]]]:
+    async def subscribe(self) -> asyncio.Queue[Optional[tuple]]:
         """Register a new subscriber; returns its dedicated queue."""
-        q: asyncio.Queue[Optional[tuple[str, dict]]] = asyncio.Queue(maxsize=_QUEUE_MAXSIZE)
+        q: asyncio.Queue[Optional[tuple]] = asyncio.Queue(maxsize=_QUEUE_MAXSIZE)
         async with self._subscribers_lock:
             self._subscribers.add(q)
         return q
 
-    async def unsubscribe(self, q: asyncio.Queue[Optional[tuple[str, dict]]]) -> None:
+    async def unsubscribe(self, q: asyncio.Queue[Optional[tuple]]) -> None:
         """Remove subscriber. Safe to call even if already removed.
 
         ``set.discard`` is idempotent — unlike ``list.remove`` it does not
@@ -157,15 +171,20 @@ class _SseEventBus:
         async with self._subscribers_lock:
             snapshot = set(self._subscribers)
         for q in snapshot:
-            self._enqueue_for(q, event_type, payload)
+            self._enqueue_for(q, event_type, payload, seq_id)
 
     @staticmethod
     def _enqueue_for(
-        q: asyncio.Queue[Optional[tuple[str, dict]]],
+        q: asyncio.Queue[Optional[tuple]],
         event_type: str,
         payload: dict,
+        seq_id: int,
     ) -> None:
-        """Push (event_type, payload) onto a subscriber's queue.
+        """Push ``(event_type, payload, seq_id)`` onto a subscriber's queue.
+
+        The ``seq_id`` rides along so the SSE generator can emit the
+        wire-level ``id:`` line (Last-Event-ID) for each live event, giving
+        reconnecting clients a cursor to replay from.
 
         Strategy: check ``full()`` first (LBYL). If full, evict the
         oldest entry then enqueue. Both ``get_nowait``+``put_nowait``
@@ -173,18 +192,28 @@ class _SseEventBus:
         treat any race as "subscriber is too slow" and drop the event.
         """
         if not q.full():
-            q.put_nowait((event_type, payload))
+            q.put_nowait((event_type, payload, seq_id))
             return
         # Queue full — try to make room by evicting the oldest entry.
         evicted = _drain_one(q)
         if evicted and not q.full():
-            q.put_nowait((event_type, payload))
+            q.put_nowait((event_type, payload, seq_id))
             return
         logger.debug("SSE publish: subscriber queue full; dropping %s", event_type)
 
     def history_since(self, since: datetime) -> list[tuple[str, dict]]:
         """Return (event_type, payload) pairs recorded after *since*."""
-        return [(et, p) for (ts, et, p, _seq) in self._history if ts > since]
+        return [(et, p) for (et, p, _seq) in self.history_since_with_seq(since)]
+
+    def history_since_with_seq(self, since: datetime) -> list[tuple[str, dict, int]]:
+        """Return ``(event_type, payload, seq_id)`` triples recorded after *since*.
+
+        Seq-carrying sibling of ``history_since`` so the SSE generator can
+        emit the wire-level ``id:`` line for replayed events, giving a
+        reconnecting client the same Last-Event-ID cursor it would have
+        received live.
+        """
+        return [(et, p, seq) for (ts, et, p, seq) in self._history if ts > since]
 
     def history_since_seq(self, since: datetime, since_seq: int) -> list[tuple[str, dict]]:
         """Return history with gap-detection via ``since_seq``.
@@ -216,12 +245,34 @@ class _SseEventBus:
         ``seq_id`` is within the contiguous range (``oldest_seq <=
         since_seq + 1``), no sentinel is emitted.
         """
-        sentinel: tuple[str, dict] = (
+        return [(et, p) for (et, p, _seq) in self.history_since_seq_with_seq(since, since_seq)]
+
+    def history_since_seq_with_seq(
+        self, since: datetime, since_seq: int
+    ) -> list[tuple[str, dict, int]]:
+        """Seq-carrying sibling of ``history_since_seq``.
+
+        Returns ``(event_type, payload, seq_id)`` triples so the SSE
+        generator can emit each replayed event's wire-level ``id:`` line.
+        The gap-detection logic (deque overflow, empty-history restart,
+        client-ahead-of-bus) is identical to ``history_since_seq``; only the
+        tuple width differs.  The ``replay_truncated`` sentinel carries
+        seq_id 0 — the reserved marker that the generator never emits as an
+        ``id:`` so a client can never adopt it as a Last-Event-ID.
+        """
+        sentinel: tuple[str, dict, int] = (
             "replay_truncated",
             {"type": "replay_truncated", "since": since_seq, "seq_id": 0},
+            0,
         )
 
-        entries = [(ts, et, p, seq) for (ts, et, p, seq) in self._history if ts > since]
+        # Replay only events strictly after the client's cursor. Constrain by
+        # both the ISO ``since`` window (when supplied) and ``since_seq`` so a
+        # reconnect resumes exactly where the client left off instead of
+        # re-emitting events it already applied.
+        entries = [
+            (et, p, seq) for (ts, et, p, seq) in self._history if ts > since and seq > since_seq
+        ]
 
         if not self._history:
             # After a restart (or fresh bus): no history at all.  If the
@@ -238,15 +289,15 @@ class _SseEventBus:
         # Case 1: gap at the tail of history (deque overflow evicted events
         # that the client has not seen yet).
         if oldest_seq > since_seq + 1:
-            return [sentinel] + [(et, p) for (_ts, et, p, _seq) in entries]
+            return [sentinel] + entries
 
         # Case 2: the client claims to have seen a seq_id that is *ahead* of
         # anything this bus has ever issued — impossible unless the bus was
         # restarted and the counter reset.  Treat as truncated.
         if since_seq > newest_seq:
-            return [sentinel] + [(et, p) for (_ts, et, p, _seq) in entries]
+            return [sentinel] + entries
 
-        return [(et, p) for (_ts, et, p, _seq) in entries]
+        return entries
 
     def _record(self, ts: datetime, event_type: str, payload: dict, seq_id: int = 0) -> None:
         # deque(maxlen=...) discards the oldest entry automatically on overflow.
@@ -261,9 +312,17 @@ sse_event_bus = _SseEventBus()
 # ---------------------------------------------------------------------------
 
 
-def _format_sse(event_type: str, data: dict) -> str:
-    """Format a single SSE message block (terminated by double newline)."""
-    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+def _format_sse(event_type: str, data: dict, seq_id: Optional[int] = None) -> str:
+    """Format a single SSE message block (terminated by double newline).
+
+    When ``seq_id`` is a positive integer an ``id:`` line is prepended so
+    standard SSE clients record it as the Last-Event-ID and can reconnect
+    with ``?since_seq=<id>``.  ``seq_id`` of ``None`` (heartbeat) or ``0``
+    (the reserved ``replay_truncated`` sentinel) emits no ``id:`` line — a
+    client must never adopt those as a resume cursor.
+    """
+    prefix = f"id: {seq_id}\n" if seq_id else ""
+    return f"{prefix}event: {event_type}\ndata: {json.dumps(data)}\n\n"
 
 
 def _parse_since(since_str: Optional[str]) -> Optional[datetime]:
@@ -279,9 +338,23 @@ def _parse_since(since_str: Optional[str]) -> Optional[datetime]:
         return None
 
 
+# Control-signal event types that always pass the ?type= filter. The
+# replay_truncated sentinel tells a reconnecting client its local state is
+# stale; suppressing it because the client narrowed ?type= would reintroduce
+# the silent-gap bug it exists to close.
+_ALWAYS_ALLOWED: frozenset[str] = frozenset({"replay_truncated"})
+
+
 def _allowed(event_type: str, type_filter: Optional[set[str]]) -> bool:
-    """Return True if this event_type passes the type filter."""
+    """Return True if this event_type passes the type filter.
+
+    The ``replay_truncated`` control sentinel always passes, even under a
+    narrow ?type= allow-list, so a filtered client still learns it must
+    perform a full reload after a history gap.
+    """
     if type_filter is None:
+        return True
+    if event_type in _ALWAYS_ALLOWED:
         return True
     return event_type in type_filter
 
@@ -312,9 +385,11 @@ _TYPE_QUERY = Query(None, description="Comma-separated event type filter")
     description=(
         "Subscribe once per page load. Receives push deltas for machines, requests, "
         "templates, and a heartbeat every 15 s.  Supports ?since= for replay and "
-        "?type= for filtering.  Add ?since_seq= alongside ?since= to enable "
-        "gap-detection: if history has overflowed a replay_truncated sentinel is "
-        "emitted first (seq_id 0)."
+        "?type= for filtering.  Add ?since_seq= (the Last-Event-ID of the last "
+        "event received, sent automatically by standard SSE clients on reconnect) "
+        "to enable gap-detection: replay resumes after that id, and if history has "
+        "overflowed a replay_truncated sentinel is emitted first (seq_id 0).  Every "
+        "real event carries an id: line so clients get Last-Event-ID semantics."
     ),
     response_class=StreamingResponse,
     responses={
@@ -340,14 +415,21 @@ async def stream_events(
     async def generator() -> AsyncGenerator[str, None]:
         q = await sse_event_bus.subscribe()
         try:
-            if since_dt is not None:
-                if since_seq is not None:
-                    history = sse_event_bus.history_since_seq(since_dt, since_seq)
-                else:
-                    history = sse_event_bus.history_since(since_dt)
-                for event_type, payload in history:
-                    if _allowed(event_type, type_filter):
-                        yield _format_sse(event_type, payload)
+            # Reconnect replay. ?since_seq= (Last-Event-ID) drives gap-detection
+            # and works with OR without ?since=: a standard SSE client resuming
+            # from a Last-Event-ID sends only since_seq, so we fall back to the
+            # epoch to replay everything the bus still retains after that id.
+            if since_seq is not None:
+                history = sse_event_bus.history_since_seq_with_seq(
+                    since_dt if since_dt is not None else _EPOCH, since_seq
+                )
+            elif since_dt is not None:
+                history = sse_event_bus.history_since_with_seq(since_dt)
+            else:
+                history = []
+            for event_type, payload, seq_id in history:
+                if _allowed(event_type, type_filter):
+                    yield _format_sse(event_type, payload, seq_id)
 
             while True:
                 try:
@@ -362,9 +444,13 @@ async def stream_events(
                     continue
                 if item is None:
                     break
-                event_type, payload = item
+                # Queue items are (event_type, payload, seq_id). Tolerate legacy
+                # 2-tuples (event_type, payload) so any external enqueuer or test
+                # that predates the seq_id contract still streams (id: omitted).
+                event_type, payload = item[0], item[1]
+                seq_id = item[2] if len(item) > 2 else None
                 if _allowed(event_type, type_filter):
-                    yield _format_sse(event_type, payload)
+                    yield _format_sse(event_type, payload, seq_id)
         finally:
             await sse_event_bus.unsubscribe(q)
 

--- a/src/orb/api/routers/events.py
+++ b/src/orb/api/routers/events.py
@@ -61,6 +61,7 @@ import asyncio
 import itertools
 import json
 import logging
+import time
 from collections import deque
 from datetime import datetime, timezone
 from typing import AsyncGenerator, Optional
@@ -86,9 +87,24 @@ _QUEUE_MAXSIZE: int = 256  # drop oldest on overflow rather than blocking
 # ?since_seq= but no ?since= timestamp — every recorded event has ts > _EPOCH.
 _EPOCH: datetime = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
-# Monotonic sequence counter — starts at 1.  seq_id 0 is reserved for the
-# replay_truncated sentinel and is never issued by this counter.
-_seq_counter = itertools.count(1)
+
+def _boot_base() -> int:
+    """Return a per-process, monotonic-across-restarts seq_id floor.
+
+    The seq counter must not restart from 1 on every process boot, otherwise a
+    client holding a cursor from a previous generation (e.g. since_seq=2) would
+    match freshly-issued low ids after a restart and silently skip the genuinely
+    new events (the seq 1..5 collision).  Seeding the counter from wall-clock
+    microseconds gives every boot a strictly higher floor than the last, so a
+    stale cross-restart cursor always lands *below* the new generation's ids and
+    is detectable as a gap.
+
+    Microsecond resolution keeps the base (~1.7e15 today) well under JavaScript's
+    2**53 safe-integer limit, so the single-integer ``id:`` wire cursor still
+    round-trips through every SDK reader unchanged — no wire-format, spec, or
+    client change is needed to carry the generation token.
+    """
+    return int(time.time() * 1_000_000)
 
 
 def _drain_one(q: asyncio.Queue) -> bool:
@@ -117,21 +133,32 @@ class _SseEventBus:
     Unsubscribe uses ``set.discard`` which is idempotent — no KeyError if
     the subscriber was already removed.
 
-    Every published event carries a monotonic ``seq_id`` (from the
-    module-level ``_seq_counter``).  The history deque stores
+    Every published event carries a monotonic ``seq_id`` (from this
+    instance's ``_seq_counter``, seeded above the previous boot).  The history deque stores
     ``(ts, event_type, payload, seq_id)`` tuples.  On reconnect the
     caller may pass ``since_seq`` to detect gaps; ``history_since_seq``
     returns a ``replay_truncated`` sentinel when the deque has overflowed
     and the requested range can no longer be served completely.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, boot_base: int = 0) -> None:
         self._subscribers: set[asyncio.Queue[Optional[tuple]]] = set()
         self._subscribers_lock: asyncio.Lock = asyncio.Lock()
         # Store recent events for ?since= replay (capped ring-buffer backed by deque
         # so append is O(1) and maxlen enforces the cap without manual slicing).
         self._history_max: int = 512
         self._history: deque[tuple[datetime, str, dict, int]] = deque(maxlen=self._history_max)
+        # Generation floor: the highest seq_id from a *previous* process boot.
+        # seq_ids issued by this instance are all strictly greater than
+        # ``_boot_base``, so any ``since_seq`` in ``(0, _boot_base]`` belongs to
+        # an earlier generation and must trigger replay_truncated.  Defaults to 0
+        # (no floor) so a directly-constructed bus behaves like a fresh counter
+        # starting at 1 — the module singleton passes a real boot base.
+        self._boot_base: int = boot_base
+        # Monotonic sequence counter for this generation.  Starts at
+        # ``boot_base + 1`` so ids never collide with a prior boot; seq_id 0 stays
+        # reserved for the replay_truncated sentinel and is never issued.
+        self._seq_counter = itertools.count(boot_base + 1)
 
     async def subscribe(self) -> asyncio.Queue[Optional[tuple]]:
         """Register a new subscriber; returns its dedicated queue."""
@@ -165,7 +192,7 @@ class _SseEventBus:
         the queue has slack, avoiding the QueueEmpty / QueueFull race
         windows entirely.
         """
-        seq_id = next(_seq_counter)
+        seq_id = next(self._seq_counter)
         ts = datetime.now(timezone.utc)
         self._record(ts, event_type, payload, seq_id)
         async with self._subscribers_lock:
@@ -220,7 +247,13 @@ class _SseEventBus:
 
         Emits a synthetic ``replay_truncated`` sentinel as the first item
         whenever the caller's ``since_seq`` claim cannot be satisfied by
-        whatever the bus holds today.  This covers two distinct cases:
+        whatever the bus holds today.  This covers three distinct cases:
+
+        0. **Cross-restart generation gap** — ``0 < since_seq <= _boot_base``,
+           i.e. the cursor was issued by a previous process boot.  This
+           instance only issues seq_ids above ``_boot_base``, so such a cursor
+           is stale; without this check a low pre-restart cursor would match
+           the fresh generation's low ids and skip the events in between.
 
         1. **Deque overflow** — the oldest surviving deque entry has a
            ``seq_id`` greater than ``since_seq + 1``, meaning at least one
@@ -274,6 +307,16 @@ class _SseEventBus:
             (et, p, seq) for (ts, et, p, seq) in self._history if ts > since and seq > since_seq
         ]
 
+        # Case 0 (cross-restart generation gap): the client's cursor belongs to a
+        # previous process boot.  This instance only issues seq_ids strictly
+        # greater than ``_boot_base``, so any ``0 < since_seq <= _boot_base`` is a
+        # stale cursor from an earlier generation.  Without this check a client at
+        # since_seq=2 reconnecting after a restart (new events 1..5 in the fresh
+        # deque) would match ``seq > 2`` and receive only 3,4,5 — silently
+        # skipping the genuinely-new seq 1,2.  Force a full resync instead.
+        if 0 < since_seq <= self._boot_base:
+            return [sentinel] + entries
+
         if not self._history:
             # After a restart (or fresh bus): no history at all.  If the
             # caller claims to have seen events (since_seq > 0), we cannot
@@ -304,7 +347,7 @@ class _SseEventBus:
         self._history.append((ts, event_type, payload, seq_id))
 
 
-sse_event_bus = _SseEventBus()
+sse_event_bus = _SseEventBus(boot_base=_boot_base())
 
 
 # ---------------------------------------------------------------------------

--- a/src/orb/api/server.py
+++ b/src/orb/api/server.py
@@ -283,6 +283,7 @@ def create_fastapi_app(server_config: Any) -> Any:
     from orb.api.middleware import (
         AuditLogMiddleware,
         AuthMiddleware,
+        ForwardedProtoMiddleware,
         LoggingMiddleware,
         RateLimitMiddleware,
         ReadOnlyMiddleware,
@@ -337,6 +338,32 @@ def create_fastapi_app(server_config: Any) -> Any:
     if _require_https:
         app.add_middleware(cast(Any, HTTPSRedirectMiddleware))
         logger.info("HTTPS redirect middleware enabled (HTTP requests redirect to HTTPS with 307)")
+
+        # Behind a TLS-terminating reverse proxy the connection to ORB is plain
+        # HTTP, so scope["scheme"] is "http" and HTTPSRedirectMiddleware would
+        # 307-redirect every request into an infinite loop (the proxy forwards
+        # the follow-up as HTTP again).  Resolve the real scheme from
+        # X-Forwarded-Proto for configured trusted proxies BEFORE the redirect
+        # middleware runs.  Added after HTTPSRedirectMiddleware so it executes
+        # first (Starlette runs middleware in reverse registration order).
+        # Only trusted proxies are honoured, so HTTPS enforcement is not
+        # weakened for direct/untrusted clients.
+        if server_config.trusted_proxies:
+            app.add_middleware(
+                cast(Any, ForwardedProtoMiddleware),
+                trusted_proxies=server_config.trusted_proxies,
+            )
+            logger.info(
+                "X-Forwarded-Proto resolution enabled for trusted proxies "
+                "(prevents HTTPS redirect loops behind TLS-terminating proxies)"
+            )
+        else:
+            logger.warning(
+                "require_https is enabled but no trusted_proxies are configured. "
+                "If ORB runs behind a reverse proxy that terminates TLS and forwards "
+                "plain HTTP, requests will be caught in an HTTPS redirect loop. Set "
+                "server.trusted_proxies to the proxy IP(s) so X-Forwarded-Proto is honoured."
+            )
 
     # Add trusted host middleware only when a restrictive allowlist is provided.
     # An empty list or a wildcard ('*') disables Host-header validation entirely,

--- a/src/orb/application/services/orchestration/get_request_status.py
+++ b/src/orb/application/services/orchestration/get_request_status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 
 from orb.application.dto.queries import SyncAndGetRequestQuery, SyncAndListActiveRequestsQuery
 from orb.application.ports.command_bus_port import CommandBusPort
@@ -104,10 +105,14 @@ class GetRequestStatusOrchestrator(OrchestratorBase[GetRequestStatusInput, GetRe
     async def _poll_until_terminal(self, input: GetRequestStatusInput) -> list[dict]:
         """Poll every requested ID until all reach a terminal state or timeout.
 
-        Wall-clock time is tracked from the first poll against
-        ``input.timeout_seconds``; the last snapshot is returned when the cap is
-        reached even if some requests are still non-terminal, so callers always
-        get the freshest known state.
+        Elapsed time is measured as true wall-clock via ``time.monotonic()``
+        deltas from the first poll against ``input.timeout_seconds``, so the real
+        latency of each ``_fetch_once`` counts toward the budget and the total
+        wait never overruns the caller's cap. (An interval-counting approach that
+        added a constant ``_POLL_INTERVAL_SECONDS`` per loop ignored fetch
+        latency and could overshoot the timeout substantially.) The last snapshot
+        is returned when the cap is reached even if some requests are still
+        non-terminal, so callers always get the freshest known state.
 
         A transient sync error (an ``error`` entry with no terminal status and
         no ``not_found`` flag) does NOT immediately end the poll — the provider
@@ -118,16 +123,18 @@ class GetRequestStatusOrchestrator(OrchestratorBase[GetRequestStatusInput, GetRe
         ``failed``/``complete`` status, or ``not_found``) still stops the poll
         immediately.
         """
-        elapsed = 0
+        start = time.monotonic()
         request_dicts = await self._fetch_once(input)
         consecutive_errors = 1 if self._has_transient_error(request_dicts) else 0
-        while not self._all_terminal(request_dicts) and elapsed < input.timeout_seconds:
+        while (
+            not self._all_terminal(request_dicts)
+            and (time.monotonic() - start) < input.timeout_seconds
+        ):
             if consecutive_errors >= _MAX_CONSECUTIVE_POLL_ERRORS:
                 # Persistent transient failures — stop retrying and surface the
                 # last snapshot rather than blocking until timeout.
                 break
             await asyncio.sleep(_POLL_INTERVAL_SECONDS)
-            elapsed += _POLL_INTERVAL_SECONDS
             request_dicts = await self._fetch_once(input)
             if self._has_transient_error(request_dicts):
                 consecutive_errors += 1

--- a/src/orb/application/services/orchestration/get_request_status.py
+++ b/src/orb/application/services/orchestration/get_request_status.py
@@ -8,6 +8,7 @@ from orb.application.dto.queries import SyncAndGetRequestQuery, SyncAndListActiv
 from orb.application.ports.command_bus_port import CommandBusPort
 from orb.application.ports.query_bus_port import QueryBusPort
 from orb.application.services.orchestration.base import (
+    MAX_CONSECUTIVE_POLL_ERRORS as _MAX_CONSECUTIVE_POLL_ERRORS,
     TERMINAL_STATUSES as _TERMINAL_STATUSES,
     OrchestratorBase,
 )
@@ -107,22 +108,72 @@ class GetRequestStatusOrchestrator(OrchestratorBase[GetRequestStatusInput, GetRe
         ``input.timeout_seconds``; the last snapshot is returned when the cap is
         reached even if some requests are still non-terminal, so callers always
         get the freshest known state.
+
+        A transient sync error (an ``error`` entry with no terminal status and
+        no ``not_found`` flag) does NOT immediately end the poll — the provider
+        may simply have blipped. Up to ``_MAX_CONSECUTIVE_POLL_ERRORS``
+        consecutive polls carrying such a transient error are tolerated (in
+        line with the acquire/return sibling loops) before the poll gives up
+        and returns the last snapshot. A genuine terminal state (a real
+        ``failed``/``complete`` status, or ``not_found``) still stops the poll
+        immediately.
         """
         elapsed = 0
         request_dicts = await self._fetch_once(input)
+        consecutive_errors = 1 if self._has_transient_error(request_dicts) else 0
         while not self._all_terminal(request_dicts) and elapsed < input.timeout_seconds:
+            if consecutive_errors >= _MAX_CONSECUTIVE_POLL_ERRORS:
+                # Persistent transient failures — stop retrying and surface the
+                # last snapshot rather than blocking until timeout.
+                break
             await asyncio.sleep(_POLL_INTERVAL_SECONDS)
             elapsed += _POLL_INTERVAL_SECONDS
             request_dicts = await self._fetch_once(input)
+            if self._has_transient_error(request_dicts):
+                consecutive_errors += 1
+            else:
+                consecutive_errors = 0
         return request_dicts
 
     @staticmethod
-    def _all_terminal(request_dicts: list[dict]) -> bool:
-        """Return True once every entry is terminal, errored, or not found."""
+    def _has_transient_error(request_dicts: list[dict]) -> bool:
+        """Return True if any entry is a transient sync error.
+
+        A transient sync error is an ``error`` entry that is neither a
+        ``not_found`` (a genuine 404) nor accompanied by a terminal status (a
+        genuine request failure). Those two cases are real terminal outcomes
+        and must not be treated as retryable blips.
+        """
         for entry in request_dicts:
-            if entry.get("not_found") or entry.get("error"):
+            if entry.get("not_found"):
+                continue
+            if not entry.get("error"):
                 continue
             status = str(entry.get("status", "")).lower()
+            if status not in _TERMINAL_STATUSES:
+                return True
+        return False
+
+    @staticmethod
+    def _all_terminal(request_dicts: list[dict]) -> bool:
+        """Return True once every entry reaches a terminal outcome.
+
+        Terminal outcomes are: ``not_found`` (a genuine 404), an entry carrying
+        a real terminal ``status`` (e.g. ``failed``/``complete``), or a
+        non-error entry whose status is terminal. A transient sync error (an
+        ``error`` entry with no terminal status) is NOT terminal, so polling
+        continues and can recover once the provider responds again.
+        """
+        for entry in request_dicts:
+            if entry.get("not_found"):
+                continue
+            status = str(entry.get("status", "")).lower()
+            if entry.get("error"):
+                # Only a terminal status makes an errored entry terminal;
+                # a bare transient error keeps the poll going.
+                if status in _TERMINAL_STATUSES:
+                    continue
+                return False
             if status not in _TERMINAL_STATUSES:
                 return False
         return True

--- a/src/orb/config/managers/configuration_manager.py
+++ b/src/orb/config/managers/configuration_manager.py
@@ -71,6 +71,13 @@ class ConfigurationManager:
         # top of the user's ORIGINAL config on ``save`` so that the merged,
         # env-expanded runtime config never reaches disk. See ``save``.
         self._pending_edits: Dict[str, Any] = {}
+        # Dot-notation paths recorded via ``set`` (leaf REPLACE semantics).
+        # ``set`` replaces a value outright in memory, so on ``save`` these
+        # paths must OVERWRITE the on-disk value rather than deep-merge into
+        # it. Without this, ``set('provider', {...})`` would leave stale
+        # sibling keys (e.g. an old ``providers`` list) on disk after a
+        # deep-merge, diverging from the in-memory state after reload.
+        self._replace_paths: set[tuple[str, ...]] = set()
         self._type_converter: Optional[ConfigTypeConverter] = None
         self._path_resolver: Optional[ConfigPathResolver] = None
         self._provider_manager: Optional[ProviderConfigManager] = None
@@ -187,6 +194,7 @@ class ConfigurationManager:
             self._cache_manager.clear_cache()
             self._raw_config = None
             self._pending_edits = {}
+            self._replace_paths = set()
             self._app_config = None
             self._type_converter = None
             self._path_resolver = None
@@ -252,7 +260,14 @@ class ConfigurationManager:
         self._cache_manager.clear_cache()
 
     def _record_edit(self, key: str, value: Any) -> None:
-        """Record a single dot-notation edit into the pending-edits overlay."""
+        """Record a single dot-notation edit into the pending-edits overlay.
+
+        ``set`` has REPLACE semantics: the value overwrites whatever was at
+        ``key`` in memory. To keep the persisted config in step with memory,
+        the full dot-notation path is recorded in ``_replace_paths`` so that
+        on ``save`` the on-disk value at that path is overwritten wholesale
+        rather than deep-merged (which would retain stale sibling keys).
+        """
         keys = key.split(".")
         target = self._pending_edits
         for k in keys[:-1]:
@@ -262,13 +277,43 @@ class ConfigurationManager:
                 target[k] = existing
             target = existing
         target[keys[-1]] = value
+        self._replace_paths.add(tuple(keys))
+
+    def _apply_edits(self, base: dict[str, Any], update: dict[str, Any]) -> None:
+        """Apply the pending-edits overlay onto *base* for persistence.
+
+        Deep-merges ``update`` into ``base`` (so ``update`` edits and scalar
+        leaf edits keep their merge/overwrite behaviour), except that any path
+        recorded in ``_replace_paths`` (a ``set``-style REPLACE) overwrites the
+        value at that path outright — matching in-memory semantics and dropping
+        stale sibling keys that a deep-merge would otherwise retain.
+        """
+        self._merge_edits(base, update, replace_paths=self._replace_paths)
 
     @classmethod
-    def _merge_edits(cls, base: dict[str, Any], update: dict[str, Any]) -> None:
-        """Deep-merge *update* into *base* (dicts merge, other values replace)."""
+    def _merge_edits(
+        cls,
+        base: dict[str, Any],
+        update: dict[str, Any],
+        replace_paths: set[tuple[str, ...]] | None = None,
+        _prefix: tuple[str, ...] = (),
+    ) -> None:
+        """Deep-merge *update* into *base* (dicts merge, other values replace).
+
+        When a path (built from ``_prefix`` + key) is in ``replace_paths`` the
+        value overwrites ``base`` wholesale instead of recursing, so a ``set``
+        of a dict subtree does not leave stale sibling keys behind on disk.
+        """
         for key, value in update.items():
-            if key in base and isinstance(base[key], dict) and isinstance(value, dict):
-                cls._merge_edits(base[key], value)
+            path = _prefix + (key,)
+            is_replace = replace_paths is not None and path in replace_paths
+            if (
+                not is_replace
+                and key in base
+                and isinstance(base[key], dict)
+                and isinstance(value, dict)
+            ):
+                cls._merge_edits(base[key], value, replace_paths, path)
             else:
                 base[key] = value
 
@@ -415,7 +460,7 @@ class ConfigurationManager:
 
         try:
             raw_config = self._load_original_user_config()
-            self._merge_edits(raw_config, self._pending_edits)
+            self._apply_edits(raw_config, self._pending_edits)
             target = Path(config_path)
             target.parent.mkdir(parents=True, exist_ok=True)
             fd, tmp_name = tempfile.mkstemp(

--- a/src/orb/infrastructure/logging/logger.py
+++ b/src/orb/infrastructure/logging/logger.py
@@ -38,6 +38,40 @@ class ColoredFormatter(logging.Formatter):
         return super().format(record)
 
 
+# Attribute names that ``logging`` always sets on a ``LogRecord``.  Anything on
+# a record that is NOT in this set was supplied by the caller via ``extra=`` (or
+# bound context) and therefore represents structured application data that must
+# be preserved in the serialized JSON — most importantly the security fields on
+# audit records (event_type, user_id, client_ip, path, method, reason, ...).
+_STANDARD_LOGRECORD_ATTRS: frozenset[str] = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "taskName",
+        "message",
+        "asctime",
+    }
+)
+
+
 class JsonFormatter(logging.Formatter):
     """Format log records as JSON."""
 
@@ -78,17 +112,23 @@ class JsonFormatter(logging.Formatter):
         if record.exc_info:
             message["exception"] = self.formatException(record.exc_info)
 
-        if hasattr(record, "request_id"):
-            message["request_id"] = record.request_id  # type: ignore[attr-defined]
+        # Merge any caller-supplied fields.  Fields passed via stdlib ``extra=``
+        # are set directly as (non-standard) attributes on the record, so we
+        # merge every attribute that is not part of the standard LogRecord set.
+        # This preserves structured data such as the security fields on audit
+        # records (event_type, user_id, client_ip, path, method, reason, ...),
+        # which would otherwise be silently dropped.  Values are only included
+        # if they serialize cleanly to avoid corrupting the JSON line.
+        for key, value in record.__dict__.items():
+            if key in _STANDARD_LOGRECORD_ATTRS or key.startswith("_"):
+                continue
+            if key == "extra" and isinstance(value, dict):
+                # Back-compat: a caller may pass ``extra={"extra": {...}}``.
+                message.update(value)
+                continue
+            message[key] = value
 
-        if hasattr(record, "correlation_id"):
-            message["correlation_id"] = record.correlation_id  # type: ignore[attr-defined]
-
-        # Include any extra fields provided in the log call
-        if hasattr(record, "extra"):
-            message.update(record.extra)  # type: ignore[attr-defined]
-
-        return json.dumps(message)
+        return json.dumps(message, default=str)
 
 
 class ContextLogger(logging.Logger):
@@ -318,6 +358,12 @@ def setup_audit_logger(audit_log_file: Optional[str] = None) -> None:
     # Prevent audit records from propagating to the root logger when a
     # dedicated handler is configured — keeps the two streams independent.
     audit_log.propagate = False
+    # Pin the audit logger to INFO regardless of the application's root log
+    # level.  Audit events are emitted at INFO; without this, a production
+    # config of logging.level=WARNING would make orb.audit inherit WARNING as
+    # its effective level and silently discard every audit record (a 0-byte
+    # audit trail).  The audit stream must be independent of the app log level.
+    audit_log.setLevel(logging.INFO)
 
     json_fmt = JsonFormatter(log_type="audit")
 
@@ -339,6 +385,9 @@ def setup_audit_logger(audit_log_file: Optional[str] = None) -> None:
                 encoding="utf-8",
             )
             fh.setFormatter(json_fmt)
+            # The handler must also admit INFO records so nothing is filtered
+            # at the handler stage.
+            fh.setLevel(logging.INFO)
             audit_log.addHandler(fh)
     # Structured stderr handler — only add if no handlers exist yet.
     elif not audit_log.handlers:
@@ -346,6 +395,7 @@ def setup_audit_logger(audit_log_file: Optional[str] = None) -> None:
 
         sh = logging.StreamHandler(sys.stderr)
         sh.setFormatter(json_fmt)
+        sh.setLevel(logging.INFO)
         audit_log.addHandler(sh)
 
 

--- a/src/orb/ui/api_http.py
+++ b/src/orb/ui/api_http.py
@@ -453,17 +453,32 @@ async def get_provider_schemas() -> dict[str, list[dict[str, Any]]]:
         return {}
 
 
-async def subscribe_events(event_types=None):
+async def subscribe_events(event_types=None, since_seq: int | None = None):
     """Yield (event_type, data) from the backend SSE stream.
 
     ``event_types`` is an optional iterable that filters server-side via
     ?type=a,b,c.
+
+    ``since_seq`` seeds the reconnect cursor: the initial connection resumes
+    from it (``?since_seq=``) so a page re-mount after a brief outage replays
+    missed events. On every reconnect ``stream_sse`` rebuilds the URL via the
+    ``url_builder`` below with the last SSE ``id:`` it saw, so events missed
+    during a connection blip are replayed instead of silently dropped — the
+    fix for status transitions being lost on reconnect.
     """
     from .sse_client import stream_sse
 
-    params = ""
-    if event_types:
-        params = "?type=" + ",".join(sorted(event_types))
-    url = f"{ORB_BASE_URL}{ORB_ROOT_PREFIX}/api/v1/events{params}"
-    async for evt, data in stream_sse(url, headers=_headers()):
+    def _build_url(last_event_id: int | None) -> str:
+        query: list[str] = []
+        if event_types:
+            query.append("type=" + ",".join(sorted(event_types)))
+        # Prefer the freshest cursor: the id observed on the last open stream,
+        # falling back to the caller-seeded since_seq for the very first connect.
+        resume_from = last_event_id if last_event_id is not None else since_seq
+        if resume_from is not None:
+            query.append(f"since_seq={resume_from}")
+        suffix = ("?" + "&".join(query)) if query else ""
+        return f"{ORB_BASE_URL}{ORB_ROOT_PREFIX}/api/v1/events{suffix}"
+
+    async for evt, data in stream_sse(_build_url(None), headers=_headers(), url_builder=_build_url):
         yield evt, data

--- a/src/orb/ui/pages/requests.py
+++ b/src/orb/ui/pages/requests.py
@@ -1263,13 +1263,65 @@ class RequestsState(AppState):
             status = str(data.get("new_status") or data.get("status") or "")
         return rid, status.lower()
 
-    def _apply_request_status_event(self, event_type: str, data: dict[str, Any]) -> bool:
-        """Patch the matching request row's status from an SSE event.
+    # Raw-request fields that feed the row's count columns and progress bar
+    # (see ``request_rows``). When an SSE event carries any of these, patching
+    # them keeps the counts/progress consistent with the new status instead of
+    # leaving stale values behind until the next full load.
+    _ROW_COUNT_FIELDS: tuple[str, ...] = (
+        "requested_count",
+        "successful_count",
+        "failed_count",
+        "returned_count",
+        "running_count",
+        "pending_count",
+        "desired_capacity",
+        "fulfilled_units",
+        "target_units",
+        "success_rate",
+        "machines",
+        "machine_ids",
+        "resource_ids",
+    )
 
-        Matches on ``request_id`` and rewrites only the ``status`` field of
-        that row (the status badge and progress-bar colour derive from it).
-        Rows for requests not currently loaded — e.g. filtered out by the
-        active tab — are ignored; they surface on the next full load.
+    @classmethod
+    def _row_updates_from_event(
+        cls, event_type: str, data: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Return the raw-request fields to patch from an SSE event payload.
+
+        Beyond ``status``, this pulls through any count/progress source fields
+        the payload carries (see ``_ROW_COUNT_FIELDS``) so the row's counts and
+        progress bar move in step with the status transition — matching what a
+        full refresh would render rather than only repainting the badge.
+
+        A ``RequestCompletedEvent`` carries ``machine_ids`` but no explicit
+        count; the fulfilled count is derived from it so the progress bar
+        reaches its final value on completion.
+        """
+        updates: dict[str, Any] = {}
+        for field in cls._ROW_COUNT_FIELDS:
+            if field in data and data[field] is not None:
+                updates[field] = data[field]
+        # Completed events report the fulfilled machines as a list; derive the
+        # fulfilled count from it when the payload does not carry one directly.
+        machine_ids = data.get("machine_ids")
+        if (
+            event_type == "RequestCompletedEvent"
+            and isinstance(machine_ids, list)
+            and "successful_count" not in updates
+        ):
+            updates["successful_count"] = len(machine_ids)
+        return updates
+
+    def _apply_request_status_event(self, event_type: str, data: dict[str, Any]) -> bool:
+        """Patch the matching request row from an SSE event.
+
+        Matches on ``request_id`` and rewrites the ``status`` field plus any
+        count/progress source fields the event carries (see
+        ``_row_updates_from_event``) so the status badge, counts columns and
+        progress bar all move together. Rows for requests not currently loaded
+        — e.g. filtered out by the active tab — are ignored; they surface on
+        the next full load.
 
         Returns True when a row was actually changed so callers/tests can
         assert the list was patched. Reassigns ``self.requests`` to a new
@@ -1278,14 +1330,25 @@ class RequestsState(AppState):
         rid, status = self._status_from_event(event_type, data)
         if not rid or not status:
             return False
+        extra = self._row_updates_from_event(event_type, data)
         updated = False
         new_rows: list[dict[str, Any]] = []
         for r in self.requests:
-            if r.get("request_id") == rid and (r.get("status") or "").lower() != status:
-                patched = dict(r)
+            if r.get("request_id") != rid:
+                new_rows.append(r)
+                continue
+            patched = dict(r)
+            row_changed = False
+            if (patched.get("status") or "").lower() != status:
                 patched["status"] = status
-                new_rows.append(patched)
+                row_changed = True
+            for key, value in extra.items():
+                if patched.get(key) != value:
+                    patched[key] = value
+                    row_changed = True
+            if row_changed:
                 updated = True
+                new_rows.append(patched)
             else:
                 new_rows.append(r)
         if updated:

--- a/src/orb/ui/pages/requests.py
+++ b/src/orb/ui/pages/requests.py
@@ -78,6 +78,13 @@ _REQUEST_STATUS_EVENT_TYPES: set[str] = {
     "RequestFailedEvent",
 }
 
+# Control sentinel the server emits on reconnect when it could not replay the
+# full gap (the client's last-seen event was already evicted from history).
+# The server always lets this through the ?type= filter; when the row-update
+# path sees it, incremental patches can no longer be trusted so it re-fetches
+# the whole list to self-heal.
+_REPLAY_TRUNCATED_EVENT: str = "replay_truncated"
+
 
 def _empty_request_skeleton() -> dict[str, Any]:
     """UI mirror of REST snake_case response shape.
@@ -1284,9 +1291,7 @@ class RequestsState(AppState):
     )
 
     @classmethod
-    def _row_updates_from_event(
-        cls, event_type: str, data: dict[str, Any]
-    ) -> dict[str, Any]:
+    def _row_updates_from_event(cls, event_type: str, data: dict[str, Any]) -> dict[str, Any]:
         """Return the raw-request fields to patch from an SSE event payload.
 
         Beyond ``status``, this pulls through any count/progress source fields
@@ -1355,6 +1360,30 @@ class RequestsState(AppState):
             self.requests = new_rows
         return updated
 
+    async def _reload_request_rows(self) -> None:
+        """Re-fetch the current tab's rows from the API and replace the list.
+
+        Extracted from ``load`` so the SSE ``replay_truncated`` handler can
+        self-heal after a history gap without duplicating the fetch/sort
+        logic. Assumes the caller does NOT already hold the state lock (it
+        performs its own ``async with self`` around the state mutation) so it
+        is safe to call from a ``background=True`` task.
+        """
+        async with self:
+            tab = self.tab
+            page_size = self.page_size
+        if tab == "returns":
+            res = await api.list_return_requests(limit=page_size)
+        else:
+            status_filter = _TAB_TO_STATUS.get(tab)
+            res = await api.list_requests(status=status_filter, limit=page_size)
+        async with self:
+            raw = res.get("requests", [])
+            self.requests = sorted(raw, key=lambda r: r.get("created_at") or "", reverse=True)
+            self.next_cursor = res.get("next_cursor") or ""
+            self.api_total_count = int(res.get("total_count") or len(raw))
+            self.last_refresh = datetime.datetime.now().strftime("%H:%M:%S")
+
     @rx.event(background=True)
     async def stream_status_events(self) -> None:
         """Subscribe to the backend SSE stream and patch request rows live.
@@ -1365,9 +1394,13 @@ class RequestsState(AppState):
         operator's scroll position, checkbox selection and any open drawer
         are preserved.
 
-        ``api.subscribe_events`` (via ``sse_client.stream_sse``) already
-        reconnects with exponential backoff (max 30 s) on disconnect, so this
-        loop only needs to drain events. Single-flight guarded by
+        ``api.subscribe_events`` (via ``sse_client.stream_sse``) reconnects
+        with exponential backoff (max 30 s) on disconnect AND resumes from the
+        last SSE ``id:`` it saw, so status transitions that occurred during a
+        brief outage are replayed rather than lost. When the gap is too large
+        to replay, the server sends a ``replay_truncated`` sentinel; we react
+        by re-fetching the whole list so a stuck row (e.g. left ``in_progress``
+        after a missed terminal event) self-heals. Single-flight guarded by
         ``_sse_started`` so a page re-mount does not open a second stream.
         """
         async with self:
@@ -1378,6 +1411,12 @@ class RequestsState(AppState):
             async for event_type, data in api.subscribe_events(
                 event_types=_REQUEST_STATUS_EVENT_TYPES
             ):
+                if event_type == _REPLAY_TRUNCATED_EVENT:
+                    # History gap too large to replay incrementally — the local
+                    # list may hold stale statuses. Re-fetch everything so any
+                    # row stuck mid-flight is reconciled to its true state.
+                    await self._reload_request_rows()
+                    continue
                 async with self:
                     self._apply_request_status_event(event_type, data)
         finally:

--- a/src/orb/ui/sse_client.py
+++ b/src/orb/ui/sse_client.py
@@ -7,8 +7,9 @@ intentionally has no external dependencies beyond httpx.
 
 from __future__ import annotations
 
+import asyncio
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 import httpx
@@ -19,19 +20,35 @@ async def stream_sse(
     *,
     headers: dict[str, str] | None = None,
     timeout: httpx.Timeout | None = None,
+    url_builder: Callable[[int | None], str] | None = None,
 ) -> AsyncIterator[tuple[str, dict[str, Any]]]:
     """Yield ``(event_type, data)`` tuples from a server-sent-events stream.
 
     Skips ``heartbeat`` events. Parses ``data:`` payload as JSON. If
     payload is not valid JSON, yields the raw string under data={"raw": "..."}.
     Auto-reconnects on transport error with a 1s backoff (max 30s).
+
+    Reconnect replay (Last-Event-ID): the server tags every real event with an
+    SSE ``id:`` line carrying its monotonic ``seq_id``. This client tracks the
+    last id it saw and, on reconnect, asks *url_builder* to produce a URL that
+    resumes from it (``?since_seq=<last id>``) so events missed during the blip
+    are replayed instead of silently lost. Without a *url_builder* the same
+    ``url`` is re-opened (legacy behaviour — no replay), preserving the original
+    single-argument call contract.
+
+    The ``replay_truncated`` sentinel (seq_id 0) is yielded through like any
+    other event; the caller reacts to it (e.g. full refresh) and it is never
+    adopted as a resume cursor because the server omits its ``id:`` line.
     """
     backoff = 1.0
     timeout = timeout or httpx.Timeout(None)  # SSE streams stay open
+    last_event_id: int | None = None
     while True:
+        # Rebuild the URL each connect so a reconnect carries the resume cursor.
+        connect_url = url_builder(last_event_id) if url_builder is not None else url
         try:
             async with httpx.AsyncClient(timeout=timeout) as client:
-                async with client.stream("GET", url, headers=headers or {}) as resp:
+                async with client.stream("GET", connect_url, headers=headers or {}) as resp:
                     if resp.status_code != 200:
                         # endpoint missing / unauthorised — back off
                         raise httpx.HTTPStatusError(
@@ -39,6 +56,7 @@ async def stream_sse(
                         )
                     backoff = 1.0  # reset on successful connect
                     event_type = "message"
+                    event_id: int | None = None
                     data_buf: list[str] = []
                     async for line in resp.aiter_lines():
                         if line == "":
@@ -46,6 +64,14 @@ async def stream_sse(
                             if data_buf:
                                 raw = "\n".join(data_buf)
                                 data_buf = []
+                                # Advance the resume cursor from this event's
+                                # id: line. The server never tags heartbeats or
+                                # the replay_truncated sentinel with an id, so
+                                # only real events move last_event_id forward and
+                                # the sentinel is never adopted as a cursor.
+                                if event_id is not None:
+                                    last_event_id = event_id
+                                event_id = None
                                 if event_type == "heartbeat":
                                     event_type = "message"
                                     continue
@@ -55,6 +81,7 @@ async def stream_sse(
                                     data = {"raw": raw}
                                 yield event_type, data
                             event_type = "message"
+                            event_id = None
                             continue
                         if line.startswith(":"):
                             continue  # comment / keep-alive
@@ -62,9 +89,13 @@ async def stream_sse(
                             event_type = line[6:].strip()
                         elif line.startswith("data:"):
                             data_buf.append(line[5:].lstrip())
+                        elif line.startswith("id:"):
+                            raw_id = line[3:].strip()
+                            try:
+                                event_id = int(raw_id)
+                            except ValueError:
+                                event_id = None
         except (httpx.HTTPError, httpx.TransportError):
-            import asyncio
-
             await asyncio.sleep(min(backoff, 30))
             backoff = min(backoff * 2, 30)
             continue

--- a/tests/security/test_https_enforcement.py
+++ b/tests/security/test_https_enforcement.py
@@ -7,10 +7,15 @@ from orb.api.server import create_fastapi_app
 from orb.config.schemas.server_schema import ServerConfig
 
 
-def _build_config(require_https: bool, hsts_max_age: int = 31536000) -> ServerConfig:
+def _build_config(
+    require_https: bool,
+    hsts_max_age: int = 31536000,
+    trusted_proxies: list[str] | None = None,
+) -> ServerConfig:
     return ServerConfig(  # type: ignore[call-arg]
         require_https=require_https,
         hsts_max_age=hsts_max_age,
+        trusted_proxies=trusted_proxies or [],
     )
 
 
@@ -40,6 +45,49 @@ class TestHTTPSRedirect:
         assert resp.status_code != 307
         # HSTS must not be advertised for an HTTP-only origin.
         assert "strict-transport-security" not in resp.headers
+
+
+class TestForwardedProtoNoRedirectLoop:
+    """Behind a TLS-terminating trusted proxy, X-Forwarded-Proto=https must not loop.
+
+    The proxy terminates TLS and forwards plain HTTP, so scope["scheme"] is
+    "http".  Without honouring X-Forwarded-Proto the redirect middleware would
+    307 every request into an infinite loop.  The forwarded scheme is only
+    trusted from a configured trusted proxy so genuine HTTP and spoofed headers
+    from untrusted clients still redirect.
+    """
+
+    def test_trusted_proxy_forwarded_https_not_redirected(self):
+        # TestClient's default direct-peer host is 'testclient'; mark it trusted.
+        app = create_fastapi_app(_build_config(require_https=True, trusted_proxies=["testclient"]))
+        client = TestClient(app, base_url="http://testserver")
+        resp = client.get(
+            "/health",
+            headers={"X-Forwarded-Proto": "https"},
+            follow_redirects=False,
+        )
+        assert resp.status_code != 307
+
+    def test_genuine_http_from_trusted_proxy_still_redirects(self):
+        # A trusted proxy that forwards a real HTTP request (no XFP=https)
+        # must still be redirected — HTTPS enforcement is not weakened.
+        app = create_fastapi_app(_build_config(require_https=True, trusted_proxies=["testclient"]))
+        client = TestClient(app, base_url="http://testserver")
+        resp = client.get("/health", follow_redirects=False)
+        assert resp.status_code == 307
+        assert resp.headers["location"].startswith("https://")
+
+    def test_forwarded_proto_ignored_without_trusted_proxies(self):
+        # With no trusted proxies configured, a spoofed X-Forwarded-Proto must
+        # be ignored so the request is still redirected to HTTPS.
+        app = create_fastapi_app(_build_config(require_https=True, trusted_proxies=[]))
+        client = TestClient(app, base_url="http://testserver")
+        resp = client.get(
+            "/health",
+            headers={"X-Forwarded-Proto": "https"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 307
 
 
 class TestHSTSMaxAgeWiring:

--- a/tests/ui/test_api_http_coverage.py
+++ b/tests/ui/test_api_http_coverage.py
@@ -675,9 +675,10 @@ class TestSubscribeEvents:
     async def test_builds_url_without_filter(self, api_http):
         captured: dict[str, Any] = {}
 
-        async def _fake_stream(url, headers=None):
+        async def _fake_stream(url, headers=None, url_builder=None):
             captured["url"] = url
             captured["headers"] = headers
+            captured["url_builder"] = url_builder
             yield "message", {"n": 1}
 
         fake_sse = MagicMock()
@@ -690,13 +691,20 @@ class TestSubscribeEvents:
         expected = f"{api_http.ORB_BASE_URL}{api_http.ORB_ROOT_PREFIX}/api/v1/events"
         assert captured["url"] == expected
         assert captured["headers"] == {"X-ORB-Scheduler": "default"}
+        # The reconnect url_builder threads the last-seen SSE id into
+        # ?since_seq= so a reconnect replays events missed during the blip.
+        builder = captured["url_builder"]
+        assert builder is not None
+        assert builder(None) == expected
+        assert builder(42) == expected + "?since_seq=42"
 
     @pytest.mark.asyncio
     async def test_builds_url_with_sorted_type_filter(self, api_http):
         captured: dict[str, Any] = {}
 
-        async def _fake_stream(url, headers=None):
+        async def _fake_stream(url, headers=None, url_builder=None):
             captured["url"] = url
+            captured["url_builder"] = url_builder
             if False:
                 yield  # pragma: no cover - make this an async generator
 
@@ -708,3 +716,6 @@ class TestSubscribeEvents:
 
         # types are joined sorted → alert,machine
         assert captured["url"].endswith("/api/v1/events?type=alert,machine")
+        # On reconnect the type filter and the resume cursor are combined.
+        builder = captured["url_builder"]
+        assert builder(7).endswith("/api/v1/events?type=alert,machine&since_seq=7")

--- a/tests/ui/test_sse_client.py
+++ b/tests/ui/test_sse_client.py
@@ -375,6 +375,65 @@ async def test_id_line_tracked_and_replayed_on_reconnect():
 
 
 @pytest.mark.asyncio
+async def test_non_integer_id_line_is_ignored_not_adopted_as_cursor():
+    """A malformed ``id:`` value must not crash and must not advance the cursor.
+
+    The event is still delivered; the bad id is simply discarded so the next
+    reconnect does not resume from a nonsense cursor.
+    """
+    from orb.ui.sse_client import stream_sse
+
+    first = _make_sse_response(
+        [
+            "id: not-a-number",
+            "event: RequestStatusChangedEvent",
+            "data: " + json.dumps({"n": 1}),
+            "",
+        ]
+    )
+    first_client = _make_client(first)
+    bad_client = MagicMock()
+    bad_client.__aenter__ = AsyncMock(side_effect=httpx.ConnectError("blip"))
+    bad_client.__aexit__ = AsyncMock(return_value=False)
+    good = _make_sse_response(["data: " + json.dumps({"n": 2}), ""])
+    good_client = _make_client(good)
+
+    builder_calls: list[int | None] = []
+
+    def _url_builder(last_id: int | None) -> str:
+        builder_calls.append(last_id)
+        return "http://localhost/events"
+
+    clients = [first_client, bad_client, good_client]
+    call_count = 0
+
+    def _factory(*a, **k):
+        nonlocal call_count
+        c = clients[min(call_count, len(clients) - 1)]
+        call_count += 1
+        return c
+
+    events: list[tuple[str, Any]] = []
+    with (
+        patch("orb.ui.sse_client.httpx.AsyncClient", side_effect=_factory),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        async for evt, data in stream_sse("http://localhost/events", url_builder=_url_builder):
+            events.append((evt, data))
+            if len(events) >= 2:
+                break
+
+    # The event with the bad id was still delivered.
+    assert events[0][1]["n"] == 1
+    # The reconnect after the drop must NOT resume from the malformed id — the
+    # cursor stayed None because the id could not be parsed.
+    assert builder_calls[0] is None
+    assert all(c is None for c in builder_calls), (
+        f"malformed id must never become a resume cursor; got {builder_calls}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_replay_truncated_event_is_yielded_to_caller():
     """The replay_truncated sentinel is passed through so the caller can react
     (e.g. full refresh). It carries no id:, so it never becomes a resume cursor.

--- a/tests/ui/test_sse_client.py
+++ b/tests/ui/test_sse_client.py
@@ -302,3 +302,92 @@ async def test_non_200_status_triggers_retry():
 
     assert call_count >= 2
     assert events[0][1]["status"] == "recovered"
+
+
+# ---------------------------------------------------------------------------
+# Last-Event-ID tracking + reconnect replay via url_builder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_id_line_tracked_and_replayed_on_reconnect():
+    """stream_sse records the SSE ``id:`` and, on reconnect, asks url_builder
+    to resume from the last id it saw (Last-Event-ID → ?since_seq=).
+
+    First connection delivers two events (id 7 then id 9) then drops
+    (transport error); the second connection returns one event. We assert the
+    url_builder was invoked with the last-seen id (9) for the reconnect.
+    """
+    from orb.ui.sse_client import stream_sse
+
+    first = _make_sse_response(
+        [
+            "id: 7",
+            "event: RequestStatusChangedEvent",
+            "data: " + json.dumps({"n": 1}),
+            "",
+            "id: 9",
+            "event: RequestStatusChangedEvent",
+            "data: " + json.dumps({"n": 2}),
+            "",
+        ]
+    )
+    first_client = _make_client(first)
+    # Make the first client's stream raise AFTER its lines are consumed so the
+    # generator reconnects. Simplest: second client raises to force url_builder,
+    # then a good client. We instead drop after first via a bad second client.
+    good = _make_sse_response(["data: " + json.dumps({"n": 3}), ""])
+    good_client = _make_client(good)
+
+    bad_client = MagicMock()
+    bad_client.__aenter__ = AsyncMock(side_effect=httpx.ConnectError("blip"))
+    bad_client.__aexit__ = AsyncMock(return_value=False)
+
+    builder_calls: list[int | None] = []
+
+    def _url_builder(last_id: int | None) -> str:
+        builder_calls.append(last_id)
+        return "http://localhost/events"
+
+    clients = [first_client, bad_client, good_client]
+    call_count = 0
+
+    def _factory(*a, **k):
+        nonlocal call_count
+        c = clients[min(call_count, len(clients) - 1)]
+        call_count += 1
+        return c
+
+    events: list[tuple[str, Any]] = []
+    with (
+        patch("orb.ui.sse_client.httpx.AsyncClient", side_effect=_factory),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        async for evt, data in stream_sse("http://localhost/events", url_builder=_url_builder):
+            events.append((evt, data))
+            if len(events) >= 3:
+                break
+
+    # First connect asks for cursor None; after seeing id 9 and dropping, the
+    # reconnect asks the builder to resume from 9.
+    assert builder_calls[0] is None
+    assert 9 in builder_calls, f"reconnect must resume from last id 9; got {builder_calls}"
+
+
+@pytest.mark.asyncio
+async def test_replay_truncated_event_is_yielded_to_caller():
+    """The replay_truncated sentinel is passed through so the caller can react
+    (e.g. full refresh). It carries no id:, so it never becomes a resume cursor.
+    """
+    lines = [
+        "event: replay_truncated",
+        "data: " + json.dumps({"type": "replay_truncated", "since": 1, "seq_id": 0}),
+        "",
+    ]
+    resp = _make_sse_response(lines)
+    client = _make_client(resp)
+
+    events = await _collect_n("http://localhost/events", 1, client)
+
+    assert events[0][0] == "replay_truncated"
+    assert events[0][1]["seq_id"] == 0

--- a/tests/ui/test_state_integration.py
+++ b/tests/ui/test_state_integration.py
@@ -385,6 +385,82 @@ class TestRequestsStateSseLiveUpdates:
         assert s._sse_started is False
 
     @pytest.mark.asyncio
+    async def test_stream_status_events_replay_truncated_triggers_full_reload(self):
+        """A replay_truncated sentinel makes the stream re-fetch the whole list.
+
+        On reconnect after a gap too large to replay incrementally, the server
+        sends replay_truncated. The row-update path must full-reload rather than
+        rely on stale incremental state — so a row stuck in_progress after a
+        missed terminal event self-heals to its true (terminal) status.
+        """
+        s = self._make_state(
+            [
+                # Locally stuck in_progress (terminal event was missed).
+                {"request_id": "req-1", "status": "in_progress"},
+            ]
+        )
+        s.tab = "all"
+        s.page_size = 200
+        s.next_cursor = ""
+        s.api_total_count = 0
+        s.last_refresh = ""
+
+        async def _fake_subscribe(event_types=None):
+            yield "replay_truncated", {"type": "replay_truncated", "since": 1, "seq_id": 0}
+
+        async def _fake_list_requests(status=None, limit=200):
+            # Server truth: req-1 actually completed while we were disconnected.
+            return {
+                "requests": [
+                    {"request_id": "req-1", "status": "complete", "created_at": "2026-01-01"}
+                ],
+                "next_cursor": "",
+                "total_count": 1,
+            }
+
+        with patch("orb.ui.pages.requests.api") as mock_api:
+            mock_api.subscribe_events = _fake_subscribe
+            mock_api.list_requests = _fake_list_requests
+            await s.stream_status_events()
+
+        # The stuck row was reconciled to its true terminal status via reload.
+        by_id = {r["request_id"]: r["status"] for r in s.requests}
+        assert by_id["req-1"] == "complete"
+        assert s._sse_started is False
+
+    @pytest.mark.asyncio
+    async def test_reconnect_replay_updates_stuck_row_to_terminal(self):
+        """End-to-end: blip → missed terminal transition → reconnect replay →
+        row moves from in_progress to its terminal status (not left stuck).
+
+        The reconnect replay surfaces the previously-missed terminal event
+        through the same generator the live stream uses, so draining it patches
+        the row exactly as a live event would — the row self-heals without a
+        manual refresh.
+        """
+        s = self._make_state([{"request_id": "req-1", "status": "in_progress"}])
+
+        async def _fake_subscribe(event_types=None):
+            # After reconnect, the server replays the terminal event the client
+            # missed during the outage (it carried an id: so since_seq resumed).
+            yield (
+                "RequestCompletedEvent",
+                {
+                    "request_id": "req-1",
+                    "completion_status": "complete",
+                    "machine_ids": ["m-1"],
+                },
+            )
+
+        with patch("orb.ui.pages.requests.api") as mock_api:
+            mock_api.subscribe_events = _fake_subscribe
+            await s.stream_status_events()
+
+        assert s.requests[0]["status"] == "complete"
+        # Progress reached its final value from the replayed event.
+        assert s.requests[0]["successful_count"] == 1
+
+    @pytest.mark.asyncio
     async def test_stream_status_events_single_flight_guard(self):
         """A second concurrent subscriber returns immediately (guarded)."""
         s = self._make_state([{"request_id": "req-1", "status": "pending"}])

--- a/tests/ui/test_state_integration.py
+++ b/tests/ui/test_state_integration.py
@@ -274,6 +274,90 @@ class TestRequestsStateSseLiveUpdates:
         assert changed is False
         assert s.requests[0]["status"] == "pending"
 
+    def test_apply_updates_counts_and_progress_not_just_status(self):
+        """A status-transition event must refresh count/progress fields too.
+
+        The row's progress bar and counts columns derive from
+        ``successful_count`` / ``requested_count`` (see ``request_rows``).
+        Patching only ``status`` would leave those stale, so the event's
+        count fields must flow through to the row.
+        """
+        s = self._make_state(
+            [
+                {
+                    "request_id": "req-1",
+                    "status": "pending",
+                    "requested_count": 4,
+                    "successful_count": 0,
+                }
+            ]
+        )
+        changed = s._apply_request_status_event(
+            "RequestStatusChangedEvent",
+            {
+                "request_id": "req-1",
+                "new_status": "in_progress",
+                "successful_count": 3,
+                "requested_count": 4,
+            },
+        )
+        assert changed is True
+        row = s.requests[0]
+        assert row["status"] == "in_progress"
+        # Counts advanced with the status transition — not left at 0.
+        assert row["successful_count"] == 3
+        assert row["requested_count"] == 4
+
+    def test_apply_completed_event_derives_fulfilled_count_from_machine_ids(self):
+        """A completed event without an explicit count derives it from machine_ids."""
+        s = self._make_state(
+            [
+                {
+                    "request_id": "req-1",
+                    "status": "in_progress",
+                    "requested_count": 2,
+                    "successful_count": 0,
+                }
+            ]
+        )
+        changed = s._apply_request_status_event(
+            "RequestCompletedEvent",
+            {
+                "request_id": "req-1",
+                "completion_status": "complete",
+                "machine_ids": ["m-1", "m-2"],
+            },
+        )
+        assert changed is True
+        row = s.requests[0]
+        assert row["status"] == "complete"
+        # Progress reaches its final value: 2 machines fulfilled.
+        assert row["successful_count"] == 2
+        assert row["machine_ids"] == ["m-1", "m-2"]
+
+    def test_apply_counts_only_change_patches_row_even_if_status_same(self):
+        """When only counts change (status unchanged), the row is still patched."""
+        s = self._make_state(
+            [
+                {
+                    "request_id": "req-1",
+                    "status": "in_progress",
+                    "requested_count": 4,
+                    "successful_count": 1,
+                }
+            ]
+        )
+        changed = s._apply_request_status_event(
+            "RequestStatusChangedEvent",
+            {
+                "request_id": "req-1",
+                "new_status": "in_progress",
+                "successful_count": 2,
+            },
+        )
+        assert changed is True
+        assert s.requests[0]["successful_count"] == 2
+
     # --- stream_status_events (drains the SSE generator) -------------------
 
     @pytest.mark.asyncio

--- a/tests/unit/api/test_events.py
+++ b/tests/unit/api/test_events.py
@@ -359,6 +359,109 @@ class TestSequenceIdAndReplayTruncated:
         # All 50 surviving history entries follow the sentinel.
         assert len(result) == 1 + 50
 
+    def test_cross_restart_cursor_at_boot_base_emits_sentinel_no_silent_drop(self):
+        """Reproduce the cross-restart seq collision the boot-token guard closes.
+
+        This isolates the *generation-floor* branch from the deque-overflow
+        branch.  The new process seeds its counter above ``boot_base``, so the
+        first fresh event is ``boot_base + 1``.  A stale client cursor of exactly
+        ``boot_base`` sits flush against that first id — ``oldest_seq
+        (boot_base+1) <= since_seq(boot_base) + 1`` — so the overflow branch does
+        NOT fire and neither does the client-ahead branch.  ONLY the
+        generation-floor guard can catch it.
+
+        Without the guard, ``filter seq > boot_base`` would return every fresh
+        event with NO sentinel, mirroring the original defect where a restarted
+        counter reissued low ids and the client silently skipped the events
+        published in the collision window.  With the guard, the stale cursor
+        forces a full resync.
+        """
+        boot_base = 5  # highest seq id the previous generation could have issued
+        bus = _SseEventBus(boot_base=boot_base)
+
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        # Fresh generation publishes 5 events: boot_base+1 .. boot_base+5.
+        for i in range(5):
+            bus._record(base, "machine.created", {"i": i}, seq_id=boot_base + 1 + i)
+
+        # oldest_seq = boot_base+1 = since_seq+1 -> overflow branch does NOT fire.
+        since = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        result = bus.history_since_seq(since, since_seq=boot_base)
+
+        assert result, "Expected at least the sentinel"
+        assert result[0][0] == "replay_truncated", (
+            "Stale cross-restart cursor must trigger replay_truncated (the guard "
+            f"is the only branch that can catch this scenario); got {result[0][0]!r}"
+        )
+        assert result[0][1]["since"] == boot_base
+        assert result[0][1]["seq_id"] == 0
+
+    def test_cross_restart_low_cursor_below_boot_base_emits_sentinel(self):
+        """A stale low cursor (since_seq=2) from a prior boot also resyncs.
+
+        Here the overflow branch would also fire, but the guard must catch the
+        stale generation cursor regardless — a cursor at or below ``_boot_base``
+        can never belong to this generation.
+        """
+        boot_base = 10
+        bus = _SseEventBus(boot_base=boot_base)
+
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        for i in range(5):
+            bus._record(base, "machine.created", {"i": i}, seq_id=boot_base + 1 + i)
+
+        since = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        result = bus.history_since_seq(since, since_seq=2)
+
+        assert result[0][0] == "replay_truncated"
+        assert result[0][1]["since"] == 2
+
+    def test_new_generation_counter_starts_above_boot_base(self):
+        """A restarted bus never reissues low ids that collide with old cursors."""
+
+        async def run():
+            boot_base = 1_000
+            bus = _SseEventBus(boot_base=boot_base)
+            await bus.publish("machine.created", {"id": "m-1"})
+            first_seq = bus._history[0][3]
+            assert first_seq == boot_base + 1, (
+                f"first seq of new generation must be boot_base+1; got {first_seq}"
+            )
+
+        asyncio.run(run())
+
+    def test_cursor_within_current_generation_replays_normally(self):
+        """A cursor issued by THIS generation (> boot_base) replays without a sentinel."""
+
+        async def run():
+            boot_base = 100
+            bus = _SseEventBus(boot_base=boot_base)
+            for i in range(3):
+                await bus.publish("machine.updated", {"i": i})
+            # This generation issued 101, 102, 103.  Client saw 101; reconnect at 101.
+            since = datetime(2025, 1, 1, tzinfo=timezone.utc)
+            result = bus.history_since_seq(since, since_seq=boot_base + 1)
+            types = [et for et, _ in result]
+            assert "replay_truncated" not in types, (
+                f"in-generation cursor must not truncate; got {types!r}"
+            )
+            # Only the two events after the cursor (102, 103) replay.
+            assert len(result) == 2
+
+        asyncio.run(run())
+
+    def test_module_singleton_seeded_with_monotonic_boot_base(self):
+        """The module bus uses a wall-clock-seeded boot base well under 2**53.
+
+        Guards the JS-safe-integer contract: the single-int ``id:`` cursor must
+        remain parseable by every SDK reader, so the boot base (and therefore
+        every issued seq_id) must stay below JavaScript's 2**53 limit.
+        """
+        from orb.api.routers.events import sse_event_bus
+
+        assert sse_event_bus._boot_base > 0, "module singleton must carry a boot floor"
+        assert sse_event_bus._boot_base < 2**53, "seq cursor must stay JS-safe-integer"
+
     def test_since_seq_param_activates_gap_detection_on_stream(self):
         """Route: ?since= + ?since_seq= triggers history_since_seq path.
 

--- a/tests/unit/api/test_events.py
+++ b/tests/unit/api/test_events.py
@@ -658,3 +658,101 @@ class TestSseReconnectDequeOverflow:
         assert sentinel_payload["seq_id"] == 0
         # The surviving history follows the sentinel.
         assert len(result) == 1 + deque_maxlen
+
+
+# ---------------------------------------------------------------------------
+# SSE wire-format: id: line (Last-Event-ID) + reconnect replay via ?since_seq=
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestSseWireSeqIdAndReconnect:
+    """The server transmits each event's seq_id on the wire as an SSE ``id:``
+    line so standard clients get Last-Event-ID semantics, and a reconnect with
+    ?since_seq=<n> replays only the events after n.
+    """
+
+    def _seed_bus(self, n: int, *, maxlen: int = 512) -> _SseEventBus:
+        bus = _SseEventBus()
+        bus._history_max = maxlen
+        bus._history = _deque(maxlen=maxlen)
+        ts = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        for i in range(n):
+            bus._record(ts, "RequestStatusChangedEvent", {"idx": i}, seq_id=i + 1)
+        return bus
+
+    def _stream(self, bus: _SseEventBus, query: str) -> str:
+        app = _make_viewer_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        mock_sub = AsyncMock()
+        mock_unsub = AsyncMock()
+        with (
+            patch("orb.api.routers.events.sse_event_bus", bus),
+            patch.object(bus, "subscribe", mock_sub),
+            patch.object(bus, "unsubscribe", mock_unsub),
+        ):
+            q: asyncio.Queue = asyncio.Queue()
+            q.put_nowait(None)  # close after history replay
+            mock_sub.return_value = q
+            resp = client.get(f"/events/{query}")
+        assert resp.status_code == 200
+        return resp.text
+
+    def test_history_replay_emits_id_line_per_event(self):
+        """Replayed events carry an ``id:`` line equal to their seq_id."""
+        bus = self._seed_bus(3)
+        body = self._stream(bus, "?since=2025-01-01T00:00:00Z")
+        # Every real event block starts with its id: line.
+        blocks = [b for b in body.split("\n\n") if "event:" in b]
+        assert len(blocks) == 3
+        for block, expected_id in zip(blocks, (1, 2, 3), strict=True):
+            assert f"id: {expected_id}" in block, (
+                f"Expected 'id: {expected_id}' in block:\n{block!r}"
+            )
+
+    def test_since_seq_alone_replays_after_cursor_with_ids(self):
+        """?since_seq=<n> WITHOUT ?since= replays only events after n, each with id:.
+
+        A standard SSE client resuming from a Last-Event-ID sends only
+        since_seq; the server must still replay from that cursor.
+        """
+        bus = self._seed_bus(5)  # seq_ids 1..5
+        body = self._stream(bus, "?since_seq=3")
+        events = _parse_sse_events(body)
+        # No sentinel (3 is within retained history), only 4 and 5 replayed.
+        assert [e["event"] for e in events] == [
+            "RequestStatusChangedEvent",
+            "RequestStatusChangedEvent",
+        ]
+        assert [e["data"]["idx"] for e in events] == [3, 4]  # idx = seq_id - 1
+        # And each carried its id: line (4 and 5).
+        ids = [line for line in body.splitlines() if line.startswith("id:")]
+        assert ids == ["id: 4", "id: 5"]
+
+    def test_since_seq_alone_too_old_emits_sentinel_without_id(self):
+        """?since_seq= pointing at an evicted event emits the sentinel first,
+        and the sentinel carries NO id: line (seq_id 0 is never a resume cursor).
+        """
+        bus = self._seed_bus(12, maxlen=10)  # oldest surviving seq_id = 3
+        body = self._stream(bus, "?since_seq=1")
+        events = _parse_sse_events(body)
+        assert events[0]["event"] == "replay_truncated"
+        assert events[0]["data"]["seq_id"] == 0
+        # The sentinel block must not carry an id: line.
+        for block in body.split("\n\n"):
+            if "replay_truncated" in block:
+                assert "id:" not in block, f"sentinel must omit id:; got:\n{block!r}"
+                break
+        else:
+            pytest.fail("replay_truncated block not found")
+
+    def test_replay_truncated_passes_narrow_type_filter(self):
+        """The sentinel reaches a client that narrowed ?type= to request events."""
+        bus = self._seed_bus(12, maxlen=10)
+        body = self._stream(
+            bus,
+            "?since_seq=1&type=RequestStatusChangedEvent,RequestCompletedEvent",
+        )
+        events = _parse_sse_events(body)
+        assert events[0]["event"] == "replay_truncated"

--- a/tests/unit/api/test_events.py
+++ b/tests/unit/api/test_events.py
@@ -859,3 +859,58 @@ class TestSseWireSeqIdAndReconnect:
         )
         events = _parse_sse_events(body)
         assert events[0]["event"] == "replay_truncated"
+
+    def _stream_with_queue(self, bus: _SseEventBus, query: str, q: asyncio.Queue) -> str:
+        """Like ``_stream`` but with a caller-provided live queue.
+
+        Lets a test seed the live queue with items that overlap the history
+        snapshot to exercise the history/live de-dupe window.
+        """
+        app = _make_viewer_app()
+        client = TestClient(app, raise_server_exceptions=False)
+        mock_sub = AsyncMock(return_value=q)
+        mock_unsub = AsyncMock()
+        with (
+            patch("orb.api.routers.events.sse_event_bus", bus),
+            patch.object(bus, "subscribe", mock_sub),
+            patch.object(bus, "unsubscribe", mock_unsub),
+        ):
+            resp = client.get(f"/events/{query}")
+        assert resp.status_code == 200
+        return resp.text
+
+    def test_history_live_overlap_event_not_emitted_twice(self):
+        """An event present in BOTH the history snapshot and the live queue
+        (published in the subscribe→snapshot window) is emitted exactly ONCE.
+
+        Regression for the duplicate-window bug: subscribe() runs before the
+        history read, so an event landing in that gap is both replayed from
+        history and delivered on the live queue with the same id:. The live loop
+        must skip items whose seq_id <= the max already replayed from history.
+        """
+        bus = self._seed_bus(3)  # history seq_ids 1,2,3
+
+        # Live queue: seq 3 is the overlap (already in history), seq 4 is new.
+        q: asyncio.Queue = asyncio.Queue()
+        q.put_nowait(("RequestStatusChangedEvent", {"idx": 2}, 3))  # duplicate of history
+        q.put_nowait(("RequestStatusChangedEvent", {"idx": 3}, 4))  # genuinely new
+        q.put_nowait(None)  # close
+
+        body = self._stream_with_queue(bus, "?since=2025-01-01T00:00:00Z", q)
+        ids = [line for line in body.splitlines() if line.startswith("id:")]
+        # History replays 1,2,3; live adds only 4 (3 de-duped). No id appears twice.
+        assert ids == ["id: 1", "id: 2", "id: 3", "id: 4"], f"got {ids!r}"
+        assert len(ids) == len(set(ids)), f"duplicate id: emitted — {ids!r}"
+
+    def test_history_live_no_overlap_all_live_events_pass(self):
+        """When live seq_ids are all above the replayed max, none are skipped."""
+        bus = self._seed_bus(3)  # history 1,2,3
+
+        q: asyncio.Queue = asyncio.Queue()
+        q.put_nowait(("RequestStatusChangedEvent", {"idx": 3}, 4))
+        q.put_nowait(("RequestStatusChangedEvent", {"idx": 4}, 5))
+        q.put_nowait(None)
+
+        body = self._stream_with_queue(bus, "?since=2025-01-01T00:00:00Z", q)
+        ids = [line for line in body.splitlines() if line.startswith("id:")]
+        assert ids == ["id: 1", "id: 2", "id: 3", "id: 4", "id: 5"], f"got {ids!r}"

--- a/tests/unit/api/test_events_router.py
+++ b/tests/unit/api/test_events_router.py
@@ -81,7 +81,12 @@ class TestSseEventBusSubscribePublish:
         q = asyncio.run(bus.subscribe())
         asyncio.run(bus.publish("machine.created", {"id": "m-1"}))
         item = q.get_nowait()
-        assert item == ("machine.created", {"id": "m-1"})
+        assert item is not None
+        # Queue tuple carries the seq_id so the generator can emit id: lines.
+        event_type, payload, seq_id = item
+        assert event_type == "machine.created"
+        assert payload == {"id": "m-1"}
+        assert seq_id >= 1
 
     def test_publish_enqueues_to_multiple_subscribers(self):
         bus = _SseEventBus()
@@ -126,11 +131,12 @@ class TestSseEventBusFullQueueEviction:
         asyncio.run(bus.publish("new.event", {"fresh": True}))
         # Queue should still be at max (one evicted, one added).
         assert q.qsize() == _QUEUE_MAXSIZE
-        # Last item should be the freshly published event.
+        # Last item should be the freshly published event (now seq-carrying).
         items = []
         while not q.empty():
             items.append(q.get_nowait())
-        assert items[-1] == ("new.event", {"fresh": True})
+        assert items[-1][0] == "new.event"
+        assert items[-1][1] == {"fresh": True}
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_forwarded_proto_middleware.py
+++ b/tests/unit/api/test_forwarded_proto_middleware.py
@@ -1,0 +1,137 @@
+"""Unit tests for ForwardedProtoMiddleware at the ASGI-scope level.
+
+The HTTP redirect-loop behaviour is covered end-to-end in
+tests/security/test_https_enforcement.py.  These tests drive the middleware
+directly at the ASGI seam so the branches that a TestClient cannot easily reach
+— websocket scheme normalisation, untrusted-peer skip, missing/invalid headers,
+and the empty-trusted-proxies no-op — are exercised as real behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orb.api.middleware.forwarded_proto_middleware import ForwardedProtoMiddleware
+
+
+async def _run(middleware: ForwardedProtoMiddleware, scope: dict) -> dict:
+    """Invoke the middleware; return the (possibly mutated) scope the app saw."""
+    seen: dict = {}
+
+    async def _app(inner_scope, receive, send):
+        seen["scope"] = inner_scope
+
+    middleware.app = _app  # type: ignore[assignment]
+
+    async def _receive():  # pragma: no cover - never awaited in these tests
+        return {"type": "http.request"}
+
+    async def _send(_message):  # pragma: no cover - app sends nothing
+        return None
+
+    await middleware(scope, _receive, _send)
+    return seen["scope"]
+
+
+def _http_scope(*, client_ip: str | None, xfp: bytes | None, scheme: str = "http") -> dict:
+    headers: list[tuple[bytes, bytes]] = []
+    if xfp is not None:
+        headers.append((b"x-forwarded-proto", xfp))
+    return {
+        "type": "http",
+        "scheme": scheme,
+        "client": (client_ip, 12345) if client_ip else None,
+        "headers": headers,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestForwardedProtoScopeRewrite:
+    @pytest.mark.asyncio
+    async def test_trusted_proxy_https_rewrites_scheme(self):
+        mw = ForwardedProtoMiddleware(None, trusted_proxies=["10.0.0.1"])  # type: ignore[arg-type]
+        scope = _http_scope(client_ip="10.0.0.1", xfp=b"https")
+        result = await _run(mw, scope)
+        assert result["scheme"] == "https"
+
+    @pytest.mark.asyncio
+    async def test_untrusted_peer_leaves_scheme_untouched(self):
+        mw = ForwardedProtoMiddleware(None, trusted_proxies=["10.0.0.1"])  # type: ignore[arg-type]
+        # Header says https but the direct peer is not a trusted proxy.
+        scope = _http_scope(client_ip="203.0.113.9", xfp=b"https")
+        result = await _run(mw, scope)
+        assert result["scheme"] == "http"
+
+    @pytest.mark.asyncio
+    async def test_no_trusted_proxies_is_noop(self):
+        mw = ForwardedProtoMiddleware(None, trusted_proxies=[])  # type: ignore[arg-type]
+        scope = _http_scope(client_ip="10.0.0.1", xfp=b"https")
+        result = await _run(mw, scope)
+        assert result["scheme"] == "http"
+
+    @pytest.mark.asyncio
+    async def test_missing_header_leaves_scheme_untouched(self):
+        mw = ForwardedProtoMiddleware(None, trusted_proxies=["10.0.0.1"])  # type: ignore[arg-type]
+        scope = _http_scope(client_ip="10.0.0.1", xfp=None)
+        result = await _run(mw, scope)
+        assert result["scheme"] == "http"
+
+    @pytest.mark.asyncio
+    async def test_unknown_scheme_value_is_ignored(self):
+        mw = ForwardedProtoMiddleware(None, trusted_proxies=["10.0.0.1"])  # type: ignore[arg-type]
+        scope = _http_scope(client_ip="10.0.0.1", xfp=b"gopher")
+        result = await _run(mw, scope)
+        assert result["scheme"] == "http"
+
+    @pytest.mark.asyncio
+    async def test_appended_header_uses_rightmost_value(self):
+        """A proxy may append; the closest (rightmost) value is authoritative."""
+        mw = ForwardedProtoMiddleware(None, trusted_proxies=["10.0.0.1"])  # type: ignore[arg-type]
+        scope = _http_scope(client_ip="10.0.0.1", xfp=b"http, https")
+        result = await _run(mw, scope)
+        assert result["scheme"] == "https"
+
+    @pytest.mark.asyncio
+    async def test_missing_client_is_treated_as_untrusted(self):
+        mw = ForwardedProtoMiddleware(None, trusted_proxies=["10.0.0.1"])  # type: ignore[arg-type]
+        scope = _http_scope(client_ip=None, xfp=b"https")
+        result = await _run(mw, scope)
+        assert result["scheme"] == "http"
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestForwardedProtoWebsocketNormalisation:
+    @pytest.mark.asyncio
+    async def test_websocket_https_normalised_to_wss(self):
+        """For a websocket connection the http/https scheme maps to ws/wss."""
+        mw = ForwardedProtoMiddleware(None, trusted_proxies=["10.0.0.1"])  # type: ignore[arg-type]
+        scope = {
+            "type": "websocket",
+            "scheme": "ws",
+            "client": ("10.0.0.1", 5555),
+            "headers": [(b"x-forwarded-proto", b"https")],
+        }
+        result = await _run(mw, scope)
+        assert result["scheme"] == "wss"
+
+    @pytest.mark.asyncio
+    async def test_websocket_http_normalised_to_ws(self):
+        mw = ForwardedProtoMiddleware(None, trusted_proxies=["10.0.0.1"])  # type: ignore[arg-type]
+        scope = {
+            "type": "websocket",
+            "scheme": "wss",
+            "client": ("10.0.0.1", 5555),
+            "headers": [(b"x-forwarded-proto", b"http")],
+        }
+        result = await _run(mw, scope)
+        assert result["scheme"] == "ws"
+
+    @pytest.mark.asyncio
+    async def test_lifespan_scope_passes_through_untouched(self):
+        """Non-http/websocket scopes (e.g. lifespan) are ignored."""
+        mw = ForwardedProtoMiddleware(None, trusted_proxies=["10.0.0.1"])  # type: ignore[arg-type]
+        scope = {"type": "lifespan"}
+        result = await _run(mw, scope)
+        assert "scheme" not in result

--- a/tests/unit/api/test_server_app_endpoints.py
+++ b/tests/unit/api/test_server_app_endpoints.py
@@ -1,0 +1,161 @@
+"""Unit tests for ``create_fastapi_app`` wiring: config validation, the global
+exception handler, and the standalone system endpoints (/info, /metrics).
+
+These exercise the factory's own logic (not the routers) so they run without a
+DI container or provider backend.  Routers are stubbed out so the app builds
+with just the system endpoints under test.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+from orb.api.server import create_fastapi_app
+from orb.config.schemas.server_schema import AuthConfig, ServerConfig
+from orb.domain.base.exceptions import ConfigurationError
+
+
+def _make_app(**overrides):
+    server_config = ServerConfig(  # type: ignore[call-arg]
+        enabled=True,
+        auth=AuthConfig(enabled=False, strategy="replace"),  # type: ignore[call-arg]
+        **overrides,
+    )
+
+    def _stub_routes(app):
+        app.include_router(APIRouter())
+
+    with patch("orb.api.server._register_routers") as mock_register:
+        mock_register.side_effect = _stub_routes
+        return create_fastapi_app(server_config)
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestConfigValidation:
+    def test_none_config_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError, match="requires a ServerConfig"):
+            create_fastapi_app(None)
+
+    def test_invalid_config_object_raises_configuration_error(self):
+        """An object missing 'docs_enabled' is rejected rather than booting fail-open."""
+
+        class _NotAServerConfig:
+            pass
+
+        with pytest.raises(ConfigurationError, match="missing required attribute"):
+            create_fastapi_app(_NotAServerConfig())
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestSystemEndpoints:
+    def test_info_endpoint_returns_service_metadata(self):
+        client = TestClient(_make_app())
+        resp = client.get("/info")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["service"] == "open-resource-broker"
+        assert "version" in body
+        # Auth configuration must NOT be disclosed to unauthenticated callers.
+        assert "auth" not in body
+
+    def test_metrics_endpoint_returns_plaintext(self):
+        client = TestClient(_make_app())
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/plain")
+
+    def test_metrics_endpoint_empty_when_prometheus_absent(self):
+        """A minimal install without prometheus_client serves an empty 200."""
+        client = TestClient(_make_app())
+        with patch.dict("sys.modules", {"prometheus_client": None}):
+            resp = client.get("/metrics")
+        assert resp.status_code == 200
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestGlobalExceptionHandler:
+    def test_unhandled_route_exception_maps_to_structured_error(self):
+        """An exception raised in a route is caught by the global handler and
+        rendered as the structured error envelope (not a bare 500)."""
+        app = _make_app()
+
+        @app.get("/boom")
+        async def _boom():
+            raise ValueError("kaboom")
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/boom")
+
+        assert resp.status_code >= 400
+        body = resp.json()
+        assert body["success"] is False
+        assert "error" in body
+        assert "code" in body["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestMiddlewareWiring:
+    def test_read_only_mode_builds(self):
+        """read_only=True installs the read-only middleware without error."""
+        app = _make_app(read_only=True)
+        client = TestClient(app)
+        # A safe GET still works; the app booted with the middleware attached.
+        assert client.get("/info").status_code == 200
+
+    def test_cors_wildcard_with_auth_enabled_builds(self):
+        """CORS origins=['*'] with auth enabled logs a warning but still boots."""
+        from orb.config.schemas.server_schema import CORSConfig
+
+        server_config = ServerConfig(  # type: ignore[call-arg]
+            enabled=True,
+            auth=AuthConfig(  # type: ignore[call-arg]
+                enabled=True,
+                strategy="bearer_token",
+                bearer_token={"secret_key": "unit-test-secret-key-very-long-and-secure"},
+            ),
+            cors=CORSConfig(enabled=True, origins=["*"], credentials=False),  # type: ignore[call-arg]
+        )
+
+        def _stub_routes(app):
+            app.include_router(APIRouter())
+
+        with patch("orb.api.server._register_routers") as mock_register:
+            mock_register.side_effect = _stub_routes
+            app = create_fastapi_app(server_config)
+
+        client = TestClient(app)
+        # /health is an excluded (public) path even with auth enabled.
+        assert client.get("/health").status_code in (200, 503)
+
+    def test_multi_worker_warnings_do_not_block_boot(self):
+        """workers>1 emits rate-limit + SSE multi-worker warnings but still boots."""
+        app = _make_app(workers=4)
+        client = TestClient(app)
+        assert client.get("/info").status_code == 200
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestTrustedHostsWiring:
+    def test_wildcard_trusted_hosts_skips_host_middleware(self):
+        """A '*' allowlist disables Host-header validation (warned, not enforced)."""
+        app = _make_app(trusted_hosts=["*"])
+        client = TestClient(app, base_url="http://evil.example.com")
+        # With host protection disabled, an arbitrary Host is still served.
+        resp = client.get("/info")
+        assert resp.status_code == 200
+
+    def test_explicit_trusted_hosts_rejects_unknown_host(self):
+        app = _make_app(trusted_hosts=["allowed.example.com"])
+        client = TestClient(app, base_url="http://evil.example.com")
+        resp = client.get("/info")
+        # TrustedHostMiddleware returns 400 for a Host not on the allowlist.
+        assert resp.status_code == 400

--- a/tests/unit/api/test_server_loopback_token.py
+++ b/tests/unit/api/test_server_loopback_token.py
@@ -1,0 +1,291 @@
+"""Unit tests for the loopback-admin token machinery in ``orb.api.server``.
+
+Covers the daemon-issued loopback token capability that lets the CLI reload
+command and the live REST tests authenticate as admin over the loopback IPC:
+
+- ``_LoopbackAdminAuthWrapper``: token acceptance (constant-time), non-ASCII
+  rejection, mtime-based auto-reload, ``rotate_token`` force reload, and
+  delegation to the inner strategy for non-matching tokens.
+- ``_LoopbackAdminTokenMiddleware``: stamps ``request.state`` with the admin
+  role for a valid token and leaves it untouched otherwise.
+- ``_load_loopback_token``: reads the daemon-written token file and registers
+  it, skipping silently when the file is absent.
+
+These are pure-logic units exercised directly (no running server), matching the
+loopback capability's design of staying fully isolated from the JWT strategy.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from orb.api.server import (
+    _load_loopback_token,
+    _LoopbackAdminAuthWrapper,
+    _LoopbackAdminTokenMiddleware,
+)
+from orb.infrastructure.adapters.ports.auth import AuthResult, AuthStatus
+
+
+@pytest.fixture(autouse=True)
+def _reset_loopback_tokens():
+    """Isolate the class-level token state between tests.
+
+    ``_LoopbackAdminAuthWrapper`` stores its token set / file on the class so it
+    survives module reloads; that means it also leaks across tests unless reset.
+    """
+    prev_tokens = set(_LoopbackAdminAuthWrapper._tokens)
+    prev_file = _LoopbackAdminAuthWrapper._token_file
+    prev_mtime = _LoopbackAdminAuthWrapper._token_file_mtime
+    _LoopbackAdminAuthWrapper._tokens = set()
+    _LoopbackAdminAuthWrapper._token_file = None
+    _LoopbackAdminAuthWrapper._token_file_mtime = 0.0
+    yield
+    _LoopbackAdminAuthWrapper._tokens = prev_tokens
+    _LoopbackAdminAuthWrapper._token_file = prev_file
+    _LoopbackAdminAuthWrapper._token_file_mtime = prev_mtime
+
+
+def _ctx(auth_header: str = "", path: str = "/api/v1/machines/request"):
+    """Minimal auth context: only ``.headers`` and ``.path`` are read."""
+    return SimpleNamespace(headers={"authorization": auth_header}, path=path)
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestLoopbackAuthWrapperAuthenticate:
+    @pytest.mark.asyncio
+    async def test_matching_token_grants_admin_identity(self):
+        _LoopbackAdminAuthWrapper._tokens = {"secret-token"}
+        inner = MagicMock()
+        inner.authenticate = AsyncMock()
+        wrapper = _LoopbackAdminAuthWrapper(inner)
+
+        result = await wrapper.authenticate(_ctx("Bearer secret-token"))
+
+        assert result.status == AuthStatus.SUCCESS
+        assert result.user_id == "loopback-admin"
+        assert result.user_roles == ["admin"]
+        assert result.permissions == ["*"]
+        assert result.metadata["strategy"] == "loopback_admin_token"
+        # The loopback token short-circuits — the inner strategy is never asked.
+        inner.authenticate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_matching_token_delegates_to_inner(self):
+        _LoopbackAdminAuthWrapper._tokens = {"secret-token"}
+        inner = MagicMock()
+        inner_result = AuthResult(status=AuthStatus.INVALID, user_id=None)
+        inner.authenticate = AsyncMock(return_value=inner_result)
+        wrapper = _LoopbackAdminAuthWrapper(inner)
+
+        result = await wrapper.authenticate(_ctx("Bearer some-other-token"))
+
+        assert result is inner_result
+        inner.authenticate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_bearer_prefix_delegates_to_inner(self):
+        _LoopbackAdminAuthWrapper._tokens = {"secret-token"}
+        inner = MagicMock()
+        inner.authenticate = AsyncMock(return_value=AuthResult(status=AuthStatus.INVALID))
+        wrapper = _LoopbackAdminAuthWrapper(inner)
+
+        await wrapper.authenticate(_ctx("Basic Zm9vOmJhcg=="))
+
+        inner.authenticate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_ascii_token_returns_invalid_without_delegating(self):
+        """A non-ASCII bearer token can never match the ASCII loopback secret.
+
+        It must return INVALID rather than crashing or silently skipping the
+        auth stamp (which could be an auth bypass).
+        """
+        _LoopbackAdminAuthWrapper._tokens = {"secret-token"}
+        inner = MagicMock()
+        inner.authenticate = AsyncMock()
+        wrapper = _LoopbackAdminAuthWrapper(inner)
+
+        result = await wrapper.authenticate(_ctx("Bearer ünïcödé"))
+
+        assert result.status == AuthStatus.INVALID
+        assert result.user_id is None
+        inner.authenticate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_bearer_token_delegates_to_inner(self):
+        _LoopbackAdminAuthWrapper._tokens = {"secret-token"}
+        inner = MagicMock()
+        inner.authenticate = AsyncMock(return_value=AuthResult(status=AuthStatus.INVALID))
+        wrapper = _LoopbackAdminAuthWrapper(inner)
+
+        await wrapper.authenticate(_ctx("Bearer "))
+
+        inner.authenticate.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestLoopbackAuthWrapperDelegation:
+    def test_get_strategy_name_delegates(self):
+        inner = MagicMock()
+        inner.get_strategy_name.return_value = "jwt"
+        assert _LoopbackAdminAuthWrapper(inner).get_strategy_name() == "jwt"
+
+    def test_is_enabled_delegates(self):
+        inner = MagicMock()
+        inner.is_enabled.return_value = True
+        assert _LoopbackAdminAuthWrapper(inner).is_enabled() is True
+
+    def test_getattr_delegates_unknown_attribute(self):
+        inner = MagicMock()
+        inner.some_custom_method.return_value = "delegated"
+        wrapper = _LoopbackAdminAuthWrapper(inner)
+        assert wrapper.some_custom_method() == "delegated"
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestLoopbackTokenReload:
+    def test_rotate_token_noop_when_no_file_registered(self):
+        _LoopbackAdminAuthWrapper._token_file = None
+        # Must not raise when there is nothing to reload.
+        _LoopbackAdminAuthWrapper.rotate_token()
+
+    def test_rotate_token_reloads_from_file(self, tmp_path):
+        token_file = tmp_path / "orb-server.token"
+        token_file.write_text("fresh-token", encoding="ascii")
+        _LoopbackAdminAuthWrapper._token_file = token_file
+
+        _LoopbackAdminAuthWrapper.rotate_token()
+
+        assert _LoopbackAdminAuthWrapper._tokens == {"fresh-token"}
+
+    def test_reload_ignores_empty_file(self, tmp_path):
+        token_file = tmp_path / "orb-server.token"
+        token_file.write_text("   ", encoding="ascii")  # whitespace only → empty
+        _LoopbackAdminAuthWrapper._token_file = token_file
+        _LoopbackAdminAuthWrapper._tokens = {"old"}
+
+        _LoopbackAdminAuthWrapper.rotate_token()
+
+        # Empty content must not clobber the existing token set.
+        assert _LoopbackAdminAuthWrapper._tokens == {"old"}
+
+    def test_reload_missing_file_is_silent(self, tmp_path):
+        missing = tmp_path / "does-not-exist.token"
+        _LoopbackAdminAuthWrapper._token_file = missing
+        # Reload of a missing file must be swallowed (OSError → debug log).
+        _LoopbackAdminAuthWrapper.rotate_token()
+
+    @pytest.mark.asyncio
+    async def test_check_and_refresh_reloads_on_mtime_change(self, tmp_path):
+        token_file = tmp_path / "orb-server.token"
+        token_file.write_text("token-v1", encoding="ascii")
+        _LoopbackAdminAuthWrapper._token_file = token_file
+        _LoopbackAdminAuthWrapper._token_file_mtime = 0.0  # force "changed"
+        _LoopbackAdminAuthWrapper._tokens = {"token-v1"}
+
+        # Rewrite with a new value; the per-request mtime check must pick it up.
+        token_file.write_text("token-v2", encoding="ascii")
+
+        inner = MagicMock()
+        inner.authenticate = AsyncMock(return_value=AuthResult(status=AuthStatus.INVALID))
+        wrapper = _LoopbackAdminAuthWrapper(inner)
+        result = await wrapper.authenticate(_ctx("Bearer token-v2"))
+
+        assert result.status == AuthStatus.SUCCESS
+        assert _LoopbackAdminAuthWrapper._tokens == {"token-v2"}
+
+    def test_check_and_refresh_noop_when_no_file(self):
+        _LoopbackAdminAuthWrapper._token_file = None
+        # Should return immediately without error.
+        _LoopbackAdminAuthWrapper._check_and_refresh()
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestLoopbackTokenMiddleware:
+    async def _run_dispatch(self, auth_header: str):
+        """Invoke the middleware dispatch and return the (request, called) pair."""
+        request = SimpleNamespace(
+            headers={"authorization": auth_header},
+            state=SimpleNamespace(),
+        )
+        called = {"next": False}
+
+        async def _call_next(req):
+            called["next"] = True
+            return "response"
+
+        result = await _LoopbackAdminTokenMiddleware._dispatch(request, _call_next)
+        return request, called, result
+
+    @pytest.mark.asyncio
+    async def test_valid_token_stamps_admin_state(self):
+        _LoopbackAdminAuthWrapper._tokens = {"secret-token"}
+        request, called, result = await self._run_dispatch("Bearer secret-token")
+        assert request.state.user_id == "loopback-admin"
+        assert request.state.user_roles == ["admin"]
+        assert request.state.permissions == ["*"]
+        assert called["next"] is True
+        assert result == "response"
+
+    @pytest.mark.asyncio
+    async def test_non_matching_token_leaves_state_untouched(self):
+        _LoopbackAdminAuthWrapper._tokens = {"secret-token"}
+        request, called, _ = await self._run_dispatch("Bearer wrong")
+        assert not hasattr(request.state, "user_id")
+        assert called["next"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_auth_header_falls_through(self):
+        _LoopbackAdminAuthWrapper._tokens = {"secret-token"}
+        request, called, _ = await self._run_dispatch("")
+        assert not hasattr(request.state, "user_id")
+        assert called["next"] is True
+
+    @pytest.mark.asyncio
+    async def test_non_ascii_token_falls_through_without_stamp(self):
+        _LoopbackAdminAuthWrapper._tokens = {"secret-token"}
+        request, called, _ = await self._run_dispatch("Bearer ünïcödé")
+        # Non-ASCII can never match the secret; state must not be elevated.
+        assert not hasattr(request.state, "user_id")
+        assert called["next"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestLoadLoopbackToken:
+    def test_loads_token_from_sibling_of_pid_file(self, tmp_path):
+        pid_file = tmp_path / "orb-server.pid"
+        token_file = tmp_path / "orb-server.token"
+        token_file.write_text("daemon-token", encoding="ascii")
+        server_config = SimpleNamespace(pid_file=str(pid_file))
+
+        _load_loopback_token(server_config)
+
+        assert _LoopbackAdminAuthWrapper._tokens == {"daemon-token"}
+        assert _LoopbackAdminAuthWrapper._token_file == token_file
+
+    def test_missing_token_file_is_silent(self, tmp_path):
+        pid_file = tmp_path / "orb-server.pid"  # no sibling .token file created
+        server_config = SimpleNamespace(pid_file=str(pid_file))
+
+        _load_loopback_token(server_config)
+
+        # No token registered; call must not raise.
+        assert _LoopbackAdminAuthWrapper._tokens == set()
+
+    def test_empty_token_file_registers_nothing(self, tmp_path):
+        pid_file = tmp_path / "orb-server.pid"
+        (tmp_path / "orb-server.token").write_text("  ", encoding="ascii")
+        server_config = SimpleNamespace(pid_file=str(pid_file))
+
+        _load_loopback_token(server_config)
+
+        assert _LoopbackAdminAuthWrapper._tokens == set()

--- a/tests/unit/application/services/orchestration/test_get_request_status_orchestrator.py
+++ b/tests/unit/application/services/orchestration/test_get_request_status_orchestrator.py
@@ -15,6 +15,24 @@ from orb.application.services.orchestration.dtos import (
 from orb.application.services.orchestration.get_request_status import GetRequestStatusOrchestrator
 
 
+class _FakeClock:
+    """Deterministic monotonic clock for wall-clock timeout tests.
+
+    ``monotonic()`` returns virtual seconds; ``advance()`` moves it forward.
+    Patching both ``asyncio.sleep`` (to advance) and ``time.monotonic`` (to
+    read) lets the timeout logic be exercised without any real waiting.
+    """
+
+    def __init__(self) -> None:
+        self._now: float = 0.0
+
+    def monotonic(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
 @pytest.fixture
 def mock_command_bus():
     bus = MagicMock()
@@ -341,17 +359,76 @@ class TestGetRequestStatusOrchestratorWait:
         pending.model_dump.return_value = {"request_id": "req-1", "status": "pending"}
         mock_query_bus.execute.return_value = pending
 
-        async def _no_sleep(_seconds):
-            return None
+        # Fake monotonic clock: the (no-op) sleep advances virtual wall-clock by
+        # the requested duration, so the timeout is driven by simulated time
+        # rather than real elapsed time — the loop is deterministic.
+        clock = _FakeClock()
+
+        async def _fake_sleep(seconds):
+            clock.advance(seconds)
 
         monkeypatch.setattr(
-            "orb.application.services.orchestration.get_request_status.asyncio.sleep", _no_sleep
+            "orb.application.services.orchestration.get_request_status.asyncio.sleep", _fake_sleep
         )
-        # timeout_seconds=2 with a 2s interval → one initial fetch + one poll, then stop.
+        monkeypatch.setattr(
+            "orb.application.services.orchestration.get_request_status.time.monotonic",
+            clock.monotonic,
+        )
+        # timeout_seconds=2 with a 2s interval → initial fetch (t=0), one poll
+        # (sleep advances t to 2), then t-start=2 is not < 2 → stop.
         input = GetRequestStatusInput(request_ids=["req-1"], wait=True, timeout_seconds=2)
         result = await orchestrator.execute(input)
         assert result.requests[0]["status"] == "pending"
         assert mock_query_bus.execute.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_wait_timeout_counts_fetch_latency_not_just_intervals(
+        self, orchestrator, mock_query_bus, monkeypatch
+    ):
+        """Slow fetches consume the wall-clock budget, so the poll stops early.
+
+        Regression for the interval-counting bug: previously ``elapsed`` grew by
+        a constant ``_POLL_INTERVAL_SECONDS`` per loop and ignored how long each
+        ``_fetch_once`` took, so a slow provider could blow past
+        ``timeout_seconds``.  With true monotonic tracking, a fetch that itself
+        consumes the whole budget must terminate the poll after a single extra
+        iteration rather than continuing to poll.
+        """
+        pending = MagicMock(spec=["model_dump"])
+        pending.model_dump.return_value = {"request_id": "req-1", "status": "pending"}
+        mock_query_bus.execute.return_value = pending
+
+        clock = _FakeClock()
+
+        # Each fetch itself takes 10 virtual seconds of wall-clock.
+        original_fetch = orchestrator._fetch_once
+
+        async def _slow_fetch(inp):
+            clock.advance(10)
+            return await original_fetch(inp)
+
+        async def _fake_sleep(seconds):
+            clock.advance(seconds)
+
+        monkeypatch.setattr(orchestrator, "_fetch_once", _slow_fetch)
+        monkeypatch.setattr(
+            "orb.application.services.orchestration.get_request_status.asyncio.sleep", _fake_sleep
+        )
+        monkeypatch.setattr(
+            "orb.application.services.orchestration.get_request_status.time.monotonic",
+            clock.monotonic,
+        )
+
+        # timeout=5. start=monotonic() at t=0 (before first fetch).  Initial fetch
+        # advances t to 10. Loop check: 10-0=10 < 5 is False → no further polls.
+        # An interval-only bound (elapsed=0 after the initial fetch) would have
+        # entered the loop and issued more fetches, overshooting the 5s cap.
+        input = GetRequestStatusInput(request_ids=["req-1"], wait=True, timeout_seconds=5)
+        result = await orchestrator.execute(input)
+        assert result.requests[0]["status"] == "pending"
+        assert mock_query_bus.execute.call_count == 1, (
+            "fetch latency must count toward the timeout budget"
+        )
 
     @pytest.mark.asyncio
     async def test_wait_tolerates_transient_error_then_returns_terminal(

--- a/tests/unit/application/services/orchestration/test_get_request_status_orchestrator.py
+++ b/tests/unit/application/services/orchestration/test_get_request_status_orchestrator.py
@@ -354,10 +354,73 @@ class TestGetRequestStatusOrchestratorWait:
         assert mock_query_bus.execute.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_wait_treats_error_entry_as_terminal(self, orchestrator, mock_query_bus):
-        mock_query_bus.execute.side_effect = Exception("boom")
+    async def test_wait_tolerates_transient_error_then_returns_terminal(
+        self, orchestrator, mock_query_bus, monkeypatch
+    ):
+        """A transient sync error on the first poll must NOT abort the wait.
+
+        The provider blips on the first fetch (raises), then recovers and
+        returns a terminal ``complete``. The loop must keep polling past the
+        transient error and return the terminal result, not the error entry.
+        """
+        done = MagicMock(spec=["model_dump"])
+        done.model_dump.return_value = {"request_id": "req-1", "status": "complete"}
+        # First fetch blips; subsequent fetches succeed terminally.
+        mock_query_bus.execute.side_effect = [Exception("transient blip"), done, done]
+
+        async def _no_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr(
+            "orb.application.services.orchestration.get_request_status.asyncio.sleep", _no_sleep
+        )
         input = GetRequestStatusInput(request_ids=["req-1"], wait=True, timeout_seconds=300)
         result = await orchestrator.execute(input)
-        # An errored entry short-circuits polling so the caller is not stuck.
+
+        assert mock_query_bus.execute.call_count >= 2, "poll must continue past the transient error"
+        assert result.requests[0]["status"] == "complete"
+        assert "error" not in result.requests[0]
+
+    @pytest.mark.asyncio
+    async def test_wait_aborts_after_max_consecutive_transient_errors(
+        self, orchestrator, mock_query_bus, monkeypatch
+    ):
+        """More than N consecutive transient errors stops the poll with the last snapshot."""
+        from orb.application.services.orchestration.base import MAX_CONSECUTIVE_POLL_ERRORS
+
+        mock_query_bus.execute.side_effect = Exception("still blipping")
+
+        async def _no_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr(
+            "orb.application.services.orchestration.get_request_status.asyncio.sleep", _no_sleep
+        )
+        input = GetRequestStatusInput(request_ids=["req-1"], wait=True, timeout_seconds=300)
+        result = await orchestrator.execute(input)
+
+        # Initial fetch + retries up to the consecutive-error cap, then stop —
+        # well short of the 300s / 2s = 150 polls a timeout-only bound implies.
+        assert mock_query_bus.execute.call_count == MAX_CONSECUTIVE_POLL_ERRORS
+        assert result.requests[0]["error"] == "still blipping"
+
+    @pytest.mark.asyncio
+    async def test_wait_stops_immediately_on_genuine_terminal_failure(
+        self, orchestrator, mock_query_bus, monkeypatch
+    ):
+        """A real terminal FAILED status (not a sync blip) stops the poll at once."""
+        failed = MagicMock(spec=["model_dump"])
+        failed.model_dump.return_value = {"request_id": "req-1", "status": "failed"}
+        mock_query_bus.execute.return_value = failed
+
+        async def _no_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr(
+            "orb.application.services.orchestration.get_request_status.asyncio.sleep", _no_sleep
+        )
+        input = GetRequestStatusInput(request_ids=["req-1"], wait=True, timeout_seconds=300)
+        result = await orchestrator.execute(input)
+
         assert mock_query_bus.execute.call_count == 1
-        assert result.requests[0]["error"] == "boom"
+        assert result.requests[0]["status"] == "failed"

--- a/tests/unit/config/test_configuration_manager_coverage.py
+++ b/tests/unit/config/test_configuration_manager_coverage.py
@@ -566,6 +566,60 @@ class TestSavePersistsOnlyUserConfig:
         # merged defaults (e.g. no top-level "version", "provider", "logging").
         assert on_disk == {"request": {"default_timeout": 222}}
 
+    def test_set_dict_value_replaces_subtree_on_disk_no_stale_keys(self, tmp_path):
+        """``set`` of a dict must REPLACE the on-disk subtree, not deep-merge it.
+
+        ``set`` has replace semantics in memory: setting ``provider`` to a new
+        dict drops the old ``providers`` sibling. Persistence must match — a
+        deep-merge would retain the stale ``providers`` key on disk, so after a
+        reload the in-memory and on-disk states would diverge.
+        """
+        from orb.config.managers.configuration_manager import ConfigurationManager
+
+        user_config = {
+            "provider": {"active_provider": "aws", "providers": ["old-aws-entry"]},
+        }
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(user_config))
+
+        mgr = ConfigurationManager(config_file=str(config_path))
+        # Replace the whole ``provider`` subtree with a value that omits
+        # ``providers`` — the in-memory result no longer has that key.
+        mgr.set("provider", {"active_provider": "gcp"})
+        in_memory = mgr.get("provider")
+        assert in_memory == {"active_provider": "gcp"}
+
+        mgr.save(str(config_path))
+        on_disk = json.loads(config_path.read_text())
+
+        # On disk must match in-memory: the stale ``providers`` key is GONE.
+        assert on_disk["provider"] == {"active_provider": "gcp"}
+        assert "providers" not in on_disk["provider"]
+        assert on_disk["provider"] == in_memory
+
+    def test_update_dict_value_still_deep_merges(self, tmp_path):
+        """``update`` keeps deep-merge semantics — set-replace must not leak into it.
+
+        ``update`` merges into existing dicts, so a partial update of the
+        ``provider`` subtree must preserve sibling keys the update did not
+        mention (unlike ``set``, which replaces wholesale).
+        """
+        from orb.config.managers.configuration_manager import ConfigurationManager
+
+        user_config = {
+            "provider": {"active_provider": "aws", "region": "us-east-1"},
+        }
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(user_config))
+
+        mgr = ConfigurationManager(config_file=str(config_path))
+        mgr.update({"provider": {"active_provider": "gcp"}})
+        mgr.save(str(config_path))
+
+        on_disk = json.loads(config_path.read_text())
+        # ``region`` survives the deep-merge; only ``active_provider`` changed.
+        assert on_disk["provider"] == {"active_provider": "gcp", "region": "us-east-1"}
+
 
 # ---------------------------------------------------------------------------
 # get_raw_config

--- a/tests/unit/interface/test_request_command_handlers.py
+++ b/tests/unit/interface/test_request_command_handlers.py
@@ -540,6 +540,47 @@ class TestHandleGetRequestStatusDetailed:
 
 
 @pytest.mark.unit
+class TestHandleGetRequestStatusWait:
+    """--wait / --timeout must be forwarded into GetRequestStatusInput."""
+
+    @pytest.mark.asyncio
+    async def test_wait_and_timeout_forwarded(self):
+        """--wait set + --timeout value → DTO receives wait=True and the timeout."""
+        from orb.application.dto.interface_response import InterfaceResponse
+
+        container, _scheduler, _, _, status_orch, *_, formatter = _mock_container()
+        status_orch.execute.return_value = GetRequestStatusOutput(requests=[])
+        formatter.format_request_status.return_value = InterfaceResponse(data={"requests": []})
+
+        args = _make_namespace(request_id="req-777", all=False, wait=True, timeout=42)
+
+        args._container = container
+        await handle_get_request_status(args)
+
+        call_input = status_orch.execute.call_args[0][0]
+        assert call_input.wait is True
+        assert call_input.timeout_seconds == 42
+
+    @pytest.mark.asyncio
+    async def test_wait_defaults_false_when_flag_absent(self):
+        """No --wait on args → DTO receives wait=False and default timeout."""
+        from orb.application.dto.interface_response import InterfaceResponse
+
+        container, _scheduler, _, _, status_orch, *_, formatter = _mock_container()
+        status_orch.execute.return_value = GetRequestStatusOutput(requests=[])
+        formatter.format_request_status.return_value = InterfaceResponse(data={"requests": []})
+
+        args = _make_namespace(request_id="req-778", all=False)
+
+        args._container = container
+        await handle_get_request_status(args)
+
+        call_input = status_orch.execute.call_args[0][0]
+        assert call_input.wait is False
+        assert call_input.timeout_seconds == 300
+
+
+@pytest.mark.unit
 class TestHandleGetRequestStatusMultiId:
     """2014: multi-ID paths in handle_get_request_status."""
 

--- a/tests/unit/misc2/test_auth_audit_logger.py
+++ b/tests/unit/misc2/test_auth_audit_logger.py
@@ -1,10 +1,15 @@
 """Tests for AuthAuditLogger — structured security-event audit logging."""
 
+import json
 import logging
 
 import pytest
 
-from orb.infrastructure.logging.logger import AuthAuditLogger
+from orb.infrastructure.logging.logger import (
+    AuthAuditLogger,
+    JsonFormatter,
+    setup_audit_logger,
+)
 
 
 @pytest.mark.unit
@@ -135,3 +140,126 @@ class TestAuthAuditLogger:
         assert rec["event_type"] == "PERMISSION_DENIED"
         assert rec["user_id"] == "dave"
         assert rec["path"] == "/api/v1/admin"
+
+
+@pytest.mark.unit
+class TestAuditJsonSerialization:
+    """The JSON sink must serialize the structured security fields.
+
+    Guards against the audit trail becoming non-attributable: security fields
+    passed via stdlib ``extra=`` land as top-level LogRecord attributes, and the
+    JSON formatter must surface them rather than dropping them.  Formatting goes
+    THROUGH ``JsonFormatter.format`` (not ``record.__dict__``) so the assertion
+    reflects exactly what is written to the audit file / SIEM.
+    """
+
+    def _format_event(self, fn) -> dict:
+        """Emit one audit event via *fn* and return the serialized JSON as a dict."""
+        formatter = JsonFormatter(log_type="audit")
+        captured: dict[str, logging.LogRecord] = {}
+
+        class _Grab(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured["record"] = record
+
+        audit_log = logging.getLogger("orb.audit")
+        prev_level = audit_log.level
+        prev_propagate = audit_log.propagate
+        handler = _Grab()
+        audit_log.addHandler(handler)
+        audit_log.setLevel(logging.INFO)
+        audit_log.propagate = False
+        try:
+            fn()
+        finally:
+            audit_log.removeHandler(handler)
+            audit_log.setLevel(prev_level)
+            audit_log.propagate = prev_propagate
+        assert "record" in captured, "no audit record was emitted"
+        return json.loads(formatter.format(captured["record"]))
+
+    def test_auth_failure_security_fields_present_in_json(self) -> None:
+        """AUTH_FAILURE serialized JSON must carry the attributable security fields."""
+        al = AuthAuditLogger()
+        payload = self._format_event(
+            lambda: al.log_auth_failure(
+                user_id="alice",
+                client_ip="10.0.0.7",
+                path="/api/v1/machines",
+                method="POST",
+                reason="invalid_token",
+                auth_strategy="enhanced_bearer_token",
+            )
+        )
+        # These fields would all be DROPPED by a formatter that only merges a
+        # non-existent ``record.extra`` sub-dict.
+        assert payload["event_type"] == "AUTH_FAILURE"
+        assert payload["client_ip"] == "10.0.0.7"
+        assert payload["user_id"] == "alice"
+        assert payload["reason"] == "invalid_token"
+        assert payload["path"] == "/api/v1/machines"
+        assert payload["method"] == "POST"
+        assert payload["auth_strategy"] == "enhanced_bearer_token"
+
+    def test_reason_is_status_name_not_token_content(self) -> None:
+        """The serialized reason is a generic classification, never credential material."""
+        al = AuthAuditLogger()
+        payload = self._format_event(
+            lambda: al.log_auth_failure(
+                client_ip="1.2.3.4",
+                path="/x",
+                method="GET",
+                reason="expired",
+            )
+        )
+        assert payload["reason"] == "expired"
+
+
+@pytest.mark.unit
+class TestAuditLevelIndependence:
+    """Audit events must emit regardless of the application's root log level."""
+
+    def test_audit_events_emit_when_root_level_is_warning(self) -> None:
+        """With root=WARNING, an INFO audit event must still reach the sink."""
+        root = logging.getLogger()
+        audit_log = logging.getLogger("orb.audit")
+        prev_root_level = root.level
+        prev_audit_level = audit_log.level
+        prev_handlers = list(audit_log.handlers)
+        prev_propagate = audit_log.propagate
+
+        received: list[logging.LogRecord] = []
+
+        class _Grab(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                received.append(record)
+
+        try:
+            # Simulate a production config where the app log level filters INFO.
+            root.setLevel(logging.WARNING)
+            # Reset the audit logger so setup_audit_logger performs its wiring.
+            for h in prev_handlers:
+                audit_log.removeHandler(h)
+            audit_log.setLevel(logging.NOTSET)
+
+            setup_audit_logger(None)
+            # setEffectiveLevel must be INFO despite root being WARNING.
+            assert audit_log.getEffectiveLevel() == logging.INFO
+
+            audit_log.addHandler(_Grab())
+            AuthAuditLogger().log_auth_failure(
+                client_ip="1.2.3.4",
+                path="/x",
+                method="GET",
+                reason="invalid",
+            )
+            assert len(received) == 1, "audit event was silenced when root level > INFO"
+            assert received[0].levelno == logging.INFO
+        finally:
+            root.setLevel(prev_root_level)
+            for h in list(audit_log.handlers):
+                audit_log.removeHandler(h)
+            for h in prev_handlers:
+                audit_log.addHandler(h)
+            audit_log.setLevel(prev_audit_level)
+            audit_log.propagate = prev_propagate


### PR DESCRIPTION
## Description
Follow-up fixes for issues found reviewing the recently-merged quality work. Each is an independent correctness fix with a regression test.

### Security / logging
- **Audit trail attribution** — the structured auth audit logger emitted its records through a JSON formatter that dropped every structured field (user_id, client_ip, reason, path, method), and the audit logger inherited the app root log level so events were silently discarded when the level was above INFO. The formatter now serialises all fields and the audit logger pins its own level, so the security audit trail is attributable and independent of the app log level.
- **HTTPS behind a TLS-terminating proxy** — with `require_https` enabled behind an off-host proxy that forwards plain HTTP, the redirect middleware saw scheme `http` and produced an infinite 307 loop. A scheme-only forwarded-proto middleware, trusting only configured proxies, resolves the scheme correctly; a spoofed header from an untrusted peer is ignored and HTTPS enforcement is preserved.

### Correctness
- **`config set` persistence** — a dict-valued `set()` replaced the value in memory but deep-merged it on disk, re-introducing keys the user had replaced. Persistence now replaces at the edited path, matching in-memory semantics.
- **`--wait` resilience** — request-status `--wait` polling aborted on the first transient provider-sync error, reporting failure for a healthy request. It now tolerates a bounded number of consecutive transient errors before giving up, matching the acquire/return poll loops; a genuine terminal failure still stops immediately.

### UI
- **Live row updates** — a status-transition SSE event patched only the row status, leaving counts and the progress bar stale; the patch now refreshes the derived count/progress fields too.
- **SSE reconnect replay** — the stream assigned a per-event sequence id but never transmitted it, so a reconnect during an outage permanently lost events (a missed terminal event left a row stuck). The server now emits the id on the wire, the client resumes from the last id via `since_seq=`, and a replay-truncated signal triggers a full refresh.

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Unit tests added/updated
- Each fix carries a regression test that fails on the prior behaviour and passes after. Type checks clean on all changed files; the enforced lint set is clean; the affected suites pass.

## Security Considerations
- [x] Restores auth audit-trail attribution and fixes an HTTPS-enforcement edge case; the forwarded-proto trust is limited to configured proxies.

## Reviewers
@finos/open-resource-broker-maintainers

### CI / release
- **npm trusted publishing** — the SDK publish job set up Node 20, but npm OIDC trusted publishing to registry.npmjs.org requires Node >= 22.14.0 (in addition to npm CLI >= 11.5.1). On Node 20 the OIDC exchange never ran and npm fell back to (empty) token auth, failing with `ENEEDAUTH` on the trusted path — which is why automatic npm releases never published while token-based publishing worked. The publish job now uses Node 22, and logs the active node/npm versions before publishing so an auth failure is diagnosable.