### PR TITLE
docs(providers): document the four AWS EC2 provisioning types

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -166,6 +166,12 @@ nav:
       - Deployment Scenarios: hostfactory/deployment_scenarios.md
       - Supported APIs: hostfactory/supported-apis.md
   - Providers:
+    - AWS:
+      - EC2 Instances (RunInstances): providers/aws/run-instances.md
+      - Auto Scaling Groups: providers/aws/asg.md
+      - Spot Fleet: providers/aws/spot-fleet.md
+      - EC2 Fleet: providers/aws/ec2-fleet.md
+      - Lambda MicroVMs: providers/aws/microvm.md
     - Kubernetes:
       - Overview: providers/k8s/index.md
       - Infrastructure Discovery: providers/k8s/discovery.md

--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -50,7 +50,7 @@ Welcome to the Open Resource Broker documentation. ORB lets you define what comp
 
 ## Features
 
-- **AWS Provider** — EC2 Instances, Auto Scaling Groups, Spot Fleet, EC2 Fleet
+- **AWS Provider** — [EC2 Instances](providers/aws/run-instances.md), [Auto Scaling Groups](providers/aws/asg.md), [Spot Fleet](providers/aws/spot-fleet.md), [EC2 Fleet](providers/aws/ec2-fleet.md), [Lambda MicroVMs](providers/aws/microvm.md)
 - **CLI** — primary interface for all operations
 - **REST API** — HTTP endpoints for service integration
 - **Python SDK** — async-first programmatic access

--- a/docs/root/providers/aws/asg.md
+++ b/docs/root/providers/aws/asg.md
@@ -1,0 +1,262 @@
+# AWS Auto Scaling Group Provider
+
+The ASG handler provisions capacity through an [Auto Scaling Group](https://docs.aws.amazon.com/autoscaling/ec2/userguide/auto-scaling-groups.html). Each ORB request creates a dedicated ASG, sized to the requested count, which AWS then keeps at that size — replacing instances that fail EC2 health checks.
+
+Use it when you want AWS to maintain capacity for you across availability zones. Use [EC2 Fleet](ec2-fleet.md) or [Spot Fleet](spot-fleet.md) when you want fleet-style provisioning without a long-lived scaling group, or [RunInstances](run-instances.md) for one-shot launches.
+
+## Quick start
+
+```bash
+pip install "orb-py[aws]"
+orb init
+```
+
+### 1. Create a template
+
+```json
+{
+  "template_id": "service-tier",
+  "name": "Service Tier ASG",
+  "description": "Long-running workers with health-checked replacement",
+  "provider_api": "ASG",
+  "image_id": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
+  "machine_types": {"t3.medium": 2, "t3.xlarge": 4},
+  "subnet_ids": ["subnet-0f984e48e6e899311", "subnet-1a2b3c4d5e6f7a8b9"],
+  "security_group_ids": ["sg-0528dfedb6d763b16"],
+  "price_type": "ondemand",
+  "max_machines": 100,
+  "tags": {"Environment": "prod"}
+}
+```
+
+### 2. Request capacity
+
+```bash
+orb machines request service-tier 6
+```
+
+With the weights above, six capacity units is satisfied by three `t3.medium` (2 each), or one `t3.medium` plus one `t3.xlarge`, or any other combination summing to 6 — see [Weighted capacity](#weighted-capacity).
+
+### 3. Check status
+
+```bash
+orb requests status <request-id>
+```
+
+### 4. Return capacity
+
+```bash
+orb machines return i-0abc1234def567890 i-0def5678abc123456
+```
+
+## Template configuration
+
+The handler uses `provider_api: "ASG"`. Each request creates a launch template, then calls `create_auto_scaling_group` with a name of the form `<asg prefix><request-id>`, where the prefix comes from `resource.prefixes.asg` and is empty unless you configure one.
+
+### Top-level fields
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `provider_api` | Yes | `string` | Must be `"ASG"` |
+| `image_id` | Yes | `string` | AMI id or SSM parameter path. |
+| `machine_types` | No | `object` | Instance type → weighted capacity. Drives the `MixedInstancesPolicy` overrides. |
+| `subnet_ids` | No | `list[string]` | Becomes `VPCZoneIdentifier` (comma-joined). Supply subnets in several AZs for multi-AZ placement. |
+| `security_group_ids` | No | `list[string]` | Security groups, applied via the launch template. |
+| `price_type` | No | `string` | `"ondemand"` (default), `"spot"`, or `"heterogeneous"`. |
+| `percent_on_demand` | No | `integer` | 0–100. On-demand share of capacity above the base. Forces a `MixedInstancesPolicy`. |
+| `allocation_strategy` | No | `string` | Spot allocation strategy. Converted to the ASG hyphenated form. |
+| `max_price` | No | `float` | Maximum spot price per hour. |
+| `abis_instance_requirements` | No | `object` | Attribute-based instance selection. Takes precedence over `machine_types`. |
+| `max_machines` | No | `integer` | Maximum capacity this template may provision. |
+| `launch_template_id` | No | `string` | Pin an existing launch template. |
+| `context` | No | `string` | Passed through as the ASG `Context` field. |
+| `tags` | No | `object` | Tags applied to the ASG with `PropagateAtLaunch: true`. |
+| `provider_api_spec` | No | `object` | Native `CreateAutoScalingGroup` parameters. See [Native spec](#native-spec). |
+
+### Group sizing
+
+ORB derives the group's bounds from the requested count rather than exposing them as template fields:
+
+| ASG field | Value |
+|---|---|
+| `MinSize` | `0` |
+| `MaxSize` | `requested_count * 2` |
+| `DesiredCapacity` | `requested_count` |
+| `DefaultCooldown` | `300` |
+| `HealthCheckType` | `EC2` |
+| `HealthCheckGracePeriod` | `300` |
+| `NewInstancesProtectedFromScaleIn` | `true` |
+
+`MinSize: 0` lets ORB scale the group to empty on return instead of fighting a floor. `MaxSize` is set to twice the request so AWS has headroom to replace unhealthy instances. Scale-in protection is on so AWS does not reclaim instances ORB has handed out to a scheduler.
+
+Override any of these with a [native spec](#native-spec) if your workload needs different bounds, a different health check type, or ELB health checks.
+
+### Weighted capacity
+
+Values in `machine_types` become `WeightedCapacity` on each `MixedInstancesPolicy` override. `DesiredCapacity` is then measured in those units, not in instances:
+
+```json
+{
+  "machine_types": {"t3.medium": 2, "t3.xlarge": 4}
+}
+```
+
+A request for 8 units can be satisfied by four `t3.medium`, two `t3.xlarge`, or one of each plus one more `t3.medium`. AWS picks the mix. This is why the fulfilment check sums weights rather than counting instances — see [Fulfilment semantics](#fulfilment-semantics).
+
+Weights of `0` or omitted values leave `WeightedCapacity` unset, which AWS treats as 1.
+
+### Pricing and mixed instances
+
+The shape of the generated config depends on pricing:
+
+| Configuration | Generated config |
+|---|---|
+| `price_type: "ondemand"`, no `percent_on_demand` | `MixedInstancesPolicy` with instance-type overrides (or a plain `LaunchTemplate` when neither `machine_types` nor ABIS is set). No `InstancesDistribution`. |
+| `price_type: "spot"` | `InstancesDistribution` with `OnDemandPercentageAboveBaseCapacity: 0` — all capacity above the base is spot. |
+| `price_type: "heterogeneous"` or any `percent_on_demand` | `InstancesDistribution` with `OnDemandPercentageAboveBaseCapacity: <percent_on_demand>`. |
+
+`OnDemandBaseCapacity` is always `0`, so the percentage governs the whole group. When `allocation_strategy` is set it becomes `SpotAllocationStrategy`.
+
+Example 30% on-demand, 70% spot:
+
+```json
+{
+  "template_id": "mixed-tier",
+  "provider_api": "ASG",
+  "machine_types": {"t3.medium": 2, "t3.large": 2, "t3.xlarge": 4},
+  "price_type": "heterogeneous",
+  "percent_on_demand": 30,
+  "allocation_strategy": "lowestPrice"
+}
+```
+
+### Allocation strategies
+
+ASG uses the hyphenated wire format. ORB accepts camelCase, hyphenated, or snake_case in templates and converts on the way out:
+
+| Template value | Sent to AWS |
+|---|---|
+| `lowestPrice` | `lowest-price` |
+| `capacityOptimized` | `capacity-optimized` |
+| `capacityOptimizedPrioritized` | `capacity-optimized-prioritized` |
+| `priceCapacityOptimized` | `price-capacity-optimized` |
+| `diversified` | `diversified` |
+
+`lowest-price` is the default when no strategy is set. Note that `prioritized` has no ASG spot equivalent and falls back to the default.
+
+### Attribute-based instance selection
+
+Setting `abis_instance_requirements` replaces the instance-type overrides with a single `InstanceRequirements` override, letting AWS choose any matching type:
+
+```json
+{
+  "provider_api": "ASG",
+  "abis_instance_requirements": {
+    "vcpu_count": {"min": 2, "max": 8},
+    "memory_mib": {"min": 4096, "max": 32768},
+    "cpu_manufacturers": ["intel", "amd"]
+  }
+}
+```
+
+When ABIS is present, `machine_types` is ignored. The requirements are also injected into a native spec that omits them. See [Attribute-Based Instance Selection](../../user_guide/abis.md).
+
+### Native spec
+
+A `provider_api_spec` is rendered and merged over the generated config. ORB always enforces `AutoScalingGroupName`, defaults `NewInstancesProtectedFromScaleIn` to `true`, and patches the launch template id and version into either `MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification` or the top-level `LaunchTemplate`, whichever the spec uses. See the [Native Spec Reference](../../api/native-spec-reference.md).
+
+## Machine data
+
+Instances carry the ASG name as `resource_id`:
+
+```json
+{
+  "instance_id": "i-0abc1234def567890",
+  "resource_id": "req-abc123def456",
+  "status": "running",
+  "private_ip": "10.0.1.42",
+  "instance_type": "t3.medium",
+  "provider_api": "ASG",
+  "provider_data": {
+    "cloud_host_id": "i-0abc1234def567890",
+    "vcpus": 2,
+    "availability_zone": "us-east-1a",
+    "region": "us-east-1"
+  }
+}
+```
+
+Instances in `Terminating`, `Terminated`, `Detaching`, and `Detached` lifecycle states are excluded from the reported set.
+
+## Fulfilment semantics
+
+The check is capacity-based, not instance-based: ORB sums `WeightedCapacity` across `InService` instances and compares that to `DesiredCapacity`.
+
+| Condition | State |
+|---|---|
+| In-service weighted capacity `>= DesiredCapacity`, nothing pending, nothing failed | `fulfilled` |
+| Instances in a failure state, none in service, none pending | `failed` |
+| Anything else | `in_progress` |
+
+Instances in `Pending`, `Pending:Wait`, and `Pending:Proceed` count as pending. Unweighted groups contribute 1 unit per in-service instance, so the same rule covers both cases.
+
+Because ASG keeps reconciling toward `DesiredCapacity`, this handler has no terminal `partial` state — a shortfall stays `in_progress` while AWS keeps trying. `requires_async_polling` is `true`: the create call returns only the group name, and instances arrive later.
+
+When one request spans several ASGs, all groups must be fulfilled for the request to be fulfilled; any failure makes it failed, any partial makes it partial, and otherwise it stays in progress.
+
+## Release behaviour
+
+Returning instances from an ASG is more involved than terminating them, because AWS would otherwise replace them immediately.
+
+1. **Group the instances.** ORB maps each instance to its ASG, from the request's stored resource mapping when available, otherwise via `describe_auto_scaling_instances`. Instances that belong to no ASG are terminated directly.
+2. **Filter to current members.** Only instances in `InService` or `Standby` are processed. This is an idempotency guard: an instance already detached or terminated had its capacity decremented on the first call, and counting it again would double-decrement.
+3. **Terminate weight-aware.** Each instance is terminated with `terminate_instance_in_auto_scaling_group` and `ShouldDecrementDesiredCapacity: true`. This decrements `DesiredCapacity` by the instance's `WeightedCapacity` rather than by 1, which is symmetric with how weighted groups scale up. `detach_instances` would decrement by count and drift the group's capacity.
+4. **Clamp `MinSize`.** The group is re-described to read live `DesiredCapacity`, and `MinSize` is lowered if it now exceeds it.
+5. **Delete when empty.** `DesiredCapacity` of zero means the group is empty, so ORB deletes the ASG (`ForceDelete: true`) and cleans up the launch template.
+
+Cancelling a request deletes the ASG directly.
+
+A separate pre-termination path (`reduce_capacity`) lowers `DesiredCapacity` and `MinSize` before instances are terminated by other means. Every failure in that path is warning-only, so a capacity-reduction hiccup never blocks a return.
+
+## IAM permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:CreateAutoScalingGroup",
+        "autoscaling:UpdateAutoScalingGroup",
+        "autoscaling:DeleteAutoScalingGroup",
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
+        "autoscaling:CreateOrUpdateTags",
+        "autoscaling:SetDesiredCapacity",
+        "autoscaling:TerminateInstanceInAutoScalingGroup",
+        "ec2:DescribeInstances",
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+ASG tagging uses `autoscaling:CreateOrUpdateTags` rather than `ec2:CreateTags`. Tag failures are non-fatal: the group is created and the request proceeds without `orb:` tags. Launch template and SSM permissions are shared with the other handlers — see the [IAM Permissions Guide](../../deployment/iam-permissions.md).
+
+## Limitations
+
+- **Group bounds are derived, not configured** — `MinSize`, `MaxSize`, cooldown, and health check settings come from the requested count unless you supply a native spec.
+- **EC2 health checks only** by default; ELB health checks need a native spec.
+- **No scaling policies or lifecycle hooks** are created. ORB reads `instance_protection` and `lifecycle_hooks` attributes if a template carries them, but they are not part of the template schema.
+- **No terminal partial state** — an under-filled group reports `in_progress` while AWS keeps reconciling, so a request for capacity that cannot be satisfied will not settle on its own.
+- **One ASG per request** — ORB does not reuse an existing group across requests.
+
+## Related
+
+- [EC2 Fleet](ec2-fleet.md) — fleet provisioning with instant, request, and maintain modes
+- [Spot Fleet](spot-fleet.md) — spot-focused diversification
+- [EC2 Instances (RunInstances)](run-instances.md) — synchronous single-type launches
+- [Attribute-Based Instance Selection](../../user_guide/abis.md) — describing requirements instead of instance types

--- a/docs/root/providers/aws/ec2-fleet.md
+++ b/docs/root/providers/aws/ec2-fleet.md
@@ -1,0 +1,278 @@
+# AWS EC2 Fleet Provider
+
+The EC2 Fleet handler provisions capacity through the [EC2 CreateFleet API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateFleet.html). It is the most flexible of the AWS provisioning types: one fleet can mix on-demand and spot capacity, span many instance types and availability zones, and be either synchronous or continuously reconciled depending on the fleet type.
+
+This is the default `provider_api` in the shipped configuration. Use [Spot Fleet](spot-fleet.md) when you need its per-override priority semantics, [ASG](asg.md) when you want a long-lived health-checked group, or [RunInstances](run-instances.md) for the simplest possible launch.
+
+## Quick start
+
+```bash
+pip install "orb-py[aws]"
+orb init
+```
+
+### 1. Create a template
+
+```json
+{
+  "template_id": "compute-fleet",
+  "name": "Compute Fleet",
+  "description": "Mixed on-demand and spot capacity",
+  "provider_api": "EC2Fleet",
+  "image_id": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
+  "machine_types": {"c5.xlarge": 2, "r5.xlarge": 3},
+  "subnet_ids": ["subnet-0f984e48e6e899311", "subnet-1a2b3c4d5e6f7a8b9"],
+  "security_group_ids": ["sg-0528dfedb6d763b16"],
+  "price_type": "heterogeneous",
+  "percent_on_demand": 30,
+  "allocation_strategy": "capacityOptimized",
+  "max_price": 0.10,
+  "max_machines": 100,
+  "metadata": {"fleet_type": "request"},
+  "tags": {"Environment": "prod"}
+}
+```
+
+### 2. Request capacity
+
+```bash
+orb machines request compute-fleet 10
+```
+
+### 3. Check status
+
+```bash
+orb requests status <request-id>
+```
+
+### 4. Return capacity
+
+```bash
+orb machines return i-0abc1234def567890 i-0def5678abc123456
+```
+
+## Template configuration
+
+The handler uses `provider_api: "EC2Fleet"`. Each request creates a launch template, then calls `create_fleet`.
+
+### Top-level fields
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `provider_api` | Yes | `string` | Must be `"EC2Fleet"` |
+| `image_id` | Yes | `string` | AMI id or SSM parameter path. |
+| `fleet_type` | Yes | `string` | `"instant"`, `"request"`, or `"maintain"`. Defaults to `request` when unset; see [Fleet types](#fleet-types). |
+| `machine_types` | No | `object` | Instance type → weighted capacity. Expanded across subnets into overrides. |
+| `machine_types_ondemand` | No | `object` | Separate instance-type map for the on-demand portion of a heterogeneous fleet. |
+| `subnet_ids` | No | `list[string]` | Target subnets, combined with each instance type. |
+| `security_group_ids` | No | `list[string]` | Security groups. |
+| `price_type` | No | `string` | `"ondemand"` (default), `"spot"`, or `"heterogeneous"`. |
+| `percent_on_demand` | No | `integer` | 0–100. On-demand share for heterogeneous fleets. |
+| `allocation_strategy` | No | `string` | Spot allocation strategy. Converted to the hyphenated EC2 Fleet form. |
+| `allocation_strategy_on_demand` | No | `string` | On-demand allocation strategy, used for heterogeneous fleets. |
+| `max_price` | No | `float` | Becomes `SpotOptions.MaxTotalPrice` — a total spend cap, not a per-instance price. |
+| `abis_instance_requirements` | No | `object` | Attribute-based instance selection, replacing instance-type overrides. |
+| `max_machines` | No | `integer` | Maximum capacity this template may provision. |
+| `context` | No | `string` | Passed through as the fleet `Context` field. |
+| `tags` | No | `object` | Tags applied to the fleet, and to instances for `instant` fleets. |
+| `provider_api_spec` | No | `object` | Native `CreateFleet` parameters. See [Native spec](#native-spec). |
+
+`fleet_type` can be set as a top-level field, in `metadata.fleet_type`, or in `metadata.providerConfig.fleet_type`. An unrecognised value is ignored with a debug log and the default applies.
+
+### Fleet types
+
+Fleet type is the most consequential choice on an EC2 Fleet template, because it changes both provisioning behaviour and how ORB judges fulfilment.
+
+| `fleet_type` | Provisioning | Replaces lost capacity | Fulfilment semantics |
+|---|---|---|---|
+| `instant` | Synchronous — instance ids come back in the `create_fleet` response | No | Count-based, like [RunInstances](run-instances.md#fulfilment-semantics) |
+| `request` | Asynchronous — one-time attempt to reach target capacity | No | Capacity-unit based |
+| `maintain` | Asynchronous — EC2 keeps the fleet at target capacity | Yes | Capacity-unit based |
+
+`maintain` also sets `ReplaceUnhealthyInstances` and `ExcessCapacityTerminationPolicy: termination`.
+
+An `instant` fleet returns instance ids immediately, but those instances are still `pending`, so ORB sets `requires_async_polling: true` and keeps polling until they are running — the create call is not the final verdict. `request` and `maintain` fleets return only a fleet id, which *is* the final synchronous answer, so `requires_async_polling` is `false` for them and instance arrival is purely a polling concern.
+
+Note that the shipped `aws_defaults.json` declares `default_fleet_type: instant` for the handler, while a template with no fleet type at all falls back to `request` during template validation.
+
+### Pricing
+
+`TotalTargetCapacity` is always the requested count. The rest depends on `price_type`:
+
+| `price_type` | Generated `TargetCapacitySpecification` and options |
+|---|---|
+| `ondemand` | `DefaultTargetCapacityType: on-demand`. |
+| `spot` | `DefaultTargetCapacityType: spot`, plus `SpotOptions.AllocationStrategy` when a strategy is set and `SpotOptions.MaxTotalPrice` when `max_price` is set. |
+| `heterogeneous` | `OnDemandTargetCapacity: requested * percent_on_demand / 100` (floored), `SpotTargetCapacity` for the remainder, and `DefaultTargetCapacityType: on-demand`. Both `SpotOptions` and `OnDemandOptions` allocation strategies apply. |
+
+`max_price` maps to `MaxTotalPrice`, which caps total spend for the fleet rather than the price of any one instance. This differs from [Spot Fleet](spot-fleet.md), where `max_price` becomes a per-override `SpotPrice`.
+
+Because the on-demand count is floored, a 10-instance request at 5% on-demand yields zero on-demand capacity. Set `percent_on_demand` high enough to round up to at least one instance if you need guaranteed on-demand capacity.
+
+### Allocation strategies
+
+EC2 Fleet uses the hyphenated wire format. ORB accepts camelCase, hyphenated, or snake_case:
+
+| Template value | Sent to AWS |
+|---|---|
+| `lowestPrice` | `lowest-price` |
+| `capacityOptimized` | `capacity-optimized` |
+| `capacityOptimizedPrioritized` | `capacity-optimized-prioritized` |
+| `priceCapacityOptimized` | `price-capacity-optimized` |
+| `prioritized` | `prioritized` |
+| `diversified` | `diversified` |
+
+`lowest-price` is the default. `allocation_strategy_on_demand` follows the same conversion and falls back to the spot strategy when unset.
+
+### Overrides
+
+`machine_types` and `subnet_ids` expand into the cartesian product of instance type and subnet, each override carrying `InstanceType` and `WeightedCapacity`. Unlike Spot Fleet, EC2 Fleet overrides carry no `Priority` or per-override price.
+
+Weighted capacity means target capacity is measured in units, not instances: a fleet offering `{"c5.xlarge": 2, "r5.xlarge": 3}` can fill a 6-unit request with three `c5.xlarge`, two `r5.xlarge`, or a mix.
+
+### Attribute-based instance selection
+
+`abis_instance_requirements` replaces the instance-type overrides with `InstanceRequirements`, one override per subnet:
+
+```json
+{
+  "provider_api": "EC2Fleet",
+  "abis_instance_requirements": {
+    "vcpu_count": {"min": 4, "max": 16},
+    "memory_mib": {"min": 8192, "max": 65536},
+    "cpu_manufacturers": ["intel", "amd"],
+    "allowed_instance_types": ["m6i.*", "c7g.*"]
+  }
+}
+```
+
+When ABIS is present, `machine_types` is ignored. See [Attribute-Based Instance Selection](../../user_guide/abis.md).
+
+### Native spec
+
+A `provider_api_spec` is rendered and used as the `create_fleet` payload. ORB patches the launch template id and version into `LaunchTemplateConfigs[0].LaunchTemplateSpecification`, and injects ABIS `InstanceRequirements` into that entry's `Overrides` when the spec does not already carry them. See the [Native Spec Reference](../../api/native-spec-reference.md).
+
+## Machine data
+
+Instances carry the fleet id as `resource_id`:
+
+```json
+{
+  "instance_id": "i-0abc1234def567890",
+  "resource_id": "fleet-12a34b56-7c89-0def-1234-56789abcdef0",
+  "status": "running",
+  "private_ip": "10.0.1.42",
+  "instance_type": "c5.xlarge",
+  "provider_api": "EC2Fleet",
+  "provider_data": {
+    "cloud_host_id": "i-0abc1234def567890",
+    "vcpus": 4,
+    "availability_zone": "us-east-1a",
+    "region": "us-east-1"
+  }
+}
+```
+
+For `instant` fleets ORB records the instance ids from the create response and reuses them on later polls. For `request` and `maintain` fleets it calls `describe_fleet_instances` to enumerate active instances.
+
+Per-fleet target capacity is read from the AWS response (`TargetCapacitySpecification.TotalTargetCapacity`) rather than the ORB request total. This matters when a request is split across several fleets: comparing each fleet's running count to the whole-request total would make a fully-running N-way split look 1/N fulfilled per fleet and produce a wrong partial verdict.
+
+## Fulfilment semantics
+
+### Instant fleets
+
+Count-based, matching RunInstances:
+
+| Condition | State |
+|---|---|
+| `running >= requested` and no failures | `fulfilled` |
+| Some instances pending | `in_progress` |
+| Some running, none pending, short of target | `partial` (final, with a capacity diagnostic) |
+| No instances yet | `in_progress` |
+| Instances present and all failed | `failed` |
+
+The `partial` verdict is final because an instant fleet is a synchronous, one-shot allocation — the missing capacity will never arrive.
+
+### Request and maintain fleets
+
+Capacity-unit based, shared with [Spot Fleet](spot-fleet.md#fulfilment-semantics):
+
+| Condition | State |
+|---|---|
+| `FulfilledCapacity >= TargetCapacity`, nothing pending, nothing failed | `fulfilled` |
+| Instances failed, none running, none pending | `failed` |
+| Anything else | `in_progress` |
+
+### Fleet errors and diagnostics
+
+`create_fleet` can return per-override errors alongside a fleet id. ORB normalises them and classifies them into a structured diagnostic so the request records *why* capacity fell short — capacity, authorization, validation, and so on — rather than just that it did.
+
+If the response carries errors **and** no instances, the request fails with a summary of every error. If it carries errors but some instances launched, ORB treats it as partial success and logs a warning. The error codes `InsufficientInstanceCapacity`, `SpotMaxPriceTooLow`, and `MaxSpotInstanceCountExceeded` additionally set `capacity_constrained` on the request's provider data.
+
+### Multi-fleet aggregation
+
+When one request spans several fleets, the combined verdict is resolved in priority order:
+
+1. All fulfilled → `fulfilled`
+2. Any in progress → `in_progress`
+3. Any failed → `failed`
+4. Any partial → `partial`
+5. Otherwise → `in_progress`
+
+`in_progress` is checked before `partial` deliberately: a request must not flip to a terminal partial while another fleet is still booting. That classification is only valid once every fleet has reached a terminal verdict. The aggregate partial is itself only final when every partial contributor is final.
+
+## Release behaviour
+
+Releases follow the shared fleet release flow:
+
+1. **Group instances by fleet**, from the request's resource mapping when available, otherwise by reading the `aws:ec2:fleet-id` tag from `describe_instances` and falling back to a fleet search. Instances belonging to no fleet are terminated directly.
+2. **Fetch fleet details** with `describe_fleets` when not supplied.
+3. **Compute the decision** from fleet type, target capacity, and the summed `WeightedCapacity` of the returned instances.
+4. **Reduce capacity first for `maintain`** fleets via `modify_fleet`, so EC2 does not launch replacements for instances about to be terminated.
+5. **Terminate the instances.**
+6. **Delete the fleet when empty.** `request` fleets re-check that no instances remain outside the batch before deletion, guarding against eventual-consistency lag. `maintain` fleets delete directly on a full return, with a capacity-zero call first in the weighted-capacity edge case.
+7. **Clean up the launch template.**
+
+Instant fleets are a special case: AWS deletes the fleet record itself, so there is no capacity to modify. ORB still attempts an explicit delete and swallows the error if the record is already gone. Because the record may be missing, ORB recovers the request id for launch template cleanup from the `orb:request-id` instance tag — which is why instant fleets tag instances with `orb:fleet-type: instant` at creation.
+
+If any fleet in a multi-fleet return fails to release, the whole return raises after the other fleets are processed.
+
+## IAM permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateFleet",
+        "ec2:ModifyFleet",
+        "ec2:DeleteFleets",
+        "ec2:DescribeFleets",
+        "ec2:DescribeFleetInstances",
+        "ec2:DescribeInstances",
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+`ec2:ModifyFleet` is only exercised for `maintain` fleets during capacity reduction. Spot capacity additionally requires the EC2 Spot service-linked role in the account. Launch template, tagging, and SSM permissions are shared across handlers — see the [IAM Permissions Guide](../../deployment/iam-permissions.md).
+
+## Limitations
+
+- **`max_price` is a total cap**, not a per-instance price — different from Spot Fleet.
+- **On-demand count is floored**, so a small `percent_on_demand` on a small request yields no on-demand capacity.
+- **No per-override priority** — use [Spot Fleet](spot-fleet.md) if you need `Priority` with `capacityOptimizedPrioritized`.
+- **Instant fleet records are deleted by AWS**, so ORB depends on instance tags to recover request context for cleanup.
+- **Request-type fleets do not replace lost capacity** — only `maintain` reconciles.
+
+## Related
+
+- [Spot Fleet](spot-fleet.md) — per-override priority and price, spot-focused
+- [Auto Scaling Groups](asg.md) — health-checked, self-replacing capacity
+- [EC2 Instances (RunInstances)](run-instances.md) — synchronous single-type launches
+- [Native Spec Reference](../../api/native-spec-reference.md) — submitting raw `CreateFleet` parameters

--- a/docs/root/providers/aws/run-instances.md
+++ b/docs/root/providers/aws/run-instances.md
@@ -1,0 +1,210 @@
+# AWS EC2 Instances (RunInstances) Provider
+
+The RunInstances handler provisions individual EC2 instances through the [EC2 RunInstances API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html). It is the simplest of the AWS provisioning types: one API call launches every instance in the request, and the call returns all instance IDs synchronously.
+
+Use it when you want predictable, immediate provisioning of a single instance type. Use [EC2 Fleet](ec2-fleet.md) or [Spot Fleet](spot-fleet.md) instead when you need multiple instance types, capacity diversification, or weighted capacity.
+
+## Quick start
+
+```bash
+pip install "orb-py[aws]"
+orb init
+```
+
+### 1. Create a template
+
+```json
+{
+  "template_id": "web-worker",
+  "name": "Web Worker",
+  "description": "On-demand workers for the web tier",
+  "provider_api": "RunInstances",
+  "image_id": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
+  "machine_types": {"t3.medium": 1},
+  "subnet_ids": ["subnet-0f984e48e6e899311"],
+  "security_group_ids": ["sg-0528dfedb6d763b16"],
+  "price_type": "ondemand",
+  "max_machines": 100,
+  "tags": {"Environment": "dev"}
+}
+```
+
+### 2. Request instances
+
+```bash
+orb machines request web-worker 5
+```
+
+### 3. Check status
+
+```bash
+orb requests status <request-id>
+```
+
+### 4. Return instances
+
+```bash
+orb machines return i-0abc1234def567890 i-0def5678abc123456
+```
+
+## Template configuration
+
+The handler uses `provider_api: "RunInstances"`. Every request creates (or reuses) a launch template, then calls `run_instances` with `MinCount: 1` and `MaxCount: <requested count>`.
+
+### Top-level fields
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `provider_api` | Yes | `string` | Must be `"RunInstances"` |
+| `image_id` | Yes | `string` | AMI id (`ami-*`) or an SSM parameter path (`/aws/service/...`). SSM paths are resolved at request time and need `ssm:GetParameters`. |
+| `machine_types` | No | `object` | Instance-type map. **Only the first key is used** — see [Single instance type](#single-instance-type). |
+| `subnet_ids` | No | `list[string]` | Target subnets. Only one subnet is used per request; see [Networking](#networking). |
+| `security_group_ids` | No | `list[string]` | Security groups to attach. |
+| `price_type` | No | `string` | `"ondemand"` (default) or `"spot"`. |
+| `max_price` | No | `float` | Maximum spot price per hour. Only applied when `price_type` is `"spot"`. |
+| `max_machines` | No | `integer` | Maximum instances this template may provision (default: 1). |
+| `machine_ssh_key` | No | `string` | EC2 key pair name. |
+| `machine_bootstrap` | No | `string` | User data script. |
+| `machine_role` | No | `string` | IAM instance profile name. |
+| `machine_disk_size_gb` | No | `integer` | Root volume size in GB. |
+| `machine_disk_type` | No | `string` | Root volume type (default `gp3`). |
+| `iops` | No | `integer` | Provisioned IOPS for `io1`/`io2`/`gp3`. |
+| `launch_template_id` | No | `string` | Pin an existing launch template instead of letting ORB create one. |
+| `tags` | No | `object` | Tags applied to instances alongside ORB's own `orb:` tags. |
+| `provider_api_spec` | No | `object` | Native `RunInstances` parameters, merged over the generated call. See [Native spec](#native-spec). |
+
+`max_machines` accepts the older name `max_instances`, and `image_id`, `vm_type`, `key_name`, `user_data`, `volume_type`, and `instance_profile` still deserialize as aliases for their `machine_*` equivalents. The alias path logs a deprecation warning.
+
+### Single instance type
+
+RunInstances launches one instance type per call. When `machine_types` holds several entries, the handler takes the **first key** and ignores the rest along with their weights:
+
+```json
+{
+  "machine_types": {"t3.medium": 1, "t3.large": 2}
+}
+```
+
+This provisions `t3.medium` only. Weighted capacity has no meaning here — each instance counts as exactly one unit. If you want ORB to spread a request across instance types, use [EC2 Fleet](ec2-fleet.md), [Spot Fleet](spot-fleet.md), or [ASG](asg.md).
+
+Attribute-based instance selection (`abis_instance_requirements`) is likewise not supported by this handler, because `RunInstances` has no `InstanceRequirements` parameter. See [Attribute-Based Instance Selection](../../user_guide/abis.md) for the handlers that do support it.
+
+### Networking
+
+Networking normally lives in the launch template ORB creates from `subnet_ids` and `security_group_ids`. When you pin an existing `launch_template_id` **and** also set `subnet_ids` or `security_group_ids`, ORB inspects the launch template first to avoid an `InvalidParameterCombination` from AWS:
+
+| Launch template state | Behaviour |
+|---|---|
+| Already defines `NetworkInterfaces`, `SubnetId`, or `SecurityGroupIds` | Request fails with a validation error telling you to remove the conflict from one side or the other. |
+| Defines no networking | ORB injects `SubnetId` (single subnet only) and `SecurityGroupIds` at the API level. |
+| Cannot be described (IAM denial) | ORB logs a warning and assumes the launch template owns networking, injecting nothing. |
+
+Because the API-level injection sets `SubnetId` (singular), only one subnet is applied. Supply a single-element `subnet_ids` list when you pin a launch template, or let the launch template own networking entirely.
+
+### Spot instances
+
+Setting `price_type: "spot"` adds `InstanceMarketOptions: {"MarketType": "spot"}` to the call, and `max_price` becomes `SpotOptions.MaxPrice`:
+
+```json
+{
+  "template_id": "batch-spot",
+  "provider_api": "RunInstances",
+  "machine_types": {"t3.medium": 1},
+  "price_type": "spot",
+  "max_price": 0.10
+}
+```
+
+`allocation_strategy` is accepted but has little effect: RunInstances has no allocation-strategy parameter, so every strategy maps to the `one-time` spot request type. Use a fleet handler if you need real allocation strategies.
+
+Note that the shipped handler defaults in `aws_defaults.json` declare `RunInstances` with `supports_spot: false`. Spot works when configured on a template as above, but on-demand is the intended path for this handler.
+
+### Native spec
+
+When a `provider_api_spec` (or `provider_api_spec_file`) is present, ORB renders it and merges it over the generated parameters. `LaunchTemplate.LaunchTemplateId` and `LaunchTemplate.Version` are always overwritten with the launch template ORB resolved for the request, and `MinCount`/`MaxCount` are filled in when the spec omits them. See the [Native Spec Reference](../../api/native-spec-reference.md) for available template variables.
+
+## Machine data
+
+Instances are reported in ORB's standard machine shape:
+
+```json
+{
+  "instance_id": "i-0abc1234def567890",
+  "resource_id": "r-0123456789abcdef0",
+  "status": "running",
+  "private_ip": "10.0.1.42",
+  "public_ip": null,
+  "launch_time": "2026-07-13T10:00:00+00:00",
+  "instance_type": "t3.medium",
+  "image_id": "ami-0abcdef1234567890",
+  "subnet_id": "subnet-0f984e48e6e899311",
+  "security_group_ids": ["sg-0528dfedb6d763b16"],
+  "vpc_id": "vpc-0123456789abcdef0",
+  "provider_api": "RunInstances",
+  "provider_data": {
+    "cloud_host_id": "i-0abc1234def567890",
+    "vcpus": 2,
+    "availability_zone": "us-east-1a",
+    "region": "us-east-1"
+  }
+}
+```
+
+`resource_id` is the EC2 **reservation id** returned by `run_instances`. It is the handle ORB uses to rediscover instances if the stored instance-id list is ever lost.
+
+## Fulfilment semantics
+
+RunInstances is synchronous — one instance equals one capacity unit — so the create call is the final answer and ORB sets `requires_async_polling: false`.
+
+| Condition | State |
+|---|---|
+| `running >= requested` and no failures | `fulfilled` |
+| Some instances still `pending`/`starting` | `in_progress` |
+| Every instance failed | `failed` |
+| Some running, none pending, short of target | `partial` (final — the shortfall will never be filled) |
+| No instance ids yet | `in_progress` |
+
+The `partial` verdict is marked final because a synchronous API will not produce more capacity later. Contrast this with [maintain-type fleets](ec2-fleet.md#fleet-types), which keep reconciling toward the target.
+
+## Release behaviour
+
+`orb machines return` terminates the named instances directly with `terminate_instances`. There is no fleet-level capacity to adjust and no group record to delete, so a partial return simply terminates that subset and leaves the rest running.
+
+Cancelling a request before instances are assigned looks up the reservation id, terminates whatever it finds, and treats "no instances" as a successful no-op. In both paths, once the request's capacity reaches zero, the launch template ORB created for it is cleaned up (subject to the `cleanup` provider config).
+
+## IAM permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:DescribeInstances",
+        "ec2:TerminateInstances"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Launch template management (`ec2:CreateLaunchTemplate`, `ec2:CreateLaunchTemplateVersion`, `ec2:DescribeLaunchTemplates`, `ec2:DescribeLaunchTemplateVersions`, `ec2:DeleteLaunchTemplate`), tagging (`ec2:CreateTags`), and SSM AMI resolution (`ssm:GetParameters`) are shared across all AWS handlers. See the [IAM Permissions Guide](../../deployment/iam-permissions.md) for which of those are optional and how failures are handled.
+
+## Limitations
+
+- **One instance type per template** — extra `machine_types` entries are ignored.
+- **No weighted capacity** — every instance is one unit.
+- **No ABIS** — `RunInstances` has no `InstanceRequirements` parameter.
+- **No allocation strategies** — all strategies collapse to a `one-time` spot request.
+- **One subnet when injecting networking** — only relevant when pinning a launch template that owns no networking.
+- **No capacity reconciliation** — a short launch stays short; nothing replaces failed or interrupted instances.
+
+## Related
+
+- [EC2 Fleet](ec2-fleet.md) — multiple instance types, mixed pricing, three fulfilment modes
+- [Spot Fleet](spot-fleet.md) — spot-focused diversification
+- [Auto Scaling Groups](asg.md) — health-checked, self-replacing capacity
+- [Template Management](../../user_guide/templates.md) — full template field reference

--- a/docs/root/providers/aws/spot-fleet.md
+++ b/docs/root/providers/aws/spot-fleet.md
@@ -1,0 +1,320 @@
+# AWS Spot Fleet Provider
+
+> **AWS discourages Spot Fleet for new work.** In [Work with Spot Fleet](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/work-with-spot-fleets.html), AWS states: "We strongly discourage using Spot Fleet because it uses a legacy API with no planned investment. If you want to manage your instance lifecycle, use EC2 Fleet instead. If you don't want to manage your instance lifecycle, use an Auto Scaling group instead. Use Spot Fleet only if you need console support for a use case where you would use EC2 Fleet."
+>
+> ORB continues to support Spot Fleet for existing deployments, and this handler is maintained. For new templates, prefer [EC2 Fleet](ec2-fleet.md) — it covers spot provisioning with the same allocation strategies plus `instant` synchronous fulfilment — or [Auto Scaling Groups](asg.md) if you want AWS to maintain capacity for you. See [Migrating to EC2 Fleet](#migrating-to-ec2-fleet) below.
+
+The Spot Fleet handler provisions capacity through the [EC2 Spot Fleet API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html). A Spot Fleet request asks EC2 for a target capacity and lets it choose instance types and availability zones according to an allocation strategy, which is how you get spot pricing without pinning yourself to a single capacity pool.
+
+Use it for interruption-tolerant work: batch processing, CI, and simulation. Spot Fleet's one remaining advantage over EC2 Fleet is its per-override `Priority` and `SpotPrice` semantics, which have no direct EC2 Fleet equivalent.
+
+## Quick start
+
+```bash
+pip install "orb-py[aws]"
+orb init
+```
+
+### 1. Create the service-linked role
+
+Spot Fleet needs a service-linked role so EC2 can launch and terminate instances on your behalf. Create it once per account:
+
+```bash
+aws iam create-service-linked-role --aws-service-name spotfleet.amazonaws.com
+```
+
+### 2. Create a template
+
+```json
+{
+  "template_id": "batch-spot",
+  "name": "Batch Spot Fleet",
+  "description": "Diversified spot capacity for batch work",
+  "provider_api": "SpotFleet",
+  "image_id": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
+  "machine_types": {"t3.medium": 2, "t3.large": 2, "t3.xlarge": 4},
+  "subnet_ids": ["subnet-0f984e48e6e899311", "subnet-1a2b3c4d5e6f7a8b9"],
+  "security_group_ids": ["sg-0528dfedb6d763b16"],
+  "price_type": "spot",
+  "allocation_strategy": "capacityOptimized",
+  "fleet_type": "request",
+  "fleet_role": "arn:aws:iam::123456789012:role/aws-service-role/spotfleet.amazonaws.com/AWSServiceRoleForEC2SpotFleet",
+  "max_price": 0.10,
+  "max_machines": 100,
+  "tags": {"Environment": "dev"}
+}
+```
+
+### 3. Request capacity
+
+```bash
+orb machines request batch-spot 10
+```
+
+### 4. Check status
+
+```bash
+orb requests status <request-id>
+```
+
+### 5. Return capacity
+
+```bash
+orb machines return i-0abc1234def567890 i-0def5678abc123456
+```
+
+## Template configuration
+
+The handler uses `provider_api: "SpotFleet"`. Each request creates a launch template, then calls `request_spot_fleet` with a `SpotFleetRequestConfig`.
+
+### Top-level fields
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `provider_api` | Yes | `string` | Must be `"SpotFleet"` |
+| `fleet_role` | Yes | `string` | IAM fleet role ARN. Validated before the fleet is created — see [Fleet role](#fleet-role). |
+| `image_id` | Yes | `string` | AMI id or SSM parameter path. |
+| `fleet_type` | No | `string` | `"request"` (default) or `"maintain"`. See [Fleet types](#fleet-types). |
+| `machine_types` | No | `object` | Instance type → weighted capacity. Expanded across subnets into overrides. |
+| `subnet_ids` | No | `list[string]` | Target subnets. Each is combined with each instance type. |
+| `security_group_ids` | No | `list[string]` | Security groups. |
+| `price_type` | No | `string` | `"spot"`, `"ondemand"`, or `"heterogeneous"`. Validated — any other value is rejected. |
+| `percent_on_demand` | No | `integer` | On-demand share. Required when `price_type` is `"heterogeneous"`. |
+| `allocation_strategy` | No | `string` | Spot allocation strategy, camelCase on the wire. |
+| `max_price` | No | `float` | Maximum spot price per hour. Must be greater than zero. |
+| `spot_fleet_request_expiry` | No | `integer` | **Minutes** until the request expires, converted to `ValidUntil`. |
+| `abis_instance_requirements` | No | `object` | Attribute-based instance selection, replacing instance-type overrides. |
+| `max_machines` | No | `integer` | Maximum capacity this template may provision. |
+| `context` | No | `string` | Passed through as the fleet `Context` field. |
+| `tags` | No | `object` | Tags applied to the `spot-fleet-request` resource. |
+| `provider_api_spec` | No | `object` | Native `RequestSpotFleet` config. See [Native spec](#native-spec). |
+
+### Fleet role
+
+Unlike the other AWS handlers, Spot Fleet will not provision without a fleet role, and the role is validated up front. `fleet_role` may be set on the template or inherited from the provider's `config.fleet_role`. In a multi-provider setup the role is read from the provider instance serving the request; with a single unnamed provider, ORB uses that provider's role.
+
+Accepted forms:
+
+| Value | Handling |
+|---|---|
+| `arn:aws:iam::<account>:role/aws-service-role/spotfleet.amazonaws.com/AWSServiceRoleForEC2SpotFleet` | Used as-is. |
+| `arn:aws:iam::<account>:role/aws-ec2-spot-fleet-tagging-role` | Used as-is. |
+| `AWSServiceRoleForEC2SpotFleet` or `AmazonEC2SpotFleetTaggingRole` | Expanded to the full service-linked role ARN using `sts:GetCallerIdentity` for the account id. |
+| An EC2 Fleet service-linked role ARN (`ec2fleet.amazonaws.com/AWSServiceRoleForEC2Fleet`) | Converted to the equivalent Spot Fleet role. |
+| Any other ARN | Treated as a custom role and verified with `iam:GetRole`. A lookup failure fails the request. |
+
+An ARN that mentions `AWSServiceRoleForEC2SpotFleet` but does not match the expected pattern is rejected with an explicit error rather than being passed to AWS.
+
+### Fleet types
+
+| `fleet_type` | Behaviour |
+|---|---|
+| `request` (default) | One-time request. EC2 fills the target capacity and does not replace interrupted instances. |
+| `maintain` | EC2 keeps the fleet at target capacity, replacing interrupted or unhealthy instances. Sets `ReplaceUnhealthyInstances` and `TerminateInstancesWithExpiration`. |
+
+Spot Fleet has no `instant` type — that is [EC2 Fleet](ec2-fleet.md#fleet-types) only. Both Spot Fleet types return only a request id from the create call; instances arrive later.
+
+### Allocation strategies
+
+Spot Fleet uses camelCase on the wire, so template values pass through nearly unchanged. ORB still normalises hyphenated and snake_case input:
+
+| Template value | Sent to AWS |
+|---|---|
+| `lowestPrice` (default) | `lowestPrice` |
+| `capacityOptimized` | `capacityOptimized` |
+| `capacityOptimizedPrioritized` | `capacityOptimizedPrioritized` |
+| `priceCapacityOptimized` | `priceCapacityOptimized` |
+| `diversified` | `diversified` |
+
+`prioritized` is not a Spot Fleet spot strategy and falls back to `lowestPrice`.
+
+### Overrides, priority, and per-override price
+
+`machine_types` and `subnet_ids` are expanded into the cartesian product of instance type and subnet. Spot Fleet overrides additionally carry:
+
+- **`Priority`** — a 1-based index in `machine_types` order, used by the `capacityOptimizedPrioritized` strategy.
+- **`SpotPrice`** — `max_price` repeated per override, when set.
+
+So `{"t3.medium": 2, "t3.large": 2}` across two subnets yields four overrides, with `t3.medium` at priority 1 and `t3.large` at priority 2 in each subnet.
+
+### Pricing mix
+
+`TargetCapacity` is always the requested count. The on-demand portion is derived:
+
+| Configuration | `OnDemandTargetCapacity` |
+|---|---|
+| `price_type: "spot"` | Not set — all capacity is spot. |
+| `price_type: "ondemand"` | The full requested count. |
+| `price_type: "heterogeneous"` with `percent_on_demand: N` | `max(1, requested * N / 100)` — at least one instance when a non-zero percentage is requested. |
+
+`percent_on_demand` is required for `heterogeneous` and the request is rejected without it. If `machine_types_ondemand` is set, `machine_types` must be set too, and every on-demand weight must be a positive integer.
+
+### Request expiry
+
+`spot_fleet_request_expiry` is in **minutes**, not seconds. It becomes `ValidUntil` at `now + N minutes`:
+
+```json
+{
+  "spot_fleet_request_expiry": 30
+}
+```
+
+The shipped provider default is 30 minutes. Combined with `maintain` and `TerminateInstancesWithExpiration`, instances are terminated when the request expires — so set this deliberately for long-running work.
+
+### Attribute-based instance selection
+
+`abis_instance_requirements` replaces the instance-type overrides with `InstanceRequirements`, one override per subnet:
+
+```json
+{
+  "provider_api": "SpotFleet",
+  "abis_instance_requirements": {
+    "vcpu_count": {"min": 2, "max": 8},
+    "memory_mib": {"min": 4096, "max": 32768},
+    "local_storage": "required"
+  }
+}
+```
+
+When ABIS is present, `machine_types` is ignored and no `Priority` is emitted. See [Attribute-Based Instance Selection](../../user_guide/abis.md).
+
+### Native spec
+
+A `provider_api_spec` is rendered and used as the `SpotFleetRequestConfig`. ORB patches the launch template id and version into every entry of `LaunchSpecifications`, and injects ABIS `InstanceRequirements` into `LaunchTemplateConfigs[0].Overrides` when the spec does not already carry them. See the [Native Spec Reference](../../api/native-spec-reference.md).
+
+## Machine data
+
+Instances carry the Spot Fleet request id as `resource_id`:
+
+```json
+{
+  "instance_id": "i-0abc1234def567890",
+  "resource_id": "sfr-73fbd2ce-aa30-494c-8788-1cee4ffcbc12",
+  "status": "running",
+  "private_ip": "10.0.1.42",
+  "instance_type": "t3.large",
+  "provider_api": "SpotFleet",
+  "provider_data": {
+    "cloud_host_id": "i-0abc1234def567890",
+    "vcpus": 2,
+    "availability_zone": "us-east-1a",
+    "region": "us-east-1"
+  }
+}
+```
+
+## Fulfilment semantics
+
+Spot Fleet uses capacity-unit semantics, identical to EC2 Fleet's maintain and request types: `FulfilledCapacity >= TargetCapacity` with nothing pending and nothing failed.
+
+| Condition | State |
+|---|---|
+| Fulfilled capacity meets target, nothing pending, nothing failed | `fulfilled` |
+| Instances failed, none running, none pending | `failed` |
+| Anything else | `in_progress` |
+
+Two intermediate cases are reported distinctly while no instances are visible yet: capacity allocated but instances not yet enumerable, and the fleet still waiting for capacity. Both are `in_progress`.
+
+Because capacity is measured in weighted units, a fleet with `{"t3.xlarge": 4}` can fulfil a 4-unit request with a single instance.
+
+For multi-fleet requests, all fleets must be fulfilled for the request to be fulfilled; any failure makes it failed; any partial makes it partial, and that aggregate is only terminal when every partial contributor is itself terminal.
+
+## Release behaviour
+
+Releases follow the shared fleet release flow, with the branch determined by fleet type:
+
+1. **Fetch fleet details** with `describe_spot_fleet_requests` when the caller did not supply them.
+2. **Compute the decision** from fleet type, current target capacity, and the summed `WeightedCapacity` of the instances being returned. Using weighted units rather than a count prevents AWS from refilling capacity that was decremented by the wrong amount.
+3. **Reduce capacity first for `maintain`** fleets, so EC2 does not launch replacements for instances about to be terminated. `request` fleets skip this — they never replace.
+4. **Terminate the instances.**
+5. **Cancel the fleet when empty.** For `request` fleets ORB re-checks that no instances remain outside the batch before cancelling, guarding against eventual-consistency lag. For `maintain` fleets a full return cancels directly; a weighted-capacity edge case where arithmetic says partial but the fleet is physically empty triggers a capacity-zero call before cancellation.
+6. **Clean up the launch template** ORB created for the request.
+
+Cancelling a request with no instances named cancels the whole fleet and terminates whatever it holds.
+
+## IAM permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RequestSpotFleet",
+        "ec2:CancelSpotFleetRequests",
+        "ec2:ModifySpotFleetRequest",
+        "ec2:DescribeSpotFleetRequests",
+        "ec2:DescribeSpotFleetInstances",
+        "ec2:DescribeInstances",
+        "ec2:TerminateInstances",
+        "sts:GetCallerIdentity"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+`sts:GetCallerIdentity` resolves short role names to full ARNs. `iam:GetRole` is additionally needed when `fleet_role` is a custom role, since validation calls it. `iam:PassRole` on the fleet role is required for EC2 to assume it. Launch template, tagging, and SSM permissions are shared across handlers — see the [IAM Permissions Guide](../../deployment/iam-permissions.md).
+
+## Limitations
+
+- **Fleet role is mandatory** and validated before provisioning; a bad role fails the request rather than the AWS call.
+- **No `instant` fleet type** — provisioning is always asynchronous, so the create call never returns instance ids.
+- **Expiry is in minutes** and defaults to 30 in the shipped config; combined with `maintain`, expiry terminates instances.
+- **Spot interruptions are not surfaced as a distinct state** — an interrupted instance appears as a capacity shortfall.
+- **`prioritized` allocation is unsupported** and silently falls back to `lowestPrice`.
+- **AWS considers the underlying API legacy** with no planned investment — see the note at the top of this page.
+
+## Migrating to EC2 Fleet
+
+Most Spot Fleet templates convert to [EC2 Fleet](ec2-fleet.md) by changing `provider_api` and adjusting four fields. ORB's template model is shared across both handlers, so `image_id`, `machine_types`, `subnet_ids`, `security_group_ids`, `tags`, and `abis_instance_requirements` carry over unchanged.
+
+| Spot Fleet | EC2 Fleet | Notes |
+|---|---|---|
+| `provider_api: "SpotFleet"` | `provider_api: "EC2Fleet"` | |
+| `fleet_role` (required) | Not used | EC2 Fleet uses the EC2 Spot service-linked role in the account rather than a per-template role. Drop the field. |
+| `fleet_type: "request"` / `"maintain"` | Same, plus `"instant"` | Behaviour is equivalent for the two shared types. `instant` is new and returns instance ids synchronously. |
+| `allocation_strategy: "capacityOptimized"` | `allocation_strategy: "capacityOptimized"` | Keep the camelCase value; ORB converts it to the hyphenated form EC2 Fleet expects. |
+| `max_price` (per-override `SpotPrice`) | `max_price` (`MaxTotalPrice`) | **Semantics change.** A per-instance price cap becomes a total fleet spend cap. Recheck the value. |
+| `spot_fleet_request_expiry` | Not supported | EC2 Fleet has no ORB-exposed expiry field. Use a native spec `ValidUntil` if you need one. |
+| Per-override `Priority` | Not supported | Only relevant with `capacityOptimizedPrioritized`. Keep Spot Fleet if you depend on it. |
+
+The `max_price` change is the one to look at closely: `0.10` as a per-instance cap is not the same constraint as `0.10` as a total fleet cap, and a total cap set too low will throttle the whole fleet.
+
+Worked example — the Spot Fleet template from [Quick start](#quick-start) as an EC2 Fleet template:
+
+```json
+{
+  "template_id": "batch-spot",
+  "name": "Batch Spot Fleet",
+  "description": "Diversified spot capacity for batch work",
+  "provider_api": "EC2Fleet",
+  "image_id": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64",
+  "machine_types": {"t3.medium": 2, "t3.large": 2, "t3.xlarge": 4},
+  "subnet_ids": ["subnet-0f984e48e6e899311", "subnet-1a2b3c4d5e6f7a8b9"],
+  "security_group_ids": ["sg-0528dfedb6d763b16"],
+  "price_type": "spot",
+  "allocation_strategy": "capacityOptimized",
+  "max_machines": 100,
+  "metadata": {"fleet_type": "request"},
+  "tags": {"Environment": "dev"}
+}
+```
+
+`fleet_role` and `spot_fleet_request_expiry` are gone, and `max_price` is omitted rather than carried over at its old value. Validate the new template before switching traffic to it:
+
+```bash
+orb templates validate --file batch-spot-ec2fleet.json
+orb machines request batch-spot-ec2fleet 1
+```
+
+Existing Spot Fleet requests are unaffected by adding an EC2 Fleet template — the two can run side by side while you migrate.
+
+## Related
+
+- [EC2 Fleet](ec2-fleet.md) — newer fleet API with instant provisioning and richer pricing mixes
+- [Auto Scaling Groups](asg.md) — health-checked, self-replacing capacity
+- [EC2 Instances (RunInstances)](run-instances.md) — synchronous single-type launches
+- [IAM Permissions Guide](../../deployment/iam-permissions.md) — service-linked role setup


### PR DESCRIPTION
## Description

Adds reference documentation for the four AWS EC2 provisioning types — RunInstances, Auto Scaling Groups, Spot Fleet, and EC2 Fleet — under `docs/root/providers/aws/`, matching the structure of the existing `microvm.md`.

Content is derived from the handler implementations rather than general AWS documentation, so it records behaviour operators actually hit and that is not obvious from the AWS docs alone:

- **RunInstances** uses only the first `machine_types` key and ignores the rest; it injects networking at the API level only when a pinned launch template owns none, and raises a validation error when both sides define it.
- **ASG** derives group bounds from the requested count (`MinSize 0`, `MaxSize 2x`, `DesiredCapacity`) and terminates weight-aware via `terminate_instance_in_auto_scaling_group` rather than `detach_instances`, so `DesiredCapacity` decrements by `WeightedCapacity` instead of by count.
- **Spot Fleet** requires a pre-validated `fleet_role` (five accepted forms, documented), and `spot_fleet_request_expiry` is in **minutes** with a 30-minute shipped default.
- **EC2 Fleet** fleet type selects between count-based (`instant`) and capacity-unit (`request`/`maintain`) fulfilment, and `max_price` maps to `MaxTotalPrice` — a total fleet spend cap, not a per-instance price as in Spot Fleet.

Cross-cutting topics (ABIS, IAM, native spec) link to the existing `user_guide/abis.md`, `deployment/iam-permissions.md`, and `api/native-spec-reference.md` rather than being restated four times.

Two things beyond the four pages:

1. **Spot Fleet legacy notice.** The page opens with AWS's own wording from [Work with Spot Fleet](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/work-with-spot-fleets.html) — "We strongly discourage using Spot Fleet because it uses a legacy API with no planned investment" — paired with ORB's position that the handler is still supported, plus a field-by-field **Migrating to EC2 Fleet** table. The `max_price` semantic change is called out explicitly, since carrying the value across unchanged silently converts a per-instance cap into a total fleet cap.
2. **Nav.** All five AWS provisioning types are now linked from the docs index, and a `Providers > AWS` section was added to `mkdocs.yml`. This makes the pre-existing `microvm.md` reachable by navigation for the first time — it was previously findable only by direct link or search.

## Type of Change
- [x] Documentation update

## Related Issues

No related issue — documentation gap noticed while reviewing provider coverage.

## How Has This Been Tested?
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Docs-only change; no source files touched, so no unit or integration tests apply.

- `mkdocs build --strict` exits 0 with no warnings. All five AWS pages generate and appear in the rendered nav.
- Every internal link and heading anchor across the four new pages and `index.md` was checked programmatically — all resolve, including the new `#migrating-to-ec2-fleet`.
- Verified the AWS legacy wording by fetching the AWS page rather than paraphrasing it.
- Claims that could not be confirmed from the AWS docs were checked against the source: `fleet_role` is never referenced under `handlers/ec2_fleet/`, and `spot_fleet_request_expiry` is read only by `spot_fleet/config_builder.py`, so both are correctly documented as Spot-Fleet-only.

## Test Configuration
* Python version: 3.14
* OS: macOS (darwin)
* AWS region: n/a — no AWS calls made
* Dependencies changed: none

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the version number (if applicable)

Tests are not applicable to a docs-only change. Existing tests are untouched.

## Additional Notes

Three points a reviewer may want to weigh in on:

1. **Three IAM actions are documented here that are absent from `deployment/iam-permissions.md`:** `autoscaling:TerminateInstanceInAutoScalingGroup`, `ec2:ModifyFleet`, and `ec2:ModifySpotFleetRequest`. I confirmed each is genuinely called by the release managers before documenting it, which suggests the existing IAM guide is incomplete. I left that guide unchanged to keep this PR scoped — happy to fix it here or in a follow-up.

2. **Commit style follows practice over CONTRIBUTING.md.** The guide says "no scope in parentheses," but 71 of the last 100 commits are scoped, including `docs(providers):` for provider docs. I matched the prevailing convention; say the word if you would rather have the unscoped form.

3. **Blockquote notes, not `!!!` admonitions.** The `admonition` extension is enabled in `mkdocs.yml` but unused anywhere in `docs/root/`; the house pattern is `> **Note:**`. I matched that rather than introducing a second style.

## Performance Impact
- [x] No significant performance impact

## Security Considerations
- [x] No security implications

Documentation only. The IAM policy examples are least-privilege and scoped per handler, and they document permissions the code already requires rather than granting anything new.

## Dependencies

None.

## Migration Guide

Not a breaking change. The Spot Fleet page does include a **Migrating to EC2 Fleet** section, but that is guidance for users moving off a legacy AWS API, not a migration required by this PR.

## Deployment Notes

None. Docs are published by the existing site build.

## Reviewers
@finos/open-resource-broker-maintainers
